### PR TITLE
fix: remove limit param from openai FileObject.list()

### DIFF
--- a/instructor/cli/files.py
+++ b/instructor/cli/files.py
@@ -1,13 +1,12 @@
-from typing import List
-from rich.table import Table
-from rich.console import Console
-
+import time
 from datetime import datetime
-from openai import OpenAI
+from typing import List
 
 import openai
 import typer
-import time
+from openai import OpenAI
+from rich.console import Console
+from rich.table import Table
 
 client = OpenAI()
 app = typer.Typer()
@@ -37,11 +36,11 @@ def generate_file_table(files: List[openai.types.FileObject]) -> Table:
     return table
 
 
-def get_files(limit: int = 5) -> List[openai.types.FileObject]:
-    files = client.files.list(limit=limit)
+def get_files() -> List[openai.types.FileObject]:
+    files = client.files.list()
     files = files.data
     files = sorted(files, key=lambda x: x.created_at, reverse=True)
-    return files[:limit]
+    return files
 
 
 def get_file_status(file_id: str) -> str:
@@ -115,8 +114,6 @@ def status(
 @app.command(
     help="List the files on OpenAI's servers",
 )  # type: ignore[misc]
-def list(
-    limit: int = typer.Option(5, help="Limit the number of files to list"),
-) -> None:
-    files = get_files(limit=limit)
+def list() -> None:
+    files = get_files()
     console.log(generate_file_table(files))


### PR DESCRIPTION
fixes #503 

<!--
ELLIPSIS_HIDDEN
-->


----

| <a href="https://ellipsis.dev" target="_blank"><img src="https://avatars.githubusercontent.com/u/80834858?s=400&u=31e596315b0d8f7465b3ee670f25cea677299c96&v=4" alt="Ellipsis" width="30px" height="30px"/></a> | :rocket: This PR description was created by [Ellipsis](https://www.ellipsis.dev) for commit 323ed9717e084b0f62a355c6fc65cdb4b908c9b6.  | 
|--------|--------|

### Summary:
This PR removes the `limit` parameter from the `get_files` function, affecting the `list` function in `instructor/cli/files.py`, to return and display all files.

**Key points**:
- Removed `limit` parameter from `get_files` function in `instructor/cli/files.py`.
- Updated `list` function to call `get_files` without `limit` parameter.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)



<!--
ELLIPSIS_HIDDEN
-->
