### PR TITLE
fix typo in Validator

### DIFF
--- a/instructor/dsl/validators.py
+++ b/instructor/dsl/validators.py
@@ -20,7 +20,7 @@ class Validator(instructor.OpenAISchema):
     )
     fixed_value: Optional[str] = Field(
         default=None,
-        description="If the attribuet is not valid, suggest a new value for the attribute",
+        description="If the attribute is not valid, suggest a new value for the attribute",
     )
 
 


### PR DESCRIPTION
Fixes a grammar typo in description of `fixed_value` of the `Validator` model.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Corrected a typographical error in the description of the `fixed_value` attribute in the `Validator` class.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->