### PR TITLE
Fix typo

### DIFF
--- a/docs/blog/posts/chain-of-density.md
+++ b/docs/blog/posts/chain-of-density.md
@@ -502,7 +502,7 @@ We'l be comparing the following models in 3 ways using 20 articles that were not
 
 : This is a GPT4 model which we applied 3 rounds of Chain Of Density rewrites to generate a summary with using the methodology above
 
-`GPT-3 (Vanilla)`
+`GPT-3.5 (Vanilla)`
 
 : This is a GPT 3.5 model that we asked to generate entity-dense summaries which were concise. Summaries were generated in a single pass
 


### PR DESCRIPTION
Fix for a small typo: The `Results` section mentions GPT-3, not GPT-3.5

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Updated the blog post to reflect the upgrade from GPT-3 to GPT-3.5 for generating summaries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->