### PR TITLE
fix(docs/examples): increase max_retries in chat.completions.create function

### DIFF
--- a/docs/examples/self_critique.md
+++ b/docs/examples/self_critique.md
@@ -104,7 +104,7 @@ By adding the `max_retries` parameter, we can retry the request with corrections
 qa: QuestionAnswerNoEvil = client.chat.completions.create(
     model="gpt-3.5-turbo",
     response_model=QuestionAnswerNoEvil,
-    max_retries=1,
+    max_retries=2,
     messages=[
         {
             "role": "system",


### PR DESCRIPTION


<!--
ELLIPSIS_HIDDEN
-->




| <a href="https://ellipsis.dev" target="_blank"><img src="https://avatars.githubusercontent.com/u/80834858?s=400&u=31e596315b0d8f7465b3ee670f25cea677299c96&v=4" alt="Ellipsis" width="30px" height="30px"/></a> | :rocket: This PR description was created by [Ellipsis](https://www.ellipsis.dev) for commit 10c92b71c10993fbbe81109b08dbe4ba17106511.  | 
|--------|--------|

### Summary:
This PR increases the `max_retries` parameter in the `client.chat.completions.create` function call from `1` to `2` in the `/docs/examples/self_critique.md` file.

**Key points**:
- Updated `max_retries` parameter from `1` to `2` in `client.chat.completions.create` function call in `/docs/examples/self_critique.md`.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)


<!--
ELLIPSIS_HIDDEN
-->
