### PR TITLE
Migrate docs posthog to proxy

### DIFF
--- a/docs/overrides/main.html
+++ b/docs/overrides/main.html
@@ -1,7 +1,7 @@
 {% extends "base.html" %} {% block announce %}
 <script>
     !function(t,e){var o,n,p,r;e.__SV||(window.posthog=e,e._i=[],e.init=function(i,s,a){function g(t,e){var o=e.split(".");2==o.length&&(t=t[o[0]],e=o[1]),t[e]=function(){t.push([e].concat(Array.prototype.slice.call(arguments,0)))}}(p=t.createElement("script")).type="text/javascript",p.async=!0,p.src=s.api_host+"/static/array.js",(r=t.getElementsByTagName("script")[0]).parentNode.insertBefore(p,r);var u=e;for(void 0!==a?u=e[a]=[]:a="posthog",u.people=u.people||[],u.toString=function(t){var e="posthog";return"posthog"!==a&&(e+="."+a),t||(e+=" (stub)"),e},u.people.toString=function(){return u.toString(1)+".people (stub)"},o="capture identify alias people.set people.set_once set_config register register_once unregister opt_out_capturing has_opted_out_capturing opt_in_capturing reset isFeatureEnabled onFeatureFlags getFeatureFlag getFeatureFlagPayload reloadFeatureFlags group updateEarlyAccessFeatureEnrollment getEarlyAccessFeatures getActiveMatchingSurveys getSurveys onSessionId".split(" "),n=0;n<o.length;n++)g(u,o[n]);e._i.push([i,s,a])},e.__SV=1)}(document,window.posthog||[]);
-    posthog.init('phc_bAUjZfg1PI0Ca2IOQCM053Y5873PRZhJ0DvTDbGsN9A',{api_host:'https://app.posthog.com'})
+    posthog.init('phc_bAUjZfg1PI0Ca2IOQCM053Y5873PRZhJ0DvTDbGsN9A',{api_host:'https://p.useinstructor.com'})
 </script>
 
 For updates follow


### PR DESCRIPTION


<!--
ELLIPSIS_HIDDEN
-->




| <a href="https://ellipsis.dev" target="_blank"><img src="https://avatars.githubusercontent.com/u/80834858?s=400&u=31e596315b0d8f7465b3ee670f25cea677299c96&v=4" alt="Ellipsis" width="30px" height="30px"/></a> | :rocket: This PR description was created by [Ellipsis](https://www.ellipsis.dev) for commit 005eb8e7b7166d91e84e28ca976f59e8ec9153b6.  | 
|--------|--------|

### Summary:
This PR changes the `api_host` in the `posthog.init` function in `main.html` from 'https://app.posthog.com' to 'https://p.useinstructor.com', indicating a migration of the PostHog analytics service.

**Key points**:
- Modified `main.html` in `docs/overrides` directory
- Changed `api_host` in `posthog.init` from 'https://app.posthog.com' to 'https://p.useinstructor.com'


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)



<!--
ELLIPSIS_HIDDEN
-->
