### PR TITLE
anthropic system prompt clean up

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -162,6 +162,8 @@ cython_debug/
 #  option (not recommended) you can uncomment the following to ignore the entire idea folder.
 .idea/
 
+.vscode/
+
 examples/citation_with_extraction/fly.toml
 my_cache_directory/
 tutorials/wandb/*

--- a/instructor/function_calls.py
+++ b/instructor/function_calls.py
@@ -1,4 +1,5 @@
 from typing import Any, Dict, Optional, Type, TypeVar
+from xml.dom.minidom import parseString
 from docstring_parser import parse
 from functools import wraps
 from pydantic import BaseModel, create_model
@@ -61,8 +62,9 @@ class OpenAISchema(BaseModel):  # type: ignore[misc]
     @classmethod
     @property
     def anthropic_schema(cls) -> str:
-        from instructor.anthropic_utils import json_to_xml, extract_xml, xml_to_model
-        return json_to_xml(cls)
+        from instructor.anthropic_utils import json_to_xml
+        return "\n".join(line.lstrip() for line in parseString(json_to_xml(cls)).toprettyxml().splitlines()[1:])
+
 
     @classmethod
     def from_response(

--- a/instructor/process_response.py
+++ b/instructor/process_response.py
@@ -29,7 +29,6 @@ from typing import (
 
 from instructor.mode import Mode
 
-
 logger = logging.getLogger("instructor")
 
 T_Model = TypeVar("T_Model", bound=BaseModel)
@@ -284,8 +283,7 @@ def handle_response_model(
         elif mode == Mode.ANTHROPIC_TOOLS:
             tool_descriptions = response_model.anthropic_schema
             system_prompt = dedent(
-                f"""
-                In this environment you have access to a set of tools you can use to answer the user's question.
+                f"""In this environment you have access to a set of tools you can use to answer the user's question.
                 You may call them like this:
                 <function_calls>
                 <invoke>
@@ -297,9 +295,8 @@ def handle_response_model(
                 </invoke>
                 </function_calls>
 
-                Here are the tools available:\n{tool_descriptions}
-                """
-            )
+                Here are the tools available:""") + tool_descriptions
+            
             if "system" in new_kwargs:
                 new_kwargs["system"] = f"{system_prompt}\n{new_kwargs['system']}"
             else:


### PR DESCRIPTION
1. Cleaning up random tabs at start of Anthropic system prompt
2. Structure function call with newlines as shown in [Functions & external tools](https://docs.anthropic.com/claude/docs/functions-external-tools)
   1. Also helps readability in tracing/eval tools
3. vscode files in .gitignore

Before
```

                In this environment you have access to a set of tools you can use to answer the user's question.
                You may call them like this:
                <function_calls>
                <invoke>
                <tool_name>$TOOL_NAME</tool_name>
                <parameters>
                <$PARAMETER_NAME>$PARAMETER_VALUE</$PARAMETER_NAME>
                ...
                </parameters>
                </invoke>
                </function_calls>

                Here are the tools available:
<tool_description><tool_name>Person</tool_name><description>This is the function that must be used to construct the response.</description><parameters><parameter><name>name</name><type>string</type><description /></parameter><parameter><name>age</name><type>integer</type><description /></parameter></parameters></tool_description>

Extract the person in the sentence.
```

After
```
In this environment you have access to a set of tools you can use to answer the user's question.
You may call them like this:
<function_calls>
<invoke>
<tool_name>$TOOL_NAME</tool_name>
<parameters>
<$PARAMETER_NAME>$PARAMETER_VALUE</$PARAMETER_NAME>
...
</parameters>
</invoke>
</function_calls>

Here are the tools available:
<tool_description>
<tool_name>Person</tool_name>
<description>This is the function that must be used to construct the response.</description>
<parameters>
<parameter>
<name>name</name>
<type>string</type>
<description/>
</parameter>
<parameter>
<name>age</name>
<type>integer</type>
<description/>
</parameter>
</parameters>
</tool_description>
```
