### PR TITLE
Pass strict through from create to from_response

### DIFF
--- a/instructor/function_calls.py
+++ b/instructor/function_calls.py
@@ -98,7 +98,7 @@ class openai_function:
 
         return wrapper(*args, **kwargs)
 
-    def from_response(self, completion, throw_error=True):
+    def from_response(self, completion, throw_error=True, strict: bool = None):
         """
         Parse the response from OpenAI's API and return the function call
 
@@ -118,7 +118,7 @@ class openai_function:
             ), "Function name does not match"
 
         function_call = message["function_call"]
-        arguments = json.loads(function_call["arguments"], strict=False)
+        arguments = json.loads(function_call["arguments"], strict=strict)
         return self.validate_func(**arguments)
 
 
@@ -209,13 +209,20 @@ class OpenAISchema(BaseModel):
         }
 
     @classmethod
-    def from_response(cls, completion, throw_error=True, validation_context=None):
+    def from_response(
+        cls,
+        completion,
+        throw_error: bool = True,
+        validation_context=None,
+        strict: bool = None,
+    ):
         """Execute the function from the response of an openai chat completion
 
         Parameters:
             completion (openai.ChatCompletion): The response from an openai chat completion
             throw_error (bool): Whether to throw an error if the function call is not detected
             validation_context (dict): The validation context to use for validating the response
+            strict (bool): Whether to use strict json parsing
 
         Returns:
             cls (OpenAISchema): An instance of the class
@@ -229,7 +236,9 @@ class OpenAISchema(BaseModel):
             ), "Function name does not match"
 
         return cls.model_validate_json(
-            message["function_call"]["arguments"], context=validation_context
+            message["function_call"]["arguments"],
+            context=validation_context,
+            strict=strict,
         )
 
 


### PR DESCRIPTION
Might help with #117 
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
### Summary by CodeRabbit

- New Feature: Enhanced the flexibility of data processing in the `OpenAISchema` and `patch` functions. Users can now choose to apply a stricter or more lenient data validation process by using the new `strict` parameter.
- Improvement: The `process_response`, `retry_async`, and `retry_sync` functions have been updated to support the new `strict` parameter, improving the robustness of error handling.
- Bug Fix: Removed a duplicate `process_response` function, reducing potential confusion and improving code maintainability.
  
Please note, these changes are under-the-hood improvements and won't affect the user interface. They are designed to enhance the reliability and flexibility of our backend processes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->