### PR TITLE
chore: add grit pattern enforcement

### DIFF
--- a/.grit/.gitignore
+++ b/.grit/.gitignore
@@ -1,0 +1,2 @@
+.gritmodules
+*.log

--- a/.grit/grit.yaml
+++ b/.grit/grit.yaml
@@ -1,9 +1,5 @@
 version: 0.0.1
 patterns:
-  - name: github.com/getgrit/js#*
-  - name: github.com/getgrit/python#*
-  - name: github.com/getgrit/json#*
-  - name: github.com/getgrit/hcl#*
   - name: github.com/getgrit/python#openai
     level: info
   - name: github.com/getgrit/python#no_skipped_tests

--- a/.grit/grit.yaml
+++ b/.grit/grit.yaml
@@ -6,3 +6,5 @@ patterns:
   - name: github.com/getgrit/hcl#*
   - name: github.com/getgrit/python#openai
     level: info
+  - name: github.com/getgrit/python#no_skipped_tests
+    level: error

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -22,6 +22,8 @@ If it is not a small change, please start by [filing an issue](https://github.co
 
 If you need ideas, you can check out the [help wanted](https://github.com/jxnl/instructor/labels/help%20wanted) or [good first issue](https://github.com/jxnl/instructor/labels/good%20first%20issue) labels.
 
+[Grit](https://docs.grit.io/) is used to enforce best practices. You can run `grit check` to check your code before submitting a pull request.
+
 # Contributors
 
 <!-- ALL-CONTRIBUTORS-LIST:START - Do not remove or modify this section -->


### PR DESCRIPTION
Right now I just forbid skip tests, but more patterns can easily be activated.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated `.gitignore` to exclude `.gritmodules` and `*.log` files.

- **Configuration Changes**
  - Streamlined `grit.yaml` patterns to focus on specific Python checks with appropriate log levels.

- **Documentation**
  - Enhanced contributing guidelines with a reference to using Grit for code quality checks before submitting pull requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->