### PR TITLE
Add minify plugin to requirements-doc.txt

### DIFF
--- a/requirements-doc.txt
+++ b/requirements-doc.txt
@@ -7,3 +7,4 @@ openai
 pydantic
 pytest
 git+https://${GH_TOKEN}@github.com/squidfunk/mkdocs-material-insiders.git
+mkdocs-minify-plugin


### PR DESCRIPTION
## Overview
This PR resolves the MkDocs CI Pipeline failure caused by the absence of the `mkdocs-minify-plugin`, which is specified in the `mkdocs.yaml` configuration.

Following the resolution of authentication problems in #108, this update ensures the entire workflow will finish successfully.
## Changes
- Add `mkdocs-minify-plugin` to `requirements-doc.txt`.