### PR TITLE
Fix #244 -- Refactor dump_message function to force content key 

### DIFF
--- a/instructor/patch.py
+++ b/instructor/patch.py
@@ -49,6 +49,8 @@ def dump_message(message: ChatCompletionMessage) -> ChatCompletionMessageParam:
     }
     if message.tool_calls is not None:
         ret["content"] += json.dumps(message.model_dump()["tool_calls"])
+    if message.function_call is not None:
+        ret["content"] += json.dumps(message.model_dump()["function_call"])
     return ret
 
 

--- a/instructor/patch.py
+++ b/instructor/patch.py
@@ -39,9 +39,13 @@ def dump_message(message) -> dict:
     if it isn't used.
     """
     dumped_message = message.model_dump()
-    if not dumped_message.get("tool_calls"):
-        del dumped_message["tool_calls"]
-    return {k: v for k, v in dumped_message.items() if v}
+    dumped_message.pop("tool_calls", None)
+    ret = {k: v for k, v in dumped_message.items() if v}
+
+    if ret.get("content"):
+        ret["content"] = ''
+
+    return ret
 
 
 def handle_response_model(
@@ -202,7 +206,7 @@ def retry_sync(
                 mode=mode,
             )
         except (ValidationError, JSONDecodeError) as e:
-            kwargs["messages"].append(response.choices[0].message)
+            kwargs["messages"].append(dump_message(response.choices[0].message))
             kwargs["messages"].append(
                 {
                     "role": "user",

--- a/instructor/patch.py
+++ b/instructor/patch.py
@@ -42,7 +42,7 @@ def dump_message(message) -> dict:
     dumped_message.pop("tool_calls", None)
     ret = {k: v for k, v in dumped_message.items() if v}
 
-    if ret.get("content"):
+    if ret.get("content") is None:
         ret["content"] = ''
 
     return ret

--- a/instructor/patch.py
+++ b/instructor/patch.py
@@ -10,7 +10,7 @@ from openai.types.chat import ChatCompletion
 from pydantic import BaseModel, ValidationError
 
 if TYPE_CHECKING:
-    from openai.types.chat import ChatCompletionMessage
+    from openai.types.chat import ChatCompletionMessage, ChatCompletionMessageParam
 
 from .function_calls import OpenAISchema, openai_schema, Mode
 
@@ -36,23 +36,16 @@ Parameters:
 """
 
 
-def dump_message(message: ChatCompletionMessage) -> dict:
+def dump_message(message: ChatCompletionMessage) -> ChatCompletionMessageParam:
     """Dumps a message to a dict, to be returned to the OpenAI API.
     Workaround for an issue with the OpenAI API, where the `tool_calls` field isn't allowed to be present in requests
     if it isn't used.
     """
-    dumped_message = message.model_dump()
-    tool_calls = dumped_message.pop("tool_calls", None)
-
-    ret = {k: v for k, v in dumped_message.items() if v}
-
-    if ret.get("content") is None:
-        ret["content"] = ''
-
-    if tool_calls:
-        ret["content"] += str(tool_calls)
-
+    ret: ChatCompletionMessageParam = {"role": message.role, "content": message.content}
+    if message.tool_calls is not None:
+        ret["content"] += message.tool_calls
     return ret
+
 
 
 def handle_response_model(


### PR DESCRIPTION
**Bug Description**
When there is a retry, a 400 error is raised from the API, stating that the 'content' property is required in the 'messages.1' object.

**Proposed Fix**
Force the “content” key to correspond to the Message object in the OpenAI API.

**PR Comment:**

Hi team! I've investigated the issue described in #244 and identified the root cause of the error. It seems that when there is a retry, a 400 error is raised from the API, indicating that the 'content' property is required in the message object.

To fix this, I suggest forcing the "content" key to correspond to the Message object in the OpenAI API. This will ensure that the required properties are correctly passed to the API.

Please review the changes and let me know if you have any feedback. Once approved, I will proceed with merging the PR.

Fix #244 


Please feel free to customize and modify the comment as  #needed..


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved message handling to ensure sensitive data is not included in the output.
  - Enhanced message retry logic for better stability and consistency.

- **Documentation**
  - Updated documentation to reflect changes in message processing.

- **Tests**
  - Added new test cases to verify the correct transformation of messages.
  - Updated existing tests to align with the latest code changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->