### PR TITLE
[docs] Add example link on index page

### DIFF
--- a/docs/examples/index.md
+++ b/docs/examples/index.md
@@ -16,5 +16,6 @@
 12. [How are action items and dependencies generated from transcripts?](action_items.md)
 13. [How to enable OpenAI's moderation](moderation.md)
 14. [How to extract tables from images](extracting_tables.md)
+15. [How to generate advertising copy from image inputs](image_to_ad_copy.md)
 
 Explore more!


### PR DESCRIPTION
From #293, I forgot to update examples/index.md to include the new tutorial. This PR fixes that.