### PR TITLE
fix: dedent json system prompt

### DIFF
--- a/instructor/patch.py
+++ b/instructor/patch.py
@@ -1,6 +1,7 @@
 import inspect
 import json
 import logging
+from textwrap import dedent
 from collections.abc import Iterable
 from functools import wraps
 from tenacity import Retrying, AsyncRetrying, stop_after_attempt, RetryError
@@ -130,11 +131,11 @@ def handle_response_model(
         elif mode in {Mode.JSON, Mode.MD_JSON, Mode.JSON_SCHEMA}:
             # If its a JSON Mode we need to massage the prompt a bit
             # in order to get the response we want in a json format
-            message = f"""
+            message = dedent(f"""
                 As a genius expert, your task is to understand the content and provide
                 the parsed objects in json that match the following json_schema:\n
                 {response_model.model_json_schema()['properties']}
-                """
+                """)
             # Check for nested models
             if "$defs" in response_model.model_json_schema():
                 message += f"\nHere are some more definitions to adhere too:\n{response_model.model_json_schema()['$defs']}"


### PR DESCRIPTION
Removes unnecessary extra whitespace before each line, cutting down on tokens (4 less lol) and possibly improving performance.  

Hard to tell these days if indent whitespace messes with OpenAI's models, but with smaller open models it does impact performance.

<!--
ELLIPSIS_HIDDEN
-->


----

| <a href="https://ellipsis.dev" target="_blank"><img src="https://avatars.githubusercontent.com/u/80834858?s=400&u=31e596315b0d8f7465b3ee670f25cea677299c96&v=4" alt="Ellipsis" width="30px" height="30px"/></a> | :rocket: This PR description was created by [Ellipsis](https://www.ellipsis.dev) for commit f49c9b6ccda49f993831103e8f5f6c5468803f45.  | 
|--------|--------|

### Summary:
The pull request optimizes the `handle_response_model` function in `instructor/patch.py` by using `dedent` to remove unnecessary leading whitespaces from a multi-line string.

**Key points**:
- Imported `dedent` from `textwrap` module in `instructor/patch.py`.
- Applied `dedent` to a multi-line string in the `handle_response_model` function to remove leading whitespaces.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)



<!--
ELLIPSIS_HIDDEN
-->
