### PR TITLE
Small doc fix for FastAPI section

### DIFF
--- a/docs/concepts/fastapi.md
+++ b/docs/concepts/fastapi.md
@@ -49,7 +49,8 @@ def endpoint_function(data: UserData) -> UserDetail:
 `FastAPI` supports streaming responses, which is useful for returning large amounts of data. This feature is particularly useful when working with large language models (LLMs) that generate a large amount of data.
 
 ```python hl_lines="6-7"
-from fastapi import StreamingResponse
+from fastapi.responses import StreamingResponse
+from typing import Iterable
 
 # Route to handle SSE events and return users
 @app.post("/extract", response_class=StreamingResponse)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Updated the FastAPI guide to reflect the correct import paths for `StreamingResponse` and included guidance on importing `Iterable` from the `typing` module.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->