### PR TITLE
fix: account for multiple times wrapped functions

### DIFF
--- a/instructor/patch.py
+++ b/instructor/patch.py
@@ -467,9 +467,11 @@ def retry_sync(
 
 def is_async(func: Callable) -> bool:
     """Returns true if the callable is async, accounting for wrapped callables"""
-    return inspect.iscoroutinefunction(func) or (
-        hasattr(func, "__wrapped__") and inspect.iscoroutinefunction(func.__wrapped__)
-    )
+    is_coroutine = inspect.iscoroutinefunction(func)
+    while hasattr(func, "__wrapped__"):
+        func = func.__wrapped__
+        is_coroutine = is_coroutine or inspect.iscoroutinefunction(func)
+    return is_coroutine
 
 
 OVERRIDE_DOCS = """

--- a/tests/test_patch.py
+++ b/tests/test_patch.py
@@ -39,6 +39,69 @@ def test_is_async_returns_true_if_wrapped_function_is_async():
     assert is_async(wrapped_function) is True
 
 
+def test_is_async_returns_true_if_double_wrapped_function_is_async():
+    async def async_function():
+        pass
+
+    @functools.wraps(async_function)
+    def wrapped_function():
+        pass
+
+    assert is_async(wrapped_function) is True
+
+
+def test_is_async_returns_true_if_double_wrapped_function_is_async():
+    async def async_function():
+        pass
+
+    # First level of wrapping
+    @functools.wraps(async_function)
+    def wrapped_function():
+        pass
+
+    # Second level of wrapping
+    @functools.wraps(wrapped_function)
+    def double_wrapped_function():
+        pass
+
+    assert is_async(double_wrapped_function) is True
+
+
+def test_is_async_returns_true_if_double_wrapped_function_is_async():
+    async def async_function():
+        pass
+
+    @functools.wraps(async_function)
+    def wrapped_function():
+        pass
+
+    @functools.wraps(wrapped_function)
+    def double_wrapped_function():
+        pass
+
+    assert is_async(double_wrapped_function) is True
+
+
+def test_is_async_returns_true_if_triple_wrapped_function_is_async():
+    async def async_function():
+        pass
+
+    @functools.wraps(async_function)
+    def wrapped_function():
+        pass
+
+    @functools.wraps(wrapped_function)
+    def double_wrapped_function():
+        pass
+
+
+    @functools.wraps(double_wrapped_function)
+    def triple_wrapped_function():
+        pass
+
+    assert is_async(triple_wrapped_function) is True
+
+
 def test_override_docs():
     assert (
         "response_model" in OVERRIDE_DOCS

--- a/tests/test_patch.py
+++ b/tests/test_patch.py
@@ -47,17 +47,6 @@ def test_is_async_returns_true_if_double_wrapped_function_is_async():
     def wrapped_function():
         pass
 
-    assert is_async(wrapped_function) is True
-
-
-def test_is_async_returns_true_if_double_wrapped_function_is_async():
-    async def async_function():
-        pass
-
-    @functools.wraps(async_function)
-    def wrapped_function():
-        pass
-
     @functools.wraps(wrapped_function)
     def double_wrapped_function():
         pass

--- a/tests/test_patch.py
+++ b/tests/test_patch.py
@@ -54,23 +54,6 @@ def test_is_async_returns_true_if_double_wrapped_function_is_async():
     async def async_function():
         pass
 
-    # First level of wrapping
-    @functools.wraps(async_function)
-    def wrapped_function():
-        pass
-
-    # Second level of wrapping
-    @functools.wraps(wrapped_function)
-    def double_wrapped_function():
-        pass
-
-    assert is_async(double_wrapped_function) is True
-
-
-def test_is_async_returns_true_if_double_wrapped_function_is_async():
-    async def async_function():
-        pass
-
     @functools.wraps(async_function)
     def wrapped_function():
         pass
@@ -93,7 +76,6 @@ def test_is_async_returns_true_if_triple_wrapped_function_is_async():
     @functools.wraps(wrapped_function)
     def double_wrapped_function():
         pass
-
 
     @functools.wraps(double_wrapped_function)
     def triple_wrapped_function():


### PR DESCRIPTION
This PR checks if any wrapped-level of the `client.chat.completions.create` is async. Note, that `AsyncClient().chat.completions.create` is already wrapped when using it directly from OpenAI.

<!--
ELLIPSIS_HIDDEN
-->


----

| <a href="https://ellipsis.dev" target="_blank"><img src="https://avatars.githubusercontent.com/u/80834858?s=400&u=31e596315b0d8f7465b3ee670f25cea677299c96&v=4" alt="Ellipsis" width="30px" height="30px"/></a> | :rocket: This PR description was created by [Ellipsis](https://www.ellipsis.dev) for commit 1dd6da2b29df0f6834af924b9eb9bcada86e1608.  | 
|--------|--------|

### Summary:
This PR enhances the `is_async` function in `instructor/patch.py` to correctly identify asynchronous functions even when they are wrapped multiple times.

**Key points**:
- Modified the `is_async` function in `instructor/patch.py` to account for multiple levels of wrapped functions.
- The function now iteratively checks each level of wrapped functions to see if any are asynchronous.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)



<!--
ELLIPSIS_HIDDEN
-->
