### PR TITLE
Add create-wrapper example with async demo scripts

### DIFF
--- a/examples/create-wrapper/as_completed.py
+++ b/examples/create-wrapper/as_completed.py
@@ -1,0 +1,135 @@
+"""Example creating and scheduling tasks `asyncio.create_task`, processing them concurrently via `as_completed`. As they complete, results are parsed using [structure pattern matching](https://jxnl.github.io/instructor/concepts/models/#structural-pattern-matching)."""
+
+import asyncio
+import openai
+import instructor
+import datetime
+
+from pydantic import BaseModel, Field
+from typing import Any, Coroutine, Callable, TypeVar, ParamSpec, Concatenate, Type, cast
+
+from openai import AsyncOpenAI
+
+models="gpt-4-0125-preview", "gpt-3.5-turbo-1106"
+model = models[0]
+
+T = TypeVar('T')
+M = TypeVar('M')
+P = ParamSpec('P')
+
+def patched_create(**kwargs: Any):
+    _client = openai.AsyncClient(**kwargs)
+    client: AsyncOpenAI = instructor.patch(_client)
+    func = client.chat.completions.create
+    def async_create_wrapper(func: Callable[P, Coroutine[Any, Any, T]]) -> Callable[Concatenate[Type[M], P], Coroutine[Any, Any, M]]:
+        async def wrapper(val: Type[M] | None = None, *args: P.args, **kwargs: P.kwargs) -> M:
+            if response_model := kwargs.pop("response_model", val):
+                val = cast(Type[M], response_model)
+            return await cast(Callable[Concatenate[Type[M] | None, P], Coroutine[Any, Any, M]], func)(val, *args, **kwargs)
+        return wrapper
+    return async_create_wrapper(func)
+
+
+class Staff(BaseModel):
+    """Correctly determine employee information."""
+    chain_of_thought: str = Field(..., description="Step by step reasoning to get the correct time range")
+    name: str = Field(..., description="Name of the staff member.")
+    position: str | None = Field(None, description="Position of the staff member.")
+    start_date: datetime.date | None = Field(None, description="Start date for the staff member.")
+
+class Recruits(BaseModel):
+    """Correctly determine newly recruited staff details."""
+    staff: list[Staff] = Field(..., description="List of new staff recruits.")
+
+system_message_text=f"Date: {datetime.date.today().isoformat()}\nPerform accurate extractions."
+system_message = {"role": "system", "content": system_message_text}
+query1="We just hired Felicity Quill, she starts on Monday."
+message1 = {"role": "user", "content": query1}
+query2="Archibald Fiddlesticks begins in 2 weeks from Monday."
+message2 = {"role": "user", "content": query2}
+
+
+async def main():
+    create = patched_create()
+    tasks: list[asyncio.Task[Staff | Recruits]] = []
+    task1 = asyncio.create_task(create(
+        Staff,
+        messages=[
+            {"role": "system", "content": system_message_text},
+            {"role": "user", "content": query1},
+        ],
+        model=model,
+    ))
+    tasks.append(task1)
+
+    task2 = asyncio.create_task(create(
+        Staff,
+        messages=[
+            {"role": "system", "content": system_message_text},
+            {"role": "user", "content": query2},
+        ],
+        model=model,
+    ))
+    tasks.append(task2)
+    task3 = asyncio.create_task(create(
+        Recruits,
+        messages=[
+            {"role": "system", "content": system_message_text},
+            {"role": "user", "content": query1},
+            {"role": "user", "content": query2},
+        ],
+        model=model,
+    ))
+    tasks.append(task3)
+    length = []
+    for task in asyncio.as_completed(tasks):
+        result = await task
+        match result:
+            case Recruits(staff=recruits):
+                assert isinstance(result, Recruits)
+                assert isinstance(recruits, list)
+                data_dump = result.model_dump_json()
+                length.append(len(data_dump))
+            case _:
+                assert isinstance(result, Staff)
+                data_dump = result.model_dump_json()
+                length.append(len(data_dump))
+        print(data_dump)
+    print(f"{length}\t= {sum(length)}")
+
+if __name__ == "__main__":
+    asyncio.run(main())
+
+_="""
+[
+    {
+        "chain_of_thought": "To determine the start date for Felicity Quill, we need to know what day today is. Generally speaking, when someone says 'starts on Monday,' without specifying a date, it implies the closest Monday from today. Given the current date is 2024-02-04, the closest Monday is actually today, which means Felicity Quill's start date is 2024-02-05.",
+        "name": "Felicity Quill",
+        "position": null,
+        "start_date": "2024-02-05"
+    }
+{
+        "chain_of_thought": "To determine Archibald Fiddlesticks' start date, we take today's date, 2024-02-04, and calculate 2 weeks from the next Monday. Considering today is Sunday, the next Monday is 2024-02-05. Adding 2 weeks to this date gives us 2024-02-19.",
+        "name": "Archibald Fiddlesticks",
+        "position": null,
+        "start_date": "2024-02-19"
+    }
+{
+        "staff": [
+            {
+                "chain_of_thought": "Today is Sunday, February 4, 2024, so Monday would be February 5, 2024. Hence, Felicity Quill's start date is February 5, 2024.",
+                "name": "Felicity Quill",
+                "position": null,
+                "start_date": "2024-02-05"
+            },
+            {
+                "chain_of_thought": "Starting from Monday, which is February 5, 2024, adding 2 weeks leads to February 19, 2024, making it Archibald Fiddlesticks' start date.",
+                "name": "Archibald Fiddlesticks",
+                "position": null,
+                "start_date": "2024-02-19"
+            }
+        ]
+    }
+]
+"""
+

