### PR TITLE
Remove unused imports

### DIFF
--- a/examples/extract-table/run_text.py
+++ b/examples/extract-table/run_text.py
@@ -1,7 +1,6 @@
 from openai import OpenAI
 from io import StringIO
 from typing import Annotated, Any, Iterable
-from openai import OpenAI
 from pydantic import (
     BaseModel,
     BeforeValidator,
@@ -10,7 +9,6 @@ from pydantic import (
     WithJsonSchema,
 )
 import pandas as pd
-from tomlkit import table
 import instructor
 
 

--- a/examples/extract-table/run_vision.py
+++ b/examples/extract-table/run_vision.py
@@ -1,7 +1,6 @@
 from openai import OpenAI
 from io import StringIO
 from typing import Annotated, Any, Iterable
-from openai import OpenAI
 from pydantic import (
     BaseModel,
     BeforeValidator,

--- a/tests/openai/test_parallel.py
+++ b/tests/openai/test_parallel.py
@@ -1,4 +1,4 @@
-from typing import Iterable, Literal, Union
+from typing import Iterable, Literal
 from pydantic import BaseModel
 
 import pytest

--- a/tests/openai/test_retries.py
+++ b/tests/openai/test_retries.py
@@ -1,5 +1,5 @@
 from typing import Annotated
-from pydantic import AfterValidator, BaseModel, BeforeValidator, Field
+from pydantic import AfterValidator, BaseModel, Field
 import pytest
 import instructor
 from itertools import product


### PR DESCRIPTION


<!--
ELLIPSIS_HIDDEN
-->




| <a href="https://ellipsis.dev" target="_blank"><img src="https://avatars.githubusercontent.com/u/80834858?s=400&u=31e596315b0d8f7465b3ee670f25cea677299c96&v=4" alt="Ellipsis" width="30px" height="30px"/></a> | :rocket: This PR description was created by [Ellipsis](https://www.ellipsis.dev) for commit 33f81e3f2ddebd051bcde0d6f0ecb8b81e704b12.  | 
|--------|--------|

### Summary:
This PR removes unused imports from four files, improving code cleanliness without altering functionality.

**Key points**:
- Removed duplicate import of `OpenAI` from `openai` in `/examples/extract-table/run_text.py` and `/examples/extract-table/run_vision.py`
- Removed unused import of `table` from `tomlkit` in `/examples/extract-table/run_text.py`
- Removed unused import of `Union` from `typing` in `/tests/openai/test_parallel.py`
- Removed unused import of `BeforeValidator` from `pydantic` in `/tests/openai/test_retries.py`
----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)


<!--
ELLIPSIS_HIDDEN
-->
