### PR TITLE
Errors in Search Docs: Missing Import + Wrong Variable Name

### DIFF
--- a/docs/examples/search.md
+++ b/docs/examples/search.md
@@ -30,7 +30,7 @@ class Search(BaseModel):
         )
 
 
-def segment(data: str) -> MultiSearch:
+def segment(data: str) -> Search:
     return client.chat.completions.create(
         model="gpt-3.5-turbo-0613",
         response_model=Iterable[Search],

--- a/docs/examples/search.md
+++ b/docs/examples/search.md
@@ -13,7 +13,7 @@ The `Search` class is a Pydantic model that defines the structure of the search 
 ```python
 import instructor
 from openai import OpenAI
-from typing import Iterable
+from typing import Iterable, Literal
 from pydantic import BaseModel, Field
 
 # Apply the patch to the OpenAI client


### PR DESCRIPTION
https://jxnl.github.io/instructor/examples/search/

the variable name was incorrect I believe.

<!--
ELLIPSIS_HIDDEN
-->


----

| <a href="https://ellipsis.dev" target="_blank"><img src="https://avatars.githubusercontent.com/u/80834858?s=400&u=31e596315b0d8f7465b3ee670f25cea677299c96&v=4" alt="Ellipsis" width="30px" height="30px"/></a> | :rocket: This PR description was created by [Ellipsis](https://www.ellipsis.dev) for commit 046ec452bf485e26b2b878a48945dee0cbce4c9e.  | 
|--------|--------|

### Summary:
This PR fixes a typo in the `search.md` documentation by correcting the return type of the `segment` function from `MultiSearch` to `Search`.

**Key points**:
- Corrected the return type of the `segment` function in `search.md` from `MultiSearch` to `Search`.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)



<!--
ELLIPSIS_HIDDEN
-->
