### PR TITLE
Update Jobs cli to include openai_key

### DIFF
--- a/instructor/cli/files.py
+++ b/instructor/cli/files.py
@@ -52,7 +52,15 @@ def upload(
     filepath: str = typer.Argument(..., help="Path to the file to upload"),
     purpose: str = typer.Option("fine-tune", help="Purpose of the file"),
     poll: int = typer.Option(5, help="Polling interval in seconds"),
+    openai_key: str = typer.Option(
+        None,
+        envvar="OPENAI_API_KEY",
+        help="OpenAI API key, can also be set using the OPENAI_API_KEY environment variable",
+    ),
 ):
+    if openai_key:
+        openai.api_key = openai_key
+
     with open(filepath, "rb") as file:
         response = openai.File.create(file=file, purpose=purpose)
     file_id = response["id"]
@@ -72,7 +80,15 @@ def upload(
 def download(
     file_id: str = typer.Argument(..., help="ID of the file to download"),
     output: str = typer.Argument(..., help="Output path for the downloaded file"),
+    openai_key: str = typer.Option(
+        None,
+        envvar="OPENAI_API_KEY",
+        help="OpenAI API key, can also be set using the OPENAI_API_KEY environment variable",
+    ),
 ):
+    if openai_key:
+        openai.api_key = openai_key
+
     with console.status(f"[bold green]Downloading file {file_id}...", spinner="dots"):
         content = openai.File.download(file_id)
         with open(output, "wb") as file:
@@ -83,7 +99,17 @@ def download(
 @app.command(
     help="Delete a file from OpenAI's servers",
 )
-def delete(file_id: str = typer.Argument(..., help="ID of the file to delete")):
+def delete(
+    file_id: str = typer.Argument(..., help="ID of the file to delete"),
+    openai_key: str = typer.Option(
+        None,
+        envvar="OPENAI_API_KEY",
+        help="OpenAI API key, can also be set using the OPENAI_API_KEY environment variable",
+    ),
+):
+    if openai_key:
+        openai.api_key = openai_key
+
     with console.status(f"[bold red]Deleting file {file_id}...", spinner="dots"):
         try:
             openai.File.delete(file_id)

--- a/instructor/cli/jobs.py
+++ b/instructor/cli/jobs.py
@@ -81,10 +81,19 @@ def watch(
     limit: int = typer.Option(5, help="Limit the number of jobs to monitor"),
     poll: int = typer.Option(5, help="Polling interval in seconds"),
     screen: bool = typer.Option(False, help="Enable or disable screen output"),
+    openai_key: str = typer.Option(
+        None,
+        envvar="OPENAI_API_KEY",
+        help="OpenAI API key, can also be set using the OPENAI_API_KEY environment variable",
+    ),
 ):
     """
     Monitor the status of the most recent fine-tuning jobs.
     """
+
+    if openai_key:
+        openai.api_key = openai_key
+
     jobs = get_jobs(limit=limit)
     with Live(generate_table(jobs), refresh_per_second=2, screen=screen) as live_table:
         while True:
@@ -99,7 +108,15 @@ def watch(
 def create_from_id(
     id: str = typer.Argument(..., help="ID of the existing fine-tuning job"),
     model: str = typer.Option("gpt-3.5-turbo", help="Model to use for fine-tuning"),
+    openai_key: str = typer.Option(
+        None,
+        envvar="OPENAI_API_KEY",
+        help="OpenAI API key, can also be set using the OPENAI_API_KEY environment variable",
+    ),
 ):
+    if openai_key:
+        openai.api_key = openai_key
+
     with console.status(
         f"[bold green]Creating fine-tuning job from ID {id}...", spinner="dots"
     ):
@@ -114,8 +131,16 @@ def create_from_id(
 def create_from_file(
     file: str = typer.Argument(..., help="Path to the file for fine-tuning"),
     model: str = typer.Option("gpt-3.5-turbo", help="Model to use for fine-tuning"),
+    openai_key: str = typer.Option(
+        None,
+        envvar="OPENAI_API_KEY",
+        help="OpenAI API key, can also be set using the OPENAI_API_KEY environment variable",
+    ),
     poll: int = typer.Option(2, help="Polling interval in seconds"),
 ):
+    if openai_key:
+        openai.api_key = openai_key
+
     with open(file, "rb") as file:
         response = openai.File.create(file=file, purpose="fine-tune")
 
@@ -142,7 +167,17 @@ def create_from_file(
 @app.command(
     help="Cancel a fine-tuning job.",
 )
-def cancel(id: str = typer.Argument(..., help="ID of the fine-tuning job to cancel")):
+def cancel(
+    id: str = typer.Argument(..., help="ID of the fine-tuning job to cancel"),
+    openai_key: str = typer.Option(
+        None,
+        envvar="OPENAI_API_KEY",
+        help="OpenAI API key, can also be set using the OPENAI_API_KEY environment variable",
+    ),
+):
+    if openai_key:
+        openai.api_key = openai_key
+
     with console.status(f"[bold red]Cancelling job {id}...", spinner="dots"):
         try:
             openai.FineTuningJob.cancel(id)

--- a/instructor/cli/usage.py
+++ b/instructor/cli/usage.py
@@ -1,5 +1,6 @@
 from typing import List
 from datetime import datetime, timedelta
+import openai
 import typer
 import os
 import aiohttp
@@ -134,7 +135,13 @@ def group_and_sum_by_date_and_snapshot(usage_data: List[dict]) -> Table:
 @app.command(help="Displays OpenAI API usage data for the past N days.")
 def list(
     n: int = typer.Option(0, help="Number of days."),
+    openai_api_key: str = typer.Option(
+        None, envvar="OPENAI_API_KEY", help="OpenAI API key."
+    ),
 ):
+    if openai_api_key:
+        openai.api_key = openai_api_key
+
     all_data = asyncio.run(get_usage_for_past_n_days(n))
     table = group_and_sum_by_date_and_snapshot(all_data)
     console.print(table)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

### Summary by CodeRabbit

- New Feature: Introduced a flexible way to set the OpenAI API key across various functions in the `instructor/cli` module. Users can now directly pass the OpenAI API key as a parameter to the `watch`, `create_from_id`, `create_from_file`, `cancel`, `upload`, `download`, `delete`, and `list` functions. This feature enhances usability by providing an alternative to setting the API key via environment variables, offering more flexibility and convenience in managing API keys.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->