### PR TITLE
fix(validation): increase max_retries from 1 to 2

### DIFF
--- a/docs/examples/self_critique.md
+++ b/docs/examples/self_critique.md
@@ -104,7 +104,7 @@ By adding the `max_retries` parameter, we can retry the request with corrections
 qa: QuestionAnswerNoEvil = client.chat.completions.create(
     model="gpt-3.5-turbo",
     response_model=QuestionAnswerNoEvil,
-    max_retries=1,
+    max_retries=2,
     messages=[
         {
             "role": "system",

--- a/examples/validators/competitors.py
+++ b/examples/validators/competitors.py
@@ -27,7 +27,7 @@ try:
     resp = client.chat.completions.create(
         model="gpt-3.5-turbo",
         response_model=Response,
-        max_retries=1,
+        max_retries=2,
         messages=[
             {
                 "role": "user",

--- a/examples/validators/llm_validator.py
+++ b/examples/validators/llm_validator.py
@@ -94,7 +94,7 @@ except Exception as e:
 qa: QuestionAnswerNoEvil = client.chat.completions.create(
     model="gpt-3.5-turbo",
     response_model=QuestionAnswerNoEvil,
-    max_retries=1,
+    max_retries=2,
     messages=[
         {
             "role": "system",
@@ -107,10 +107,10 @@ qa: QuestionAnswerNoEvil = client.chat.completions.create(
     ],
 )  # type: ignore
 
-print("After validation with `llm_validator` with `max_retries=1`")
+print("After validation with `llm_validator` with `max_retries=2`")
 print(qa.model_dump_json(indent=2), end="\n\n")
 """
-After validation with `llm_validator` with `max_retries=1`
+After validation with `llm_validator` with `max_retries=2`
 {
   "question": "What is the meaning of life?",
   "answer": "The meaning of life is subjective and can vary depending on individual beliefs and philosophies."

--- a/examples/validators/readme.md
+++ b/examples/validators/readme.md
@@ -116,13 +116,13 @@ except Exception as e:
 
 ### Retrying Validation
 
-Allow for retries by setting `max_retries=1`.
+Allow for retries by setting `max_retries=2`.
 
 ```python
 qa: QuestionAnswerNoEvil = openai.ChatCompletion.create(
     model="gpt-3.5-turbo",
     response_model=QuestionAnswerNoEvil,
-    max_retries=1,
+    max_retries=2,
     messages=[
         {
             "role": "system",
@@ -138,7 +138,7 @@ qa: QuestionAnswerNoEvil = openai.ChatCompletion.create(
 
 #### Output
 
-After validation with `llm_validator` and `max_retries=1`:
+After validation with `llm_validator` and `max_retries=2`:
 
 ```json
 {


### PR DESCRIPTION


<!--
ELLIPSIS_HIDDEN
-->




| <a href="https://ellipsis.dev" target="_blank"><img src="https://avatars.githubusercontent.com/u/80834858?s=400&u=31e596315b0d8f7465b3ee670f25cea677299c96&v=4" alt="Ellipsis" width="30px" height="30px"/></a> | :rocket: This PR description was created by [Ellipsis](https://www.ellipsis.dev) for commit 4d2f22a1044c43d5570f88ca6d742ab56a8dd8ed.  | 
|--------|--------|

### Summary:
This PR increases the `max_retries` parameter from 1 to 2 in several files, affecting the retry logic in response to validation errors.

**Key points**:
- Updated `max_retries` from 1 to 2 in `/docs/examples/self_critique.md`, `/examples/validators/competitors.py`, `/examples/validators/llm_validator.py`, and `/examples/validators/readme.md`.
- This change affects the retry logic in response to validation errors.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)


<!--
ELLIPSIS_HIDDEN
-->
