### PR TITLE
Add optional dependencies for anthropic and xmltodict

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,10 +17,12 @@ typer = "^0.9.0"
 rich = "^13.7.0"
 aiohttp = "^3.9.1"
 tenacity = "^8.2.3"
+anthropic = { version = "^0.18.1", optional = true }
+xmltodict = { version = "^0.13.0", optional = true }
 
-[tool.poetry.group.anthropic.dependencies]
-anthropic = "^0.18.1"
-xmltodict = "^0.13.0"
+
+[tool.poetry.extras]
+anthropic = ["anthropic", "xmltodict"]
 
 [tool.poetry.scripts]
 instructor = "instructor.cli.cli:app"


### PR DESCRIPTION
Fixes https://github.com/jxnl/instructor/issues/518

When running `pip install instructor[anthropic]` anthropic and xmltodict are not installed and the following warning is shown `WARNING: instructor 0.6.5 does not provide the extra 'anthropic'`

1. Adds optional depencencies to pyproject.toml

Ive tested to ensure `pip install instructor` does not install anthropic and xmltodict unintentionally, as well as `pip install instructor[anthropic]` to verify there is no issues with install anthropic and xmltodict.

<!--
ELLIPSIS_HIDDEN
-->


----

| <a href="https://ellipsis.dev" target="_blank"><img src="https://avatars.githubusercontent.com/u/80834858?s=400&u=31e596315b0d8f7465b3ee670f25cea677299c96&v=4" alt="Ellipsis" width="30px" height="30px"/></a> | :rocket: This PR description was created by [Ellipsis](https://www.ellipsis.dev) for commit 32d17e0660bf522ce6292d95d5d626b2a8dc98d5.  | 
|--------|--------|

### Summary:
This PR modifies 'pyproject.toml' to add 'anthropic' and 'xmltodict' as optional dependencies, ensuring they are not installed unintentionally and are correctly installed with 'pip install instructor[anthropic]'.

**Key points**:
- Added optional dependencies for 'anthropic' and 'xmltodict' in 'pyproject.toml'.
- Ensured these dependencies are not installed unintentionally with 'pip install instructor'.
- Verified that 'pip install instructor[anthropic]' installs these dependencies without issues.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)



<!--
ELLIPSIS_HIDDEN
-->
