### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,10 +19,10 @@ Instructor is not limited to the OpenAI API, we have support for many other back
 
 Including but not limited to:
 
-- [Together](./blog/posts/together.md)
-- [Ollama](./blog/posts/ollama.md)
-- [AnyScale](./blog/posts/anyscale.md)
-- [llama-cpp-python](./blog/posts/llama-cpp-python.md)
+- [Together](./docs/hub/together.md)
+- [Ollama](./docs/hub/ollama.md)
+- [AnyScale](./docs/hub/anyscale.md)
+- [llama-cpp-python](./docs/hub/llama-cpp-python.md)
 
 ## Get Started in Moments
 


### PR DESCRIPTION
fix broken 'Including but not limited to' links

<!--
ELLIPSIS_HIDDEN
-->


----

| <a href="https://ellipsis.dev" target="_blank"><img src="https://avatars.githubusercontent.com/u/80834858?s=400&u=31e596315b0d8f7465b3ee670f25cea677299c96&v=4" alt="Ellipsis" width="30px" height="30px"/></a> | :rocket: This PR description was created by [Ellipsis](https://www.ellipsis.dev) for commit ad55f307e1fa91fc17ac432ec9eda869cb6a2567.  | 
|--------|--------|

### Summary:
This PR fixes broken links in the `README.md` file by updating the paths from `./blog/posts/` to `./docs/hub/`.

**Key points**:
- Updated broken links in `README.md`.
- Links initially pointed to `./blog/posts/`.
- Links now correctly point to `./docs/hub/`.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)



<!--
ELLIPSIS_HIDDEN
-->
