### PR TITLE
Fix typos

### DIFF
--- a/examples/citation_with_extraction/main.py
+++ b/examples/citation_with_extraction/main.py
@@ -61,13 +61,13 @@ class Fact(BaseModel):
 
 class QuestionAnswer(OpenAISchema, MultiTaskBase):
     """
-    Class representing a question and its answer as a list of facts each one should have a soruce.
+    Class representing a question and its answer as a list of facts each one should have a source.
     each sentence contains a body and a list of sources."""
 
     question: str = Field(..., description="Question that was asked")
     tasks: List[Fact] = Field(
         ...,
-        description="Body of the answer, each fact should be its seperate object with a body and a list of sources",
+        description="Body of the answer, each fact should be its separate object with a body and a list of sources",
     )
 
 


### PR DESCRIPTION
Just a couple typo and spelling fixes

<!--
ELLIPSIS_HIDDEN
-->


----

| <a href="https://ellipsis.dev" target="_blank"><img src="https://avatars.githubusercontent.com/u/80834858?s=400&u=31e596315b0d8f7465b3ee670f25cea677299c96&v=4" alt="Ellipsis" width="30px" height="30px"/></a> | :rocket: This PR description was created by [Ellipsis](https://www.ellipsis.dev) for commit 8bf5f5a67699c1b44fb1dea07d99f5fec8e02332.  | 
|--------|--------|

### Summary:
This PR fixes two spelling errors in the `QuestionAnswer` class in the `main.py` file of the `examples/citation_with_extraction` directory.

**Key points**:
- Corrected spelling of 'soruce' to 'source' in the `QuestionAnswer` class docstring.
- Corrected spelling of 'seperate' to 'separate' in the `tasks` field description of the `QuestionAnswer` class.
----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)


<!--
ELLIPSIS_HIDDEN
-->
