### PR TITLE
Install `pngquant` in MkDocs Pipeline for correct image optimization

### DIFF
--- a/.github/workflows/mkdocs.yml
+++ b/.github/workflows/mkdocs.yml
@@ -33,7 +33,11 @@ jobs:
             mkdocs-material-
 
       - name: Install Requirements
-        run: pip install -r requirements-doc.txt
+        run: |
+          sudo apt-get update &&
+          sudo apt-get install pngquant &&
+          pip install -r requirements-doc.txt
+
         env:
           GH_TOKEN: ${{ secrets.GH_TOKEN }}
 


### PR DESCRIPTION
## Overview
The third time's the charm (hopefully). Following the recommendation from [the optimize documentation](https://squidfunk.github.io/mkdocs-material/plugins/optimize/#configuration), this PR ensures `pngquant` is installed prior to building the `instructor` documentation. 

I apologize for the iterative approach. Because I have no access to MkDocs insiders, I couldn't replicate `instructor`'s precise workflow to test it comprehensively in one go.


## Changes
- Install `pngquant` before building `instructor`'s documentation.

## Tests
Tested the installation of `pngquant` in [this fork](https://github.com/jlondonobo/instructor/actions/runs/6286240333/job/17069475980).