### PR TITLE
Azure support multitask.py

### DIFF
--- a/instructor/dsl/multitask.py
+++ b/instructor/dsl/multitask.py
@@ -31,9 +31,11 @@ class MultiTaskBase:
     @staticmethod
     def extract_json(completion):
         for chunk in completion:
-            delta = chunk["choices"][0]["delta"]
-            if "function_call" in delta:
-                yield delta["function_call"]["arguments"]
+            if chunk["choices"]:
+                delta = chunk["choices"][0]["delta"]
+                if "function_call" in delta:
+                    if "arguments" in delta["function_call"]:
+                        yield delta["function_call"]["arguments"]
 
     @staticmethod
     def get_object(str, stack):


### PR DESCRIPTION
Azure support for Multiple Extractions

Without validation, Azure use breaks with some chunks not containing any `choices` and the first `function_call` chunk not containing `arguments`.

As of API version "2023-07-01-preview", most chunks related to a function call seem to spit out all at once. So be aware the experience won't match OpenAI until it's addressed in a future API update.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Enhanced error handling in the new task extraction process to prevent potential issues and improve overall app stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->