### PR TITLE
References to PHP port added to docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -160,7 +160,8 @@ cython_debug/
 #  be found at https://github.com/github/gitignore/blob/main/Global/JetBrains.gitignore
 #  and can be added to the global gitignore or merged into this file.  For a more nuclear
 #  option (not recommended) you can uncomment the following to ignore the entire idea folder.
-#.idea/
+.idea/
+
 examples/citation_with_extraction/fly.toml
 my_cache_directory/
 tutorials/wandb/*

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ _Structured outputs powered by llms. Designed for simplicity, transparency, and 
 
 Instructor stands out for its simplicity, transparency, and user-centric design. We leverage Pydantic to do the heavy lifting, and we've built a simple, easy-to-use API on top of it by helping you manage [validation context](./docs/concepts/reask_validation.md), retries with [Tenacity](./docs/concepts/retrying.md), and streaming [Lists](./docs/concepts/lists.md) and [Partial](./docs/concepts/partial.md) responses.
 
-Check us out in [Typescript](https://instructor-ai.github.io/instructor-js/) and [Elixir](https://github.com/thmsmlr/instructor_ex/).
+Check us out in [Typescript](https://instructor-ai.github.io/instructor-js/), [Elixir](https://github.com/thmsmlr/instructor_ex/) and [PHP](https://github.com/cognesy/instructor-php/).
 
 Instructor is not limited to the OpenAI API, we have support for many other backends that via patching. Check out more on [patching](./docs/concepts/patching.md).
 

--- a/docs/hub/together.md
+++ b/docs/hub/together.md
@@ -24,7 +24,7 @@ By the end of this blog post, you will learn how to effectively utilize instruct
 !!! note "Other Languages"
 
     This blog post is written in Python, but the concepts are applicable to other languages as well, as we currently have support for [Javascript](
-        https://instructor-ai.github.io/instructor-js) and [Elixir](https://hexdocs.pm/instructor/Instructor.html)
+        https://instructor-ai.github.io/instructor-js), [Elixir](https://hexdocs.pm/instructor/Instructor.html) and [PHP](https://github.com/cognesy/instructor-php/).
 
 <!-- more -->
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -12,7 +12,7 @@ Instructor makes it easy to reliably get structured data like JSON from Large La
 
 By leveraging various modes like Function Calling, Tool Calling and even constrained sampling modes like JSON mode, JSON Schema; Instructor stands out for its simplicity, transparency, and user-centric design. We leverage Pydantic to do the heavy lifting, and we've built a simple, easy-to-use API on top of it by helping you manage [validation context](./concepts/reask_validation.md), retries with [Tenacity](./concepts/retrying.md), and streaming [Lists](./concepts/lists.md) and [Partial](./concepts/partial.md) responses.
 
-We also provide library in [Typescript](https://instructor-ai.github.io/instructor-js/) and [Elixir](https://github.com/thmsmlr/instructor_ex/).
+We also provide library in [Typescript](https://instructor-ai.github.io/instructor-js/), [Elixir](https://github.com/thmsmlr/instructor_ex/) and [PHP](https://github.com/cognesy/instructor-php/).
 
 ## Usage
 


### PR DESCRIPTION


<!--
ELLIPSIS_HIDDEN
-->




| <a href="https://ellipsis.dev" target="_blank"><img src="https://avatars.githubusercontent.com/u/80834858?s=400&u=31e596315b0d8f7465b3ee670f25cea677299c96&v=4" alt="Ellipsis" width="30px" height="30px"/></a> | :rocket: This PR description was created by [Ellipsis](https://www.ellipsis.dev) for commit 8758d2ea5485bc81038cc3b3bcd0494576645a5c.  | 
|--------|--------|

### Summary:
This PR adds references to the PHP port of the Instructor library in the project's documentation.

**Key points**:
- Added PHP port reference in `/README.md`
- Included PHP port link in `/docs/hub/together.md`
- Inserted PHP port reference in `/docs/index.md`


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)



<!--
ELLIPSIS_HIDDEN
-->