--- a/examples/create-wrapper/gather.py
+++ b/examples/create-wrapper/gather.py
@@ -1,0 +1,135 @@
+"""Example creating and scheduling tasks `asyncio.create_task`, processing them concurrently via `asyncio.gather`. Once all tasks have completed, results are parsed using [structure pattern matching](https://jxnl.github.io/instructor/concepts/models/#structural-pattern-matching)."""
+
+import asyncio
+import openai
+import instructor
+import datetime
+
+from pydantic import BaseModel, Field
+from typing import Any, Coroutine, Callable, TypeVar, ParamSpec, Concatenate, Type, cast
+
+from openai import AsyncOpenAI
+
+models="gpt-4-0125-preview", "gpt-3.5-turbo-1106"
+model = models[0]
+
+T = TypeVar('T')
+M = TypeVar('M')
+P = ParamSpec('P')
+
+def patched_create(**kwargs: Any):
+    _client = openai.AsyncClient(**kwargs)
+    client: AsyncOpenAI = instructor.patch(_client)
+    func = client.chat.completions.create
+    def async_create_wrapper(func: Callable[P, Coroutine[Any, Any, T]]) -> Callable[Concatenate[Type[M], P], Coroutine[Any, Any, M]]:
+        async def wrapper(val: Type[M] | None = None, *args: P.args, **kwargs: P.kwargs) -> M:
+            if response_model := kwargs.pop("response_model", val):
+                val = cast(Type[M], response_model)
+            return await cast(Callable[Concatenate[Type[M] | None, P], Coroutine[Any, Any, M]], func)(val, *args, **kwargs)
+        return wrapper
+    return async_create_wrapper(func)
+
+
+class Staff(BaseModel):
+    """Correctly determine employee information."""
+    chain_of_thought: str = Field(..., description="Step by step reasoning to get the correct time range")
+    name: str = Field(..., description="Name of the staff member.")
+    position: str | None = Field(None, description="Position of the staff member.")
+    start_date: datetime.date | None = Field(None, description="Start date for the staff member.")
+
+class Recruits(BaseModel):
+    """Correctly determine newly recruited staff details."""
+    staff: list[Staff] = Field(..., description="List of new staff recruits.")
+
+system_message_text=f"Date: {datetime.date.today().isoformat()}\nPerform accurate extractions."
+system_message = {"role": "system", "content": system_message_text}
+query1="We just hired Felicity Quill, she starts on Monday."
+message1 = {"role": "user", "content": query1}
+query2="Archibald Fiddlesticks begins in 2 weeks from Monday."
+message2 = {"role": "user", "content": query2}
+
+
+async def main():
+    create = patched_create()
+    tasks: list[asyncio.Task[Staff | Recruits]] = []
+    task1 = asyncio.create_task(create(
+        Staff,
+        messages=[
+            {"role": "system", "content": system_message_text},
+            {"role": "user", "content": query1},
+        ],
+        model=model,
+    ))
+    tasks.append(task1)
+
+    task2 = asyncio.create_task(create(
+        Staff,
+        messages=[
+            {"role": "system", "content": system_message_text},
+            {"role": "user", "content": query2},
+        ],
+        model=model,
+    ))
+    tasks.append(task2)
+    task3 = asyncio.create_task(create(
+        Recruits,
+        messages=[
+            {"role": "system", "content": system_message_text},
+            {"role": "user", "content": query1},
+            {"role": "user", "content": query2},
+        ],
+        model=model,
+    ))
+    tasks.append(task3)
+    results = await asyncio.gather(*tasks)
+    length = []
+    for result in results:
+        match result:
+            case Recruits(staff=recruits):
+                assert isinstance(result, Recruits)
+                assert isinstance(recruits, list)
+                data_dump = result.model_dump_json()
+                length.append(len(data_dump))
+            case _:
+                assert isinstance(result, Staff)
+                data_dump = result.model_dump_json()
+                length.append(len(data_dump))
+        print(data_dump)
+    print(f"{length}\t= {sum(length)}")
+
+if __name__ == "__main__":
+    asyncio.run(main())
+
+_="""
+[
+    {
+        "chain_of_thought": "To accurately determine Felicity Quill's start date, we need to identify which Monday is referred to in the provided information. Since the exact date was not provided and the system's current date is 2024-02-04, we can infer that her start date is the nearest upcoming Monday from today's date. Since today is 2024-02-04, and is a Sunday, the nearest Monday would be 2024-02-05. Therefore, Felicity Quill's start date is Monday, 2024-02-05.",
+        "name": "Felicity Quill",
+        "position": null,
+        "start_date": "2024-02-05"
+    },
+    {
+        "chain_of_thought": "Given that today is February 4, 2024, two weeks from Monday would mean starting from February 5, 2024. Therefore, Archibald Fiddlesticks begins on February 19, 2024.",
+        "name": "Archibald Fiddlesticks",
+        "position": null,
+        "start_date": "2024-02-19"
+    },
+    {
+        "staff": [
+            {
+                "chain_of_thought": "Today is February 4, 2024. Felicity starts on the coming Monday, which is February 5, 2024.",
+                "name": "Felicity Quill",
+                "position": null,
+                "start_date": "2024-02-05"
+            },
+            {
+                "chain_of_thought": "Today is February 4, 2024. Archibald starts in 2 weeks from the coming Monday. The coming Monday is February 5, 2024, so 2 weeks from that is February 19, 2024.",
+                "name": "Archibald Fiddlesticks",
+                "position": null,
+                "start_date": "2024-02-19"
+            }
+        ]
+    }
+]
+"""
+

