### PR TITLE
fix: updated deprecated pydantic import

### DIFF
--- a/docs/examples/exact_citations.md
+++ b/docs/examples/exact_citations.md
@@ -20,7 +20,7 @@ The `Fact` class encapsulates a single statement or fact. It contains two fields
 This method validates the sources (`substring_quote`) in the context. It utilizes regex to find the span of each substring quote in the given context. If the span is not found, the quote is removed from the list.
 
 ```python hl_lines="6 8-13"
-from pydantic import Field, BaseModel, model_validator, FieldValidationInfo
+from pydantic import Field, BaseModel, model_validator, ValidationInfo
 from typing import List
 
 
@@ -29,7 +29,7 @@ class Fact(BaseModel):
     substring_quote: List[str] = Field(...)
 
     @model_validator(mode="after")
-    def validate_sources(self, info: FieldValidationInfo) -> "Fact":
+    def validate_sources(self, info: ValidationInfo) -> "Fact":
         text_chunks = info.context.get("text_chunk", None)
         spans = list(self.get_spans(text_chunks))
         self.substring_quote = [text_chunks[span[0] : span[1]] for span in spans]


### PR DESCRIPTION
Update import statement and parameter name in validate_sources example method.

This was the only instance of a [`pydantic_core` v2.10.0](https://github.com/pydantic/pydantic-core/releases/tag/v2.10.0)   [deprecated import change](https://github.com/pydantic/pydantic-core/pull/980/files#diff-11106d7a94c9e5ff8c1ed553e1d62fe6fa4eeed912297235be1dc098e2550187) found in the repo.