### PR TITLE
Avoid double-including error message in retry when Mode.TOOLS

### DIFF
--- a/instructor/retry.py
+++ b/instructor/retry.py
@@ -26,6 +26,7 @@ T = TypeVar("T")
 def reask_messages(response: ChatCompletion, mode: Mode, exception: Exception):
     yield dump_message(response.choices[0].message)
 
+    # TODO: Give users more control on configuration
     if mode == Mode.TOOLS:
         for tool_call in response.choices[0].message.tool_calls:  # type: ignore
             yield {
@@ -34,9 +35,7 @@ def reask_messages(response: ChatCompletion, mode: Mode, exception: Exception):
                 "name": tool_call.function.name,
                 "content": f"Validation Error found:\n{exception}\nRecall the function correctly, fix the errors",
             }
-
-    # TODO: Give users more control on configuration
-    if mode == Mode.MD_JSON:
+    elif mode == Mode.MD_JSON:
         yield {
             "role": "user",
             "content": f"Correct your JSON ONLY RESPONSE, based on the following errors:\n{exception}",


### PR DESCRIPTION
fixes jxnl/instructor#513

<!--
ELLIPSIS_HIDDEN
-->


----

| <a href="https://ellipsis.dev" target="_blank"><img src="https://avatars.githubusercontent.com/u/80834858?s=400&u=31e596315b0d8f7465b3ee670f25cea677299c96&v=4" alt="Ellipsis" width="30px" height="30px"/></a> | :rocket: This PR description was created by [Ellipsis](https://www.ellipsis.dev) for commit c88e1d5fd6eee0fff4af6602add604b6fe3c4ad3.  | 
|--------|--------|

### Summary:
This PR modifies the `reask_messages` function in `instructor/retry.py` to prevent double-inclusion of error messages when the mode is `Mode.TOOLS`.

**Key points**:
- Modified `reask_messages` function in `instructor/retry.py`.
- Changed if-else condition to avoid double-including error messages in `Mode.TOOLS`.
- Error message is now only included for the relevant mode.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)



<!--
ELLIPSIS_HIDDEN
-->
