### PR TITLE
fixes retry_async message unpacking

### DIFF
--- a/instructor/patch.py
+++ b/instructor/patch.py
@@ -89,7 +89,7 @@ async def retry_async(
                 None,
             )
         except (ValidationError, JSONDecodeError) as e:
-            kwargs["messages"].append(dict(**response.choices[0].message))  # type: ignore
+            kwargs["messages"].append(response.choices[0].message)  # type: ignore
             kwargs["messages"].append(
                 {
                     "role": "user",


### PR DESCRIPTION
This fixes #174 by applying the same message appending logic as in [the hotfix made here](https://github.com/jxnl/instructor/commit/877f57a2baea1766774d028b7fc976979ef83129#diff-1ccc47ac75961e3a4f37760e35da89919e2497efffdb67f3e5b6675a419c44b5) for `retry_sync`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Improved error handling and message storage in the retry mechanism for asynchronous operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->