### PR TITLE
fix: examples/citation_with_extraction/citation_fuzzy_match.py is out of sync with the website

### DIFF
--- a/examples/citation_with_extraction/citation_fuzzy_match.py
+++ b/examples/citation_with_extraction/citation_fuzzy_match.py
@@ -82,29 +82,19 @@ class QuestionAnswer(instructor.OpenAISchema):
 
 
 def ask_ai(question: str, context: str) -> QuestionAnswer:
-    completion = client.chat.completions.create(
+    return client.chat.completions.create(
         model="gpt-3.5-turbo-0613",
         temperature=0,
-        functions=[QuestionAnswer.openai_schema],
-        function_call={"name": QuestionAnswer.openai_schema["name"]},
+        response_model=QuestionAnswer,
         messages=[
             {
                 "role": "system",
-                "content": "You are a world class algorithm to answer questions with correct and exact citations. ",
+                "content": "You are a world class algorithm to answer questions with correct and exact citations.",
             },
-            {"role": "user", "content": "Answer question using the following context"},
             {"role": "user", "content": f"{context}"},
             {"role": "user", "content": f"Question: {question}"},
-            {
-                "role": "user",
-                "content": "Tips: Make sure to cite your sources, and use the exact words from the context.",
-            },
         ],
-    )
-
-    # Creating an Answer object from the completion response
-    return QuestionAnswer.from_response(
-        completion, validation_context={"text_chunk": context}
+        validation_context={"text_chunk": context},
     )
 
 


### PR DESCRIPTION
Specifically, the ask_ai() function is obsolete. This PR syncs it with the website.

<!--
ELLIPSIS_HIDDEN
-->


----

| <a href="https://ellipsis.dev" target="_blank"><img src="https://avatars.githubusercontent.com/u/80834858?s=400&u=31e596315b0d8f7465b3ee670f25cea677299c96&v=4" alt="Ellipsis" width="30px" height="30px"/></a> | :rocket: This PR description was created by [Ellipsis](https://www.ellipsis.dev) for commit 5ca840c329b70332e008f941fefdd3fd33a6c671.  | 
|--------|--------|

### Summary:
This PR simplifies the `ask_ai` function in `examples/citation_with_extraction/citation_fuzzy_match.py` and updates the messages passed to `client.chat.completions.create`.

**Key points**:
- Updated `ask_ai` function in `examples/citation_with_extraction/citation_fuzzy_match.py`.
- Removed unnecessary lines and simplified the function call to `client.chat.completions.create`.
- Set the response model to `QuestionAnswer`.
- Updated the messages passed to the function.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)



<!--
ELLIPSIS_HIDDEN
-->
