### PR TITLE
Fix MkDocs Build in CI Pipeline

### DIFF
--- a/.github/workflows/mkdocs.yml
+++ b/.github/workflows/mkdocs.yml
@@ -34,6 +34,8 @@ jobs:
 
       - name: Install Requirements
         run: pip install -r requirements-doc.txt
+        env:
+          GH_TOKEN: ${{ secrets.GH_TOKEN }}
 
       - name: Build and deploy MkDocs
         run: mkdocs gh-deploy --force


### PR DESCRIPTION
## Overview
This PR addresses an issue where the MkDocs CI Pipeline would fail during the installation of `mkdocs-material-insiders` due to missing credentials. It potentially resolves issue #49.

## Changes
- Ensure credentials are passed during the `Install Requirements` step by utilizing the `GH_TOKEN` environment variable.
- Leverage the value stored in `secrets.GH_TOKEN` to set the `GH_TOKEN` environment variable.

## Configuration
To successfully implement this fix, the following setup is necessary:

1. The repository must have an [actions repository secret](https://github.com/jxnl/instructor/settings/secrets/actions) labeled as `GH_TOKEN`.
2. This `GH_TOKEN` secret should correspond to a [GitHub token](https://github.com/settings/tokens/new) with a minimum access level of the `repo` scope.