### PR TITLE
fix: clean up imports for anthropic

### DIFF
--- a/instructor/anthropic_utils.py
+++ b/instructor/anthropic_utils.py
@@ -9,7 +9,7 @@ try:
     import xml.etree.ElementTree as ET
 except ImportError:
     import warnings
-    warnings.warn("xmltodict module not found. Please install it to proceed. `pip install xmltodict`", ImportWarning)
+warnings.warn("xmltodict and xml.etree.ElementTree modules not found. Please install them to proceed. `pip install xmltodict`", ImportWarning)
 
 
 T = TypeVar("T", bound=BaseModel)

--- a/instructor/anthropic_utils.py
+++ b/instructor/anthropic_utils.py
@@ -1,8 +1,16 @@
+# type: ignore
 import re
-import xmltodict
 from pydantic import BaseModel
-import xml.etree.ElementTree as ET
 from typing import Type, Any, Dict, TypeVar
+
+
+try:
+    import xmltodict
+    import xml.etree.ElementTree as ET
+except ImportError:
+    import warnings
+    warnings.warn("xmltodict module not found. Please install it to proceed. `pip install xmltodict`", ImportWarning)
+
 
 T = TypeVar("T", bound=BaseModel)
 

--- a/instructor/function_calls.py
+++ b/instructor/function_calls.py
@@ -7,7 +7,6 @@ from instructor.exceptions import IncompleteOutputException
 from instructor.mode import Mode
 from instructor.utils import extract_json_from_codeblock
 import logging
-import importlib
 
 
 T = TypeVar("T")

--- a/instructor/function_calls.py
+++ b/instructor/function_calls.py
@@ -2,14 +2,13 @@ from typing import Any, Dict, Optional, Type, TypeVar
 from docstring_parser import parse
 from functools import wraps
 from pydantic import BaseModel, create_model
-from instructor.exceptions import IncompleteOutputException
 from openai.types.chat import ChatCompletion
+from instructor.exceptions import IncompleteOutputException
 from instructor.mode import Mode
 from instructor.utils import extract_json_from_codeblock
 import logging
 import importlib
 
-from .anthropic_utils import json_to_xml, extract_xml, xml_to_model
 
 T = TypeVar("T")
 
@@ -63,6 +62,7 @@ class OpenAISchema(BaseModel):  # type: ignore[misc]
     @classmethod
     @property
     def anthropic_schema(cls) -> str:
+        from instructor.anthropic_utils import json_to_xml, extract_xml, xml_to_model
         return json_to_xml(cls)
 
     @classmethod
@@ -87,10 +87,7 @@ class OpenAISchema(BaseModel):  # type: ignore[misc]
         """
         if mode == Mode.ANTHROPIC_TOOLS:
             try:
-                assert isinstance(
-                    completion,
-                    importlib.import_module("anthropic.types.message").Message,
-                )
+                from instructor.anthropic_utils import extract_xml, xml_to_model
             except ImportError as err:
                 raise ImportError("Please 'pip install anthropic' package to proceed.") from err
             assert hasattr(completion, "content")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "instructor"
-version = "0.6.5"
+version = "0.6.6"
 description = "structured outputs for llm"
 authors = ["Jason Liu <jason@jxnl.co>"]
 license = "MIT"


### PR DESCRIPTION
fixes #516 

<!--
ELLIPSIS_HIDDEN
-->


----

| <a href="https://ellipsis.dev" target="_blank"><img src="https://avatars.githubusercontent.com/u/80834858?s=400&u=31e596315b0d8f7465b3ee670f25cea677299c96&v=4" alt="Ellipsis" width="30px" height="30px"/></a> | :rocket: This PR description was created by [Ellipsis](https://www.ellipsis.dev) for commit 5752334b3becc7b2a84e430ae54271b2fd6bd169.  | 
|--------|--------|

### Summary:
This PR handles import errors in `anthropic_utils.py`, moves some imports inside functions in `function_calls.py`, and updates the package version in `pyproject.toml`.

**Key points**:
- Handled import errors for `xmltodict` and `xml.etree.ElementTree` in `anthropic_utils.py`
- Moved some imports inside functions in `function_calls.py` to avoid import errors
- Updated the package version in `pyproject.toml`


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)



<!--
ELLIPSIS_HIDDEN
-->
