### PR TITLE
fix: add handling for List[non-object] types

### DIFF
--- a/instructor/anthropic_utils.py
+++ b/instructor/anthropic_utils.py
@@ -45,6 +45,7 @@ def _add_params(
     # TODO: handling of nested params with the same name
     properties = model_dict.get("properties", {})
     list_found = False
+    nested_list_found = False
 
     for field_name, details in properties.items():
         parameter = ET.SubElement(root, "parameter")
@@ -69,10 +70,18 @@ def _add_params(
             field_type = details.get(
                 "type", "unknown"
             )  # Might be better to fail here if there is no type since pydantic models require types
+        
+        if "array" in field_type and "items" not in details:
+            raise ValueError("Invalid array item.")
 
-        # Adjust type if array
-        if "array" in field_type or "List" in field_type:
+        # Check for nested List
+        if "array" in field_type and "$ref" in details["items"]:
             type_element.text = f"List[{details['title']}]"
+            list_found = True
+            nested_list_found = True     
+        # Check for non-nested List
+        elif "array" in field_type and "type" in details["items"]:
+            type_element.text = f"List[{details['items']['type']}]"
             list_found = True
         else:
             type_element.text = field_type
@@ -89,20 +98,11 @@ def _add_params(
                 _resolve_reference(references, details["$ref"]),
                 references,
             )
-        elif field_type == "array":  # Handling for List[] type
+        elif field_type == "array" and nested_list_found:  # Handling for List[] type
             nested_params = ET.SubElement(parameter, "parameters")
             list_found |= _add_params(
                 nested_params,
                 _resolve_reference(references, details["items"]["$ref"]),
-                references,
-            )
-        elif "array" in field_type:  # Handling for optional List[] type
-            nested_params = ET.SubElement(parameter, "parameters")
-            list_found |= _add_params(
-                nested_params,
-                _resolve_reference(
-                    references, details["anyOf"][0]["items"]["$ref"]
-                ),  # CHANGE
                 references,
             )
 

--- a/tests/anthropic/test_simple.py
+++ b/tests/anthropic/test_simple.py
@@ -64,6 +64,31 @@ def test_nested_type():
     assert resp.address.street_name == "First Avenue"
 
 @pytest.mark.skip
+def test_list():
+    class User(BaseModel):
+        name: str
+        age: int
+        family: List[str]
+    
+    resp = create(
+        model="claude-3-opus-20240229", # Fails with claude-3-haiku-20240307
+        max_tokens=1024,
+        max_retries=0,
+        messages=[
+            {
+                "role": "user",
+                "content": "Create a user for a model with a name, age, and family members.",
+            }
+        ],
+        response_model=User,
+    )
+    
+    assert isinstance(resp, User)
+    assert isinstance(resp.family, List)
+    for member in resp.family:
+        assert isinstance(member, str)
+
+@pytest.mark.skip
 def test_nested_list():
     class Properties(BaseModel):
         key: str


### PR DESCRIPTION
 - adds handling for List[non-object] types in the model
 - adds test for List[non-object] type case
 - note: haiku tends to hallucinate the List[non-object] format, opus works better