### PR TITLE
small typo fix

### DIFF
--- a/instructor/patch.py
+++ b/instructor/patch.py
@@ -186,7 +186,7 @@ def wrap_chatcompletion(func: Callable) -> Callable:
 
 def patch(client):
     """
-    Patch the `client.chat.completions.create` and `client.chat.completions.create` methods
+    Patch the `client.chat.completions.create` method
 
     Enables the following features:
 


### PR DESCRIPTION
Really simple PR. `client.chat.completions.create` was typed out twice in the doc string for the `patch` function. 
This initially threw me off thinking the patch was for both async and normal client.