### PR TITLE
docs: example on Vision API (image to ad copy)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.DS_Store
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]
@@ -5,6 +6,7 @@ __pycache__/
 
 # C extensions
 *.so
+
 
 # Distribution / packaging
 .Python

--- a/docs/examples/image_to_ad_copy.md
+++ b/docs/examples/image_to_ad_copy.md
@@ -1,0 +1,176 @@
+# Use Vision API to detect products and generate advertising copy
+
+This post demonstrates how to use GPT-4 Vision API and the Chat API to automatically generate advertising copy from product images. This method can be useful for marketing and advertising teams, as well as for e-commerce platforms.
+
+The full code is available on [GitHub](https://www.github.com/openai/gpt-4).
+
+## Building the models
+
+### Product
+
+For the `Product` model, we define a class that represents a product extracted from an image and store the name, key features, and description. The product attributes are dynamically determined based on the content of the image.
+
+Note that it is easy to add Validators and other Pydantic features to the model to ensure that the data is valid and consistent.
+
+```python
+class Product(BaseModel):
+    """
+    Represents a product extracted from an image using AI.
+
+    The product attributes are dynamically determined based on the content
+    of the image and the AI's interpretation. This class serves as a structured
+    representation of the identified product characteristics.
+    """
+
+    name: str = Field(
+        description="A generic name for the product.", example="Headphones"
+    )
+    key_features: Optional[list[str]] = Field(
+        description="A list of key features of the product that stand out.",
+        default=None,
+    )
+
+    description: Optional[str] = Field(
+        description="A description of the product.",
+        default=None,
+    )
+
+    # Can be customized and automatically generated
+    def generate_prompt(self):
+        prompt = f"Product: {self.name}\n"
+        if self.description:
+            prompt += f"Description: {self.description}\n"
+        if self.key_features:
+            prompt += f"Key Features: {', '.join(self.key_features)}\n"
+        return prompt
+
+    def __repr__(self):
+        return self.generate_prompt()
+```
+
+### Identified Product
+
+We also define a class that represents a list of products identified in the images. We also add an error flag and message to indicate if there was an error in the processing of the image.
+
+```python
+class IdentifiedProduct(BaseModel):
+    """
+    Represents a list of products identified in the images.
+    """
+
+    products: Optional[List[Product]] = Field(
+        description="A list of products identified by the AI.",
+        example=[
+            Product(
+                name="Headphones",
+                description="Wireless headphones with noise cancellation.",
+                key_features=["Wireless", "Noise Cancellation"],
+            )
+        ],
+        default=None,
+    )
+
+    error: bool = Field(default=False)
+    message: Optional[str] = Field(default=None)
+```
+
+### Advertising Copy
+
+Finally, the `AdCopy` models stores the output in a structured format with a headline and the text.
+
+```python
+class AdCopy(BaseModel):
+    """
+    Represents a generated ad copy.
+    """
+
+    headline: str = Field(
+        description="A short, catchy, and memorable headline for the given product. The headline should invoke curiosity and interest in the product.",
+    )
+    ad_copy: str = Field(
+        description="A long-form advertisement copy for the given product. This will be used in campaigns to promote the product with a persuasive message and a call-to-action with the objective of driving sales.",
+    )
+    name: str = Field(
+        description="The name of the product being advertised.",    )
+
+    def __str__(self):
+        return f"{self.name}: \n" + "-" * 100 + f"{self.headline}\n{self.ad_copy}"
+
+    def __repr__(self):
+        return str(self)
+```
+
+## Calling the API
+
+### Product Detection
+
+The `read_images` function uses OpenAI's vision model to process a list of image URLs and identify products in each of them. We utilize the `instructor` library to patch the OpenAI client for this purpose.
+
+```python
+def read_images(image_urls: List[str]):
+    """
+    Given a list of image URLs, identify the products in the images.
+    """
+
+    logger.info(f"Identifying products in images... {len(image_urls)} images")
+
+    return client_image.chat.completions.create(
+        model="gpt-4-vision-preview",
+        response_model=IdentifiedProduct,
+        max_tokens=1024, # can be changed
+        temperature=0,
+        messages=[
+            {
+                "role": "user",
+                "content": [
+                    {
+                        "type": "text",
+                        "text": "Identify products using the given images and generate key features for each product.",
+                    },
+                    *[
+                        {"type": "image_url", "image_url": {"url": url}}
+                        for url in image_urls
+                    ],
+                ],
+            }
+        ],
+    )
+```
+
+This gives us a list of products identified in all the images.
+
+### Generate advertising copy
+
+Then, we can use the `generate_ad_copy` function to generate advertising copy for each of the products identified in the images.
+
+Two clients are defined for the two different models. This is because the `gpt-4-vision-preview` model is not compatible with the `gpt-4-1106-preview` model in terms of their response format.
+
+```python
+def generate_ad_copy(product: Product):
+    """
+    Given a product, generate an ad copy for the product.
+    """
+
+    logger.info(f"Generating ad copy for product: {product.name}")
+
+    return client_copy.chat.completions.create(
+        model="gpt-4-1106-preview",
+        response_model=AdCopy,
+        temperature=0.3,
+        messages=[
+            {
+                "role": "system",
+                "content": "You are an expert marketing assistant for all products. Your task is to generate an advertisement copy for a product using the name, description, and key features.",
+            },
+            {"role": "user", "content": product.generate_prompt()},
+        ],
+    )
+```
+
+### Putting it all together
+
+Finally, we can put it all together in a single function that takes a list of image URLs and generates advertising copy for the products identified in the images.
+
+## Input file
+
+The input file is currently a list of image URLs, but this trivial to change to any required format.

--- a/docs/examples/image_to_ad_copy.md
+++ b/docs/examples/image_to_ad_copy.md
@@ -10,7 +10,7 @@ The full code is available on [GitHub](https://www.github.com/jxnl/instructor/ex
 
 For the `Product` model, we define a class that represents a product extracted from an image and store the name, key features, and description. The product attributes are dynamically determined based on the content of the image.
 
-Note that it is easy to add Validators and other Pydantic features to the model to ensure that the data is valid and consistent.
+Note that it is easy to add [Validators](https://jxnl.github.io/instructor/concepts/reask_validation/) and other Pydantic features to the model to ensure that the data is valid and consistent.
 
 ```python
 class Product(BaseModel):
@@ -169,7 +169,7 @@ def generate_ad_copy(product: Product):
 
 ### Putting it all together
 
-Finally, we can put it all together in a single function that takes a list of image URLs and generates advertising copy for the products identified in the images.
+Finally, we can put it all together in a single function that takes a list of image URLs and generates advertising copy for the products identified in the images. Please refer to the [full code](https://www.github.com/jxnl/instructor/examples/vision/image_to_ad_copy.py) for the complete implementation.
 
 ## Input file
 

--- a/docs/examples/image_to_ad_copy.md
+++ b/docs/examples/image_to_ad_copy.md
@@ -138,7 +138,7 @@ Then, we can use the `generate_ad_copy` function to generate advertising copy fo
 Two clients are defined for the two different models. This is because the `gpt-4-vision-preview` model is not compatible with the `gpt-4-1106-preview` model in terms of their response format.
 
 ```python
-def generate_ad_copy(product: Product):
+def generate_ad_copy(product: Product) -> AdCopy:
     """
     Given a product, generate an ad copy for the product.
     """

--- a/docs/examples/image_to_ad_copy.md
+++ b/docs/examples/image_to_ad_copy.md
@@ -107,7 +107,7 @@ class AdCopy(BaseModel):
 The `read_images` function uses OpenAI's vision model to process a list of image URLs and identify products in each of them. We utilize the `instructor` library to patch the OpenAI client for this purpose.
 
 ```python
-def read_images(image_urls: List[str]):
+def read_images(image_urls: List[str]) -> IdentifiedProduct:
     """
     Given a list of image URLs, identify the products in the images.
     """

--- a/docs/examples/image_to_ad_copy.md
+++ b/docs/examples/image_to_ad_copy.md
@@ -25,7 +25,7 @@ class Product(BaseModel):
     name: str = Field(
         description="A generic name for the product.", example="Headphones"
     )
-    key_features: Optional[list[str]] = Field(
+    key_features: Optional[List[str]] = Field(
         description="A list of key features of the product that stand out.",
         default=None,
     )
@@ -174,3 +174,8 @@ Finally, we can put it all together in a single function that takes a list of im
 ## Input file
 
 The input file is currently a list of image URLs, but this trivial to change to any required format.
+
+```plaintext
+https://images.unsplash.com/photo-1702261343783-0e97c493a07b?crop=entropy
+https://images.unsplash.com/photo-1702499125332-75e7a9a64621?crop=entropy
+```

--- a/docs/examples/image_to_ad_copy.md
+++ b/docs/examples/image_to_ad_copy.md
@@ -168,8 +168,10 @@ Finally, we can put it all together in a single function that takes a list of im
 The input file is currently a list of image URLs, but this trivial to change to any required format.
 
 ```plaintext
-https://images.unsplash.com/photo-1702261343783-0e97c493a07b?crop=entropy
-https://images.unsplash.com/photo-1702499125332-75e7a9a64621?crop=entropy
+https://contents.mediadecathlon.com/p1279823/9a1c59ad97a4084a346c014740ae4d3ff860ea70b485ee65f34017ff5e9ae5f7/recreational-ice-skates-fit-50-black.jpg?format=auto
+https://contents.mediadecathlon.com/p1279822/a730505231dbd6747c14ee93e8f89e824d3fa2a5b885ec26de8d7feb5626638a/recreational-ice-skates-fit-50-black.jpg?format=auto
+https://contents.mediadecathlon.com/p2329893/1ed75517602a5e00245b89ab6a1c6be6d8968a5a227c932b10599f857f3ed4cd/mens-hiking-leather-boots-sh-100-x-warm.jpg?format=auto
+https://contents.mediadecathlon.com/p2047870/8712c55568dd9928c83b19c6a4067bf161811a469433dc89244f0ff96a50e3e9/men-s-winter-hiking-boots-sh-100-x-warm-grey.jpg?format=auto
 ```
 
 ??? Note "Expand to see the output"

--- a/docs/examples/image_to_ad_copy.md
+++ b/docs/examples/image_to_ad_copy.md
@@ -2,7 +2,7 @@
 
 This post demonstrates how to use GPT-4 Vision API and the Chat API to automatically generate advertising copy from product images. This method can be useful for marketing and advertising teams, as well as for e-commerce platforms.
 
-The full code is available on [GitHub](https://www.github.com/openai/gpt-4).
+The full code is available on [GitHub](https://www.github.com/jxnl/instructor/examples/vision/image_to_ad_copy.py).
 
 ## Building the models
 

--- a/docs/examples/image_to_ad_copy.md
+++ b/docs/examples/image_to_ad_copy.md
@@ -43,9 +43,6 @@ class Product(BaseModel):
         if self.key_features:
             prompt += f"Key Features: {', '.join(self.key_features)}\n"
         return prompt
-
-    def __repr__(self):
-        return self.generate_prompt()
 ```
 
 ### Identified Product
@@ -91,13 +88,8 @@ class AdCopy(BaseModel):
         description="A long-form advertisement copy for the given product. This will be used in campaigns to promote the product with a persuasive message and a call-to-action with the objective of driving sales.",
     )
     name: str = Field(
-        description="The name of the product being advertised.",    )
-
-    def __str__(self):
-        return f"{self.name}: \n" + "-" * 100 + f"{self.headline}\n{self.ad_copy}"
-
-    def __repr__(self):
-        return str(self)
+        description="The name of the product being advertised."
+    )
 ```
 
 ## Calling the API
@@ -179,3 +171,57 @@ The input file is currently a list of image URLs, but this trivial to change to 
 https://images.unsplash.com/photo-1702261343783-0e97c493a07b?crop=entropy
 https://images.unsplash.com/photo-1702499125332-75e7a9a64621?crop=entropy
 ```
+
+??? Note "Expand to see the output"
+
+    ```json
+    {
+        "products":
+        [
+            {
+                "name": "Ice Skates",
+                "key_features": [
+                    "Lace-up closure",
+                    "Durable blade",
+                    "Ankle support"
+                ],
+                "description": "A pair of ice skates with lace-up closure for secure fit, durable blade for ice skating, and reinforced ankle support."
+            },
+            {
+                "name": "Hiking Boots",
+                "key_features": [
+                    "High-top design",
+                    "Rugged outsole",
+                    "Water-resistant"
+                ],
+                "description": "Sturdy hiking boots featuring a high-top design for ankle support, rugged outsole for grip on uneven terrain, and water-resistant construction."
+            },
+            {
+                "name": "Winter Boots",
+                "key_features": [
+                    "Insulated lining",
+                    "Waterproof lower",
+                    "Slip-resistant sole"
+                ],
+                "description": "Warm winter boots with insulated lining for cold weather, waterproof lower section to keep feet dry, and a slip-resistant sole for stability."
+            }
+        ],
+        "ad_copies": [
+            {
+                "headline": "Glide with Confidence - Discover the Perfect Ice Skates!",
+                "ad_copy": "Step onto the ice with poise and precision with our premium Ice Skates. Designed for both beginners and seasoned skaters, these skates offer a perfect blend of comfort and performance. The lace-up closure ensures a snug fit that keeps you stable as you carve through the ice. With a durable blade that withstands the test of time, you can focus on perfecting your moves rather than worrying about your equipment. The reinforced ankle support provides the necessary protection and aids in preventing injuries, allowing you to skate with peace of mind. Whether you're practicing your spins, jumps, or simply enjoying a leisurely glide across the rink, our Ice Skates are the ideal companion for your ice adventures. Lace up and get ready to experience the thrill of ice skating like never before!",
+                "name": "Ice Skates"
+            },
+            {
+                "headline": "Conquer Every Trail with Confidence!",
+                "ad_copy": "Embark on your next adventure with our top-of-the-line Hiking Boots! Designed for the trail-blazing spirits, these boots boast a high-top design that provides unparalleled ankle support to keep you steady on any path. The rugged outsole ensures a firm grip on the most uneven terrains, while the water-resistant construction keeps your feet dry as you traverse through streams and muddy trails. Whether you're a seasoned hiker or just starting out, our Hiking Boots are the perfect companion for your outdoor escapades. Lace up and step into the wild with confidence - your journey awaits!",
+                "name": "Hiking Boots"
+            },
+            {
+                "headline": "Conquer the Cold with Comfort!",
+                "ad_copy": "Step into the season with confidence in our Winter Boots, the ultimate ally against the chill. Designed for those who don't let the cold dictate their moves, these boots feature an insulated lining that wraps your feet in a warm embrace, ensuring that the biting cold is a worry of the past. But warmth isn't their only virtue. With a waterproof lower section, your feet will remain dry and cozy, come rain, snow, or slush. And let's not forget the slip-resistant sole that stands between you and the treacherous ice, offering stability and peace of mind with every step you take. Whether you're braving a blizzard or just nipping out for a coffee, our Winter Boots are your trusty companions, keeping you warm, dry, and upright. Don't let winter slow you down. Lace up and embrace the elements!",
+                "name": "Winter Boots"
+            }
+        ]
+    }
+    ```

--- a/examples/vision/image_to_ad_copy.py
+++ b/examples/vision/image_to_ad_copy.py
@@ -51,9 +51,6 @@ class Product(BaseModel):
             prompt += f"Key Features: {', '.join(self.key_features)}\n"
         return prompt
 
-    def __repr__(self):
-        return self.generate_prompt()
-
 
 class IdentifiedProduct(BaseModel):
     """
@@ -98,12 +95,6 @@ class AdCopy(BaseModel):
         description="The name of the product being advertised.",
         example="Headphones",
     )
-
-    def __str__(self):
-        return f"{self.name}: \n" + "-" * 100 + f"{self.headline}\n{self.ad_copy}"
-
-    def __repr__(self):
-        return str(self)
 
 
 # Define clients
@@ -227,3 +218,55 @@ if __name__ == "__main__":
             f,
             indent=4,
         )
+
+""" 
+Example output:
+{
+    "products": [
+        {
+            "name": "Ice Skates",
+            "key_features": [
+                "Lace-up closure",
+                "Durable blade",
+                "Ankle support"
+            ],
+            "description": "A pair of ice skates with lace-up closure for secure fit, durable blade for ice skating, and reinforced ankle support."
+        },
+        {
+            "name": "Hiking Boots",
+            "key_features": [
+                "High-top design",
+                "Rugged outsole",
+                "Water-resistant"
+            ],
+            "description": "Sturdy hiking boots featuring a high-top design for ankle support, rugged outsole for grip on uneven terrain, and water-resistant construction."
+        },
+        {
+            "name": "Winter Boots",
+            "key_features": [
+                "Insulated lining",
+                "Waterproof lower",
+                "Slip-resistant sole"
+            ],
+            "description": "Warm winter boots with insulated lining for cold weather, waterproof lower section to keep feet dry, and a slip-resistant sole for stability."
+        }
+    ],
+    "ad_copies": [
+        {
+            "headline": "Glide with Confidence - Discover the Perfect Ice Skates!",
+            "ad_copy": "Step onto the ice with poise and precision with our premium Ice Skates. Designed for both beginners and seasoned skaters, these skates offer a perfect blend of comfort and performance. The lace-up closure ensures a snug fit that keeps you stable as you carve through the ice. With a durable blade that withstands the test of time, you can focus on perfecting your moves rather than worrying about your equipment. The reinforced ankle support provides the necessary protection and aids in preventing injuries, allowing you to skate with peace of mind. Whether you're practicing your spins, jumps, or simply enjoying a leisurely glide across the rink, our Ice Skates are the ideal companion for your ice adventures. Lace up and get ready to experience the thrill of ice skating like never before!",
+            "name": "Ice Skates"
+        },
+        {
+            "headline": "Conquer Every Trail with Confidence!",
+            "ad_copy": "Embark on your next adventure with our top-of-the-line Hiking Boots! Designed for the trail-blazing spirits, these boots boast a high-top design that provides unparalleled ankle support to keep you steady on any path. The rugged outsole ensures a firm grip on the most uneven terrains, while the water-resistant construction keeps your feet dry as you traverse through streams and muddy trails. Whether you're a seasoned hiker or just starting out, our Hiking Boots are the perfect companion for your outdoor escapades. Lace up and step into the wild with confidence - your journey awaits!",
+            "name": "Hiking Boots"
+        },
+        {
+            "headline": "Conquer the Cold with Comfort!",
+            "ad_copy": "Step into the season with confidence in our Winter Boots, the ultimate ally against the chill. Designed for those who don't let the cold dictate their moves, these boots feature an insulated lining that wraps your feet in a warm embrace, ensuring that the biting cold is a worry of the past. But warmth isn't their only virtue. With a waterproof lower section, your feet will remain dry and cozy, come rain, snow, or slush. And let's not forget the slip-resistant sole that stands between you and the treacherous ice, offering stability and peace of mind with every step you take. Whether you're braving a blizzard or just nipping out for a coffee, our Winter Boots are your trusty companions, keeping you warm, dry, and upright. Don't let winter slow you down. Lace up and embrace the elements!",
+            "name": "Winter Boots"
+        }
+    ]
+}
+"""

--- a/examples/vision/image_to_ad_copy.py
+++ b/examples/vision/image_to_ad_copy.py
@@ -2,13 +2,14 @@ import json
 import logging
 import os
 import sys
-from typing import List, Optional
+from typing import List, Optional, Tuple
 
-import instructor
 from dotenv import find_dotenv, load_dotenv
 from openai import OpenAI
 from pydantic import BaseModel, Field
 from rich import print as rprint
+
+import instructor
 
 load_dotenv(find_dotenv())
 
@@ -31,7 +32,7 @@ class Product(BaseModel):
     name: str = Field(
         description="A generic name for the product.", example="Headphones"
     )
-    key_features: Optional[list[str]] = Field(
+    key_features: Optional[List[str]] = Field(
         description="A list of key features of the product that stand out.",
         example=["Wireless", "Noise Cancellation"],
         default=None,
@@ -107,7 +108,7 @@ client_copy = instructor.patch(
 
 
 # Define functions
-def read_images(image_urls: List[str]):
+def read_images(image_urls: List[str]) -> IdentifiedProduct:
     """
     Given a list of image URLs, identify the products in the images.
     """
@@ -137,7 +138,7 @@ def read_images(image_urls: List[str]):
     )
 
 
-def generate_ad_copy(product: Product):
+def generate_ad_copy(product: Product) -> AdCopy:
     """
     Given a product, generate an ad copy for the product.
     """
@@ -158,7 +159,7 @@ def generate_ad_copy(product: Product):
     )
 
 
-def run(images: list[str]):
+def run(images: List[str]) -> Tuple[List[Product], List[AdCopy]]:
     """
     Given a list of images, identify the products in the images and generate ad copy for each product.
     """

--- a/examples/vision/image_to_ad_copy.py
+++ b/examples/vision/image_to_ad_copy.py
@@ -1,0 +1,229 @@
+import json
+import logging
+import os
+import sys
+from typing import List, Optional
+
+import instructor
+from dotenv import find_dotenv, load_dotenv
+from openai import OpenAI
+from pydantic import BaseModel, Field
+from rich import print as rprint
+
+load_dotenv(find_dotenv())
+
+# Add logger
+logging.basicConfig()
+logger = logging.getLogger("app")
+logger.setLevel("INFO")
+
+
+# Define models
+class Product(BaseModel):
+    """
+    Represents a product extracted from an image using AI.
+
+    The product attributes are dynamically determined based on the content
+    of the image and the AI's interpretation. This class serves as a structured
+    representation of the identified product characteristics.
+    """
+
+    name: str = Field(
+        description="A generic name for the product.", example="Headphones"
+    )
+    key_features: Optional[list[str]] = Field(
+        description="A list of key features of the product that stand out.",
+        example=["Wireless", "Noise Cancellation"],
+        default=None,
+    )
+
+    description: Optional[str] = Field(
+        description="A description of the product.",
+        example="Wireless headphones with noise cancellation.",
+        default=None,
+    )
+
+    def generate_prompt(self):
+        prompt = f"Product: {self.name}\n"
+        if self.description:
+            prompt += f"Description: {self.description}\n"
+        if self.key_features:
+            prompt += f"Key Features: {', '.join(self.key_features)}\n"
+        return prompt
+
+    def __repr__(self):
+        return self.generate_prompt()
+
+
+class IdentifiedProduct(BaseModel):
+    """
+    Represents a list of products identified in the images.
+    """
+
+    products: Optional[List[Product]] = Field(
+        description="A list of products identified by the AI.",
+        example=[
+            Product(
+                name="Headphones",
+                description="Wireless headphones with noise cancellation.",
+                key_features=["Wireless", "Noise Cancellation"],
+            )
+        ],
+        default=None,
+    )
+
+    error: bool = Field(default=False)
+    message: Optional[str] = Field(default=None)
+
+    def __bool__(self):
+        return self.products is not None and len(self.products) > 0
+
+
+class AdCopy(BaseModel):
+    """
+    Represents a generated ad copy.
+    """
+
+    headline: str = Field(
+        description="A short, catchy, and memorable headline for the given product. The headline should invoke curiosity and interest in the product.",
+        example="Wireless Headphones",
+    )
+    ad_copy: str = Field(
+        description="A long-form advertisement copy for the given product. This will be used in campaigns to promote the product with a persuasive message and a call-to-action with the objective of driving sales.",
+        example="""
+        "Experience the ultimate sound quality with our wireless headphones, featuring high-definition audio, noise-cancellation, and a comfortable, ergonomic design for all-day listening."
+        """,
+    )
+    name: str = Field(
+        description="The name of the product being advertised.",
+        example="Headphones",
+    )
+
+    def __str__(self):
+        return f"{self.name}: \n" + "-" * 100 + f"{self.headline}\n{self.ad_copy}"
+
+    def __repr__(self):
+        return str(self)
+
+
+# Define clients
+client_image = instructor.patch(
+    OpenAI(api_key=os.getenv("OPENAI_API_KEY")), mode=instructor.Mode.MD_JSON
+)
+client_copy = instructor.patch(
+    OpenAI(api_key=os.getenv("OPENAI_API_KEY")), mode=instructor.Mode.FUNCTIONS
+)
+
+
+# Define functions
+def read_images(image_urls: List[str]):
+    """
+    Given a list of image URLs, identify the products in the images.
+    """
+
+    logger.info(f"Identifying products in images... {len(image_urls)} images")
+
+    return client_image.chat.completions.create(
+        model="gpt-4-vision-preview",
+        response_model=IdentifiedProduct,
+        max_tokens=1024,
+        temperature=0,
+        messages=[
+            {
+                "role": "user",
+                "content": [
+                    {
+                        "type": "text",
+                        "text": "Identify products using the given images and generate key features for each product.",
+                    },
+                    *[
+                        {"type": "image_url", "image_url": {"url": url}}
+                        for url in image_urls
+                    ],
+                ],
+            }
+        ],
+    )
+
+
+def generate_ad_copy(product: Product):
+    """
+    Given a product, generate an ad copy for the product.
+    """
+
+    logger.info(f"Generating ad copy for product: {product.name}")
+
+    return client_copy.chat.completions.create(
+        model="gpt-4-1106-preview",
+        response_model=AdCopy,
+        temperature=0.3,
+        messages=[
+            {
+                "role": "system",
+                "content": "You are an expert marketing assistant for all products. Your task is to generate an advertisement copy for a product using the name, description, and key features.",
+            },
+            {"role": "user", "content": product.generate_prompt()},
+        ],
+    )
+
+
+def run(images: list[str]):
+    """
+    Given a list of images, identify the products in the images and generate ad copy for each product.
+    """
+
+    identified_products: IdentifiedProduct = read_images(images)
+    ad_copies = []
+
+    if identified_products.error:
+        rprint(f"[red]Error: {identified_products.message}[/red]")
+        return []
+
+    if not identified_products:
+        rprint("[yellow]No products identified.[/yellow]")
+        return []
+
+    for product in identified_products.products:
+        ad_copy: AdCopy = generate_ad_copy(product)
+        ad_copies.append(ad_copy)
+
+    return identified_products.products, ad_copies
+
+
+if __name__ == "__main__":
+    # Run logger
+    logger.info("Starting app...")
+
+    if len(sys.argv) != 2:
+        print("Usage: python app.py <path_to_image_list_file>")
+        sys.exit(1)
+
+    image_file = sys.argv[1]
+    with open(image_file, "r") as file:
+        logger.info(f"Reading images from file: {image_file}")
+        try:
+            image_list = file.read().splitlines()
+            logger.info(f"{len(image_list)} images read from file: {image_file}")
+        except Exception as e:
+            logger.error(f"Error reading images from file: {image_file}")
+            logger.error(e)
+            sys.exit(1)
+
+    products, ad_copies = run(image_list)
+
+    rprint(f"[green]{len(products)} products identified:[/green]")
+    for product, ad_copy in zip(products, ad_copies):
+        rprint(f"[green]{product}[/green]")
+        rprint(f"[blue]Ad Copy: {ad_copy.ad_copy}[/blue]")
+
+    logger.info("Writing results to file...")
+
+    with open("results.json", "w") as f:
+        json.dump(
+            {
+                "products": [prod.model_dump() for prod in products],
+                "ad_copies": [ad.model_dump() for ad in ad_copies],
+            },
+            f,
+            indent=4,
+        )

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -147,6 +147,7 @@ nav:
     - Text Classification: 'examples/classification.md'
     - Self Critique: 'examples/self_critique.md'
     - Image Extracting Tables: 'examples/extracting_tables.md'
+    - Image to Ad Copy: 'examples/image_to_ad_copy.md'
     - Moderation: 'examples/moderation.md'
     - Citations: 'examples/exact_citations.md'
     - Knowledge Graph: 'examples/knowledge_graph.md'


### PR DESCRIPTION
This pull request adds the .DS_Store file to the .gitignore file to prevent it from being tracked in the repository. It also includes an example on how to use the GPT-4 Vision API and the Chat API to automatically generate advertising copy from product images.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a guide on using GPT-4 Vision API and Chat API to generate ad copy from images.
  - Implemented a new example script for identifying products in images and creating advertising content.

- **Documentation**
  - Added `image_to_ad_copy.md` to showcase usage and capabilities of the new feature.

- **Chores**
  - Updated `.gitignore` to exclude macOS system files.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->