### PR TITLE
fix: json modes - don't add json schema again in system message

### DIFF
--- a/instructor/patch.py
+++ b/instructor/patch.py
@@ -159,9 +159,8 @@ def handle_response_model(
                         "content": message,
                     },
                 )
-
-            # if the first message is a system append the schema to the end
-            if new_kwargs["messages"][0]["role"] == "system":
+            # if it is, system append the schema to the end
+            else:
                 new_kwargs["messages"][0]["content"] += f"\n\n{message}"
         else:
             raise ValueError(f"Invalid patch mode: {mode}")


### PR DESCRIPTION
Using any of the JSON modes, the final action in `handle_response_model` adds the schema to the system message.

This PR fixes fixes a missing `else` in the logic for checking the existence of the system message. If there's no system message the code currently adds the schema twice: first by creating a system message, then checking if a system message exists and if so appending the schema.

Just needs the `else`