--- a/examples/create-wrapper/patched_create.py
+++ b/examples/create-wrapper/patched_create.py
@@ -1,0 +1,129 @@
+
+import openai
+import instructor
+import functools
+
+from typing import Coroutine, Any, Callable, Type, TypeVar, ParamSpec, Concatenate, cast
+
+from openai import AsyncOpenAI
+from instructor import Mode
+
+
+T = TypeVar('T')
+M = TypeVar('M')
+P = ParamSpec('P')
+
+
+def patched_create_delay_response_model(mode: Mode = Mode.FUNCTIONS, **client_kwargs: Any):
+    """
+    Creates a patched version of the `openai_client.chat.completions.create` method.
+    This patched version requires the `response_model` to be provided as the first positional argument.
+    The `response_model` is the type that the coroutine will return an instance of.
+
+    Args:
+        mode (instructor.Mode): The mode to use for the patched client.
+        **client_kwargs: Arbitrary keyword arguments that will be passed to the `openai.AsyncClient` constructor.
+
+    Returns:
+        A callable that represents the patched `create` method. This callable can be awaited to obtain
+        an instance of the specified `response_model`.
+    """
+    # Initialize the OpenAI async client with the provided keyword arguments
+    _client = openai.AsyncClient(**client_kwargs)
+    
+    # Patch the client using `instructor.patch`
+    client: AsyncOpenAI = instructor.patch(client=_client, mode=mode)
+
+    # Get the original `create` method from the patched client
+    original_create = client.chat.completions.create
+
+    # Define a wrapper function that will concatenate the `response_model` as a positional arguments
+    def create_wrapper(original_create: Callable[P, Coroutine[Any, Any, T]]) -> Callable[Concatenate[Type[M], P], Coroutine[Any, Any, M]]:
+        """
+        A wrapper coroutine for the `openai_client.chat.completions.create` method.
+
+        This coroutine requires that the `response_model` is passed as the first argument `__p0` to the patched
+        `create` method and returns an instance of the `response_model` via `instructor`.
+
+        Args:
+            response_model: The type of the model that the coroutine will return an instance of.
+            *args: ParamSpec.args
+            **kwargs: ParamSpec.kwargs
+        Returns:
+            An instance of the specified `response_model` via `instructor`.
+        """
+        async def wrapper(response_model: Type[M] | None = None, *args: P.args, **kwargs: P.kwargs) -> M:
+            # Potential catch for future if `response_model` is passed as a keyword argument
+            if untyped_response_model := kwargs.pop("response_model", response_model):
+                response_model = cast(Type[M], untyped_response_model)
+            
+            # Cast the original function to accept the `response_model` as the first argument
+            typed_original_create = cast(Callable[Concatenate[Type[M] | None, P], Coroutine[Any, Any, M]], original_create)
+
+            # Call and await the function including the `response_model` as the first argument and return the result
+            response_model_instance = await typed_original_create(response_model, *args, **kwargs)
+            return response_model_instance
+        
+        # Return the wrapper coroutine function
+        return wrapper
+    
+    # Return the wrapped `create` function
+    return create_wrapper(original_create)
+
+
+
+
+
+def patched_create(response_model: Type[M], mode: Mode = Mode.FUNCTIONS, **client_kwargs: Any):
+    """
+    Creates a patched version of the `openai_client.chat.completion.create` method.
+
+    This function takes a `response_model` class and additional `client_kwargs`, and returns
+    a new `create` function that automatically includes the `response_model` as the first
+    argument when called. This allows the caller to use the `create` function without
+    specifying the `response_model` each time.
+
+    Args:
+        response_model: The model class that the API response should be deserialized into.
+        mode (instructor.Mode): The mode to use for the patched client.
+        **client_kwargs: Additional keyword arguments to be passed to the `AsyncClient`.
+
+    Returns:
+        A coroutine function that, when awaited, sends a request to the OpenAI API and
+        returns an instance of the `response_model` via `instructor`.
+    """
+    # Initialize the OpenAI async client with the provided keyword arguments
+    _client = openai.AsyncClient(**client_kwargs)
+    
+    # Patch the client using `instructor.patch`
+    client: AsyncOpenAI = instructor.patch(client=_client, mode=mode)
+    
+    # Get the original `create` method from the patched client
+    original_create = client.chat.completions.create
+    
+    # Define a wrapper function that will prepend the `response_model` to the arguments
+    def create_wrapper(original_create: Callable[P, Coroutine[Any, Any, T]]) -> Callable[P, Coroutine[Any, Any, M]]:
+        # Cast the original function to accept the `response_model` as the first argument
+        typed_original_create = cast(Callable[Concatenate[Type[M], P], Coroutine[Any, Any, M]], original_create)
+
+        # Create a partial function that includes the `response_model` as the first argument
+        partial_create = functools.partial(typed_original_create, response_model)
+
+        # Cast the partial function back to the expected type
+        typed_partial_create = cast(Callable[P, Coroutine[Any, Any, T]], partial_create)
+        
+        # Define the actual wrapper coroutine that will be called by the user
+        async def wrapper(*args: P.args, **kwargs: P.kwargs) -> M:
+            # Cast the partial function to return the `response_model`
+            typed_partial_create_response = cast(Callable[P, Coroutine[Any, Any, M]], typed_partial_create)
+
+            # Await the partial function with the provided arguments and return the result
+            response_model_instance = await typed_partial_create_response(*args, **kwargs)
+            return response_model_instance
+        
+        # Return the wrapper coroutine function
+        return wrapper
+    
+    # Return the wrapped `create` function
+    return create_wrapper(original_create)
+

