### PR TITLE
fix: match the monkey-patched method signature with upstream openai

### DIFF
--- a/instructor/patch.py
+++ b/instructor/patch.py
@@ -141,7 +141,7 @@ def wrap_chatcompletion(func: Callable) -> Callable:
 
     @wraps(func)
     async def new_chatcompletion_async(
-        response_model=None, validation_context=None, *args, max_retries=1, **kwargs
+        cls, response_model=None, validation_context=None, *args, max_retries=1, **kwargs
     ):
         response_model, new_kwargs = handle_response_model(response_model, kwargs)  # type: ignore
         response, error = await retry_async(
@@ -158,7 +158,7 @@ def wrap_chatcompletion(func: Callable) -> Callable:
 
     @wraps(func)
     def new_chatcompletion_sync(
-        response_model=None, validation_context=None, *args, max_retries=1, **kwargs
+        cls, response_model=None, validation_context=None, *args, max_retries=1, **kwargs
     ):
         response_model, new_kwargs = handle_response_model(response_model, kwargs)  # type: ignore
         response, error = retry_sync(
@@ -175,7 +175,7 @@ def wrap_chatcompletion(func: Callable) -> Callable:
 
     wrapper_function = new_chatcompletion_async if is_async else new_chatcompletion_sync
     wrapper_function.__doc__ = OVERRIDE_DOCS
-    return wrapper_function
+    return classmethod(wrapper_function)
 
 
 original_chatcompletion = openai.ChatCompletion.create

--- a/tests/test_patch.py
+++ b/tests/test_patch.py
@@ -1,7 +1,7 @@
 from pydantic import BaseModel
 import pytest
 import openai
-from instructor import patch
+from instructor import patch, unpatch
 
 
 @pytest.mark.skip("Not implemented")
@@ -56,3 +56,15 @@ def test_runmodel_validator():
     assert hasattr(
         model, "_raw_response"
     ), "The raw response should be available from OpenAI"
+
+
+def test_is_classmethod_without_patch():
+    ftype = type(openai.ChatCompletion.create)
+    assert str(ftype) == "<class 'method'>"
+
+
+def test_is_classmethod_with_patch():
+    patch()
+    ftype = type(openai.ChatCompletion.create)
+    assert str(ftype) == "<class 'method'>"
+    unpatch()


### PR DESCRIPTION
When instructor monkey-patches the create and acreate methods, it changes the type of the function from 'classmethod' to 'function'. This works fine in most cases, but when other tools attempt to, themselves, wrap the OpenAI class methods, this produces an error because those tools are expecting classmethods; not functions.

The example I encountered is using the python "wrapt" library/module. When wrapping the monkey-patched code, it produces the following error

  TypeError: missing 1 required positional argument

This patch changes the method signature to match the one that OpenAI themselves use.

I've included tests to ensure that the existing instructor behavior remains unchanged. Additionally, I tested with the tests that are marked with pytest unimplemented marks to ensure that the continued class instances are correct.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Enhanced the chat completion function to support class methods.
- **Tests**
	- Added and updated tests to verify the chat completion function's behavior with and without patching.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->