--- a/examples/create-wrapper/readme.md
+++ b/examples/create-wrapper/readme.md
@@ -1,0 +1,57 @@
+# Chat Completion Wrapper
+
+## Overview
+
+A generic method to create a wrapped reusable `chat.completion.create` function. It could very well be more interesting than useful but it's functional and doesn't break types in 3.10.
+
+## Dependencies
+
+- python >= 3.10.13 # lowest tested
+- openai
+- Pydantic
+
+## Usage
+
+```python
+import openai
+from typing import Any, Coroutine, Callable, TypeVar, ParamSpec, Concatenate, Type
+
+T = TypeVar('T')
+M = TypeVar('M')
+P = ParamSpec('P')
+
+def patched_create(**kwargs: Any):
+    _client = openai.AsyncClient(**kwargs)
+    client: AsyncOpenAI = instructor.patch(_client)
+    func = client.chat.completions.create
+    def async_create_wrapper(func: Callable[P, Coroutine[Any, Any, T]]) -> Callable[Concatenate[Type[M], P], Coroutine[Any, Any, M]]:
+        async def wrapper(val: Type[M] | None = None, *args: P.args, **kwargs: P.kwargs) -> M:
+            if response_model := kwargs.pop("response_model", val):
+                val = cast(Type[M], response_model)
+            return await cast(Callable[Concatenate[Type[M] | None, P], Coroutine[Any, Any, M]], func)(val, *args, **kwargs)
+        return wrapper
+    return async_create_wrapper(func)
+
+class Staff(BaseModel):
+    """Correctly determine employee information."""
+    name: str = Field(..., description="Name of the staff member.")
+
+create = patched_create()
+staff = await create(
+    Staff,
+    messages=[{"role": "user", "content": ...}],
+    model="gpt-3.5-turbo-1106",
+)
+
+assert isinstance(staff, Staff)
+
+```
+
+## Examples
+
+- ***./run.py*** - standard multi-model typed async example via `asyncio.run`
+- ***./gather.py*** - multi-model typed concurrent async example using [structural pattern matching](https://jxnl.github.io/instructor/concepts/models/#structural-pattern-matching) via `asyncio.gather`
+- ***./as_completed.py*** - multi-model typed concurrent async example using [structural pattern matching](https://jxnl.github.io/instructor/concepts/models/#structural-pattern-matching) via `asyncio.as_completed`.
+
+
+> Continuation idea: cast `Awaitable` return object compatible with `coroutine` parameters accepted by `asyncio.create_task`.

--- a/examples/create-wrapper/run.py
+++ b/examples/create-wrapper/run.py
@@ -1,0 +1,118 @@
+import asyncio
+import openai
+import instructor
+import datetime
+
+from pydantic import BaseModel, Field
+from typing import Any, Coroutine, Callable, TypeVar, ParamSpec, Concatenate, Type, cast
+
+from openai import AsyncOpenAI
+
+models="gpt-4-0125-preview", "gpt-3.5-turbo-1106"
+model = models[0]
+
+T = TypeVar('T')
+M = TypeVar('M')
+P = ParamSpec('P')
+
+def patched_create(**kwargs: Any):
+    _client = openai.AsyncClient(**kwargs)
+    client: AsyncOpenAI = instructor.patch(_client)
+    func = client.chat.completions.create
+    def async_create_wrapper(func: Callable[P, Coroutine[Any, Any, T]]) -> Callable[Concatenate[Type[M], P], Coroutine[Any, Any, M]]:
+        async def wrapper(val: Type[M] | None = None, *args: P.args, **kwargs: P.kwargs) -> M:
+            if response_model := kwargs.pop("response_model", val):
+                val = cast(Type[M], response_model)
+            return await cast(Callable[Concatenate[Type[M] | None, P], Coroutine[Any, Any, M]], func)(val, *args, **kwargs)
+        return wrapper
+    return async_create_wrapper(func)
+
+
+class Staff(BaseModel):
+    """Correctly determine employee information."""
+    chain_of_thought: str = Field(..., description="Step by step reasoning to get the correct time range")
+    name: str = Field(..., description="Name of the staff member.")
+    position: str | None = Field(None, description="Position of the staff member.")
+    start_date: datetime.date | None = Field(None, description="Start date for the staff member.")
+
+class Recruits(BaseModel):
+    """Correctly determine newly recruited staff details."""
+    staff: list[Staff] = Field(..., description="List of new staff recruits.")
+
+system_message_text=f"Date: {datetime.date.today().isoformat()}\nPerform accurate extractions."
+system_message = {"role": "system", "content": system_message_text}
+query1="We just hired Felicity Quill, she starts on Monday."
+message1 = {"role": "user", "content": query1}
+query2="Archibald Fiddlesticks begins in 2 weeks from Monday."
+message2 = {"role": "user", "content": query2}
+
+
+async def main():
+    create = patched_create()
+    staff1 = await create(
+        Staff,
+        messages=[
+            {"role": "system", "content": system_message_text},
+            {"role": "user", "content": query1},
+        ],
+        model=model,
+    )
+    staff2 = await create(
+        Staff,
+        messages=[
+            {"role": "system", "content": system_message_text},
+            {"role": "user", "content": query1},
+        ],
+        model=model,
+    )
+    recruits = await create(
+        Recruits,
+        messages=[
+            {"role": "system", "content": system_message_text},
+            {"role": "user", "content": query1},
+        ],
+        model=model,
+    )
+    assert isinstance(staff1, Staff)
+    print(staff1.model_dump_json())
+    assert isinstance(staff2, Staff)
+    print(staff2.model_dump_json())
+    assert isinstance(recruits, Recruits)
+    print(recruits.model_dump_json())
+
+if __name__ == "__main__":
+    asyncio.run(main())
+
+_="""
+[
+    {
+        "chain_of_thought": "To determine Felicity's start date, we must identify the current date and then find the upcoming Monday. The current date is 2024-02-04, and the upcoming Monday from this date is 2024-02-05, which is the start date for Felicity Quill.",
+        "name": "Felicity Quill",
+        "position": null,
+        "start_date": "2024-02-05"
+    },
+    {
+        "chain_of_thought": "To find the start date for Archibald Fiddlesticks, we first identify today's date, which is February 4, 2024. Knowing that the context is set from a Monday, we calculate two weeks from the next Monday following today. The next Monday from February 4 is February 5. Two weeks from February 5 is February 19, 2024, which marks the start date for Archibald Fiddlesticks.",
+        "name": "Archibald Fiddlesticks",
+        "position": null,
+        "start_date": "2024-02-19"
+    },
+    {
+        "staff": [
+            {
+                "chain_of_thought": "Today is Saturday, February 3, 2024. Monday refers to February 5, 2024, which is the start date for Felicity Quill.",
+                "name": "Felicity Quill",
+                "position": null,
+                "start_date": "2024-02-05"
+            },
+            {
+                "chain_of_thought": "Today is Saturday, February 3, 2024. Two weeks from Monday refers to the Monday after next, which is February 19, 2024, the start date for Archibald Fiddlesticks.",
+                "name": "Archibald Fiddlesticks",
+                "position": null,
+                "start_date": "2024-02-19"
+            }
+        ]
+    }
+]
+"""
+

--- a/examples/create-wrapper/test_patched_create.py
+++ b/examples/create-wrapper/test_patched_create.py
@@ -1,0 +1,87 @@
+import asyncio
+import pytest_asyncio
+import pytest
+from itertools import product
+from pydantic import BaseModel
+from instructor.function_calls import Mode
+from tests.openai.util import models, modes
+
+from patched_create import patched_create, patched_create_delay_response_model
+
+
+class UserDetails(BaseModel):
+    name: str
+    age: int
+
+
+# Lists for models, test data, and modes
+test_data = [
+    ("Jason is 10", "Jason", 10),
+    ("Alice is 25", "Alice", 25),
+    ("Bob is 35", "Bob", 35),
+]
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("model, data, mode", product(models, test_data, modes))
+async def test_user_details(model, data, mode):
+    sample_data, expected_name, expected_age = data
+
+    if (mode, model) in {
+        (Mode.JSON, "gpt-3.5-turbo"),
+        (Mode.JSON, "gpt-4"),
+    }:
+        pytest.skip(f"{mode} mode is not supported for {model}, skipping test")
+    
+    # Setting up the client with the instructor patch
+    # and patching the create function
+    create = patched_create(UserDetails, mode=mode)
+
+    # Calling the extract function with the provided model, sample data, and mode
+    response = await create(
+        model=model,
+        messages=[
+            {"role": "user", "content": sample_data},
+        ],
+    )
+    
+    # Now you can assert that the parsed details match the expected values
+    # Assertions
+    assert (
+        response.name == expected_name
+    ), f"Expected name {expected_name}, got {response.name}"
+    assert (
+        response.age == expected_age
+    ), f"Expected age {expected_age}, got {response.age}"
+
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("model, data, mode", product(models, test_data, modes))
+async def test_patched_create_delay_response_model(model, data, mode):
+    sample_data, expected_name, expected_age = data
+
+    if (mode, model) in {
+        (Mode.JSON, "gpt-3.5-turbo"),
+        (Mode.JSON, "gpt-4"),
+    }:
+        pytest.skip(f"{mode} mode is not supported for {model}, skipping test")
+
+    # Setting up the client with the instructor patch
+    create = patched_create_delay_response_model(mode=mode)
+
+    # Calling the extract function with the provided model, sample data, and mode
+    response = await create(
+        UserDetails,
+        model=model,
+        messages=[
+            {"role": "user", "content": sample_data},
+        ],
+    )
+
+    # Assertions
+    assert (
+        response.name == expected_name
+    ), f"Expected name {expected_name}, got {response.name}"
+    assert (
+        response.age == expected_age
+    ), f"Expected age {expected_age}, got {response.age}"


### PR DESCRIPTION
## Describe your changes
This pull request adds a create-wrapper example with async demo scripts. The create-wrapper function is a generic method that creates a wrapped reusable `chat.completion.create` function. It includes usage examples and dependencies.

## Issue ticket number and link
n/a

## Checklist before requesting a review

- [ x ] I have performed a self-review of my code
- [ - ] If it is a core feature, I have added thorough tests.
- [ - ] If it is a core feature, I have added documentation.


<!--
ELLIPSIS_HIDDEN
-->


----

| <a href="https://ellipsis.dev" target="_blank"><img src="https://avatars.githubusercontent.com/u/80834858?s=400&u=31e596315b0d8f7465b3ee670f25cea677299c96&v=4" alt="Ellipsis" width="30px" height="30px"/></a> | :rocket: This PR description was created by [Ellipsis](https://www.ellipsis.dev) for commit bb2b196a1e97b5c483bcb964c45acda442797d26.  | 
|--------|--------|

### Summary:
This PR introduces a generic method for creating a reusable `chat.completion.create` function and provides examples demonstrating its usage with different asyncio methods and structural pattern matching.

**Key points**:
- Added a generic method to create a wrapped reusable `chat.completion.create` function in `examples/create-wrapper`.
- Included three examples (`run.py`, `gather.py`, `as_completed.py`) demonstrating the usage of the new function with different asyncio methods and structural pattern matching.
----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)


<!--
ELLIPSIS_HIDDEN
-->
