### PR TITLE
anthropic supports enum

### DIFF
--- a/instructor/anthropic_utils.py
+++ b/instructor/anthropic_utils.py
@@ -91,7 +91,6 @@ def _add_params(
                 for value in enum_values:
                     value_element = ET.SubElement(values, "value")
                     value_element.text = value
-                print('done')
                 continue
 
             nested_params = ET.SubElement(parameter, "parameters")

--- a/instructor/anthropic_utils.py
+++ b/instructor/anthropic_utils.py
@@ -83,10 +83,21 @@ def _add_params(
         if (
             isinstance(details, dict) and "$ref" in details
         ):  # Checking if there are nested params
+            reference = _resolve_reference(references, details["$ref"])
+
+            if 'enum' in reference:
+                enum_values = reference['enum']
+                values =  ET.SubElement(parameter, "values")
+                for value in enum_values:
+                    value_element = ET.SubElement(values, "value")
+                    value_element.text = value
+                print('done')
+                continue
+
             nested_params = ET.SubElement(parameter, "parameters")
             list_found |= _add_params(
                 nested_params,
-                _resolve_reference(references, details["$ref"]),
+                reference,
                 references,
             )
         elif field_type == "array":  # Handling for List[] type

--- a/instructor/anthropic_utils.py
+++ b/instructor/anthropic_utils.py
@@ -86,6 +86,7 @@ def _add_params(
             reference = _resolve_reference(references, details["$ref"])
 
             if 'enum' in reference:
+                type_element.text = reference['type']
                 enum_values = reference['enum']
                 values =  ET.SubElement(parameter, "values")
                 for value in enum_values:

--- a/tests/anthropic/test_anthropic.py
+++ b/tests/anthropic/test_anthropic.py
@@ -1,12 +1,14 @@
-import pytest
-import anthropic
-import instructor
-from pydantic import BaseModel
+from enum import Enum
 from typing import List
 
-create = instructor.patch(
-    create=anthropic.Anthropic().messages.create, mode=instructor.Mode.ANTHROPIC_TOOLS
-)
+import anthropic
+import pytest
+from pydantic import BaseModel
+
+import instructor
+
+create = instructor.patch(create=anthropic.Anthropic().messages.create, mode=instructor.Mode.ANTHROPIC_TOOLS)
+
 
 @pytest.mark.skip
 def test_anthropic():
@@ -33,3 +35,59 @@ def test_anthropic():
     )  # type: ignore
 
     assert isinstance(resp, User)
+
+
+@pytest.mark.skip
+def test_anthropic():
+    class ProgrammingLanguage(Enum):
+        PYTHON = "python"
+        JAVASCRIPT = "javascript"
+        TYPESCRIPT = "typescript"
+        UNKNOWN = "unknown"
+        OTHER = "other"
+
+    class SimpleEnum(BaseModel):
+        language: ProgrammingLanguage
+
+    resp = create(
+        model="claude-3-haiku-20240307",
+        max_tokens=1024,
+        max_retries=0,
+        messages=[
+            {
+                "role": "user",
+                "content": "What is your favorite programming language?",
+            }
+        ],
+        response_model=SimpleEnum,
+    )  # type: ignore
+
+    assert isinstance(resp, SimpleEnum)
+
+
+@pytest.mark.skip
+def test_anthropic_enum():
+    class ProgrammingLanguage(Enum):
+        PYTHON = "python"
+        JAVASCRIPT = "javascript"
+        TYPESCRIPT = "typescript"
+        UNKNOWN = "unknown"
+        OTHER = "other"
+
+    class SimpleEnum(BaseModel):
+        language: ProgrammingLanguage
+
+    resp = create(
+        model="claude-3-haiku-20240307",
+        max_tokens=1024,
+        max_retries=0,
+        messages=[
+            {
+                "role": "user",
+                "content": "What is your favorite programming language?",
+            }
+        ],
+        response_model=SimpleEnum,
+    )  # type: ignore
+
+    assert isinstance(resp, SimpleEnum)

--- a/tests/anthropic/test_anthropic.py
+++ b/tests/anthropic/test_anthropic.py
@@ -38,34 +38,6 @@ def test_anthropic():
 
 
 @pytest.mark.skip
-def test_anthropic():
-    class ProgrammingLanguage(Enum):
-        PYTHON = "python"
-        JAVASCRIPT = "javascript"
-        TYPESCRIPT = "typescript"
-        UNKNOWN = "unknown"
-        OTHER = "other"
-
-    class SimpleEnum(BaseModel):
-        language: ProgrammingLanguage
-
-    resp = create(
-        model="claude-3-haiku-20240307",
-        max_tokens=1024,
-        max_retries=0,
-        messages=[
-            {
-                "role": "user",
-                "content": "What is your favorite programming language?",
-            }
-        ],
-        response_model=SimpleEnum,
-    )  # type: ignore
-
-    assert isinstance(resp, SimpleEnum)
-
-
-@pytest.mark.skip
 def test_anthropic_enum():
     class ProgrammingLanguage(Enum):
         PYTHON = "python"


### PR DESCRIPTION
Enums were coming back wrong in most cases due to Anthropic not knowing the type and possible values. Seems to work well now.

Results before and after for response_model.anthropic_schema

Before:
```xml
<tool_description>
    <tool_name>SimpleEnum</tool_name>
    <description>This is the function that must be used to construct the response.</description>
    <parameters>
        <parameter>
            <name>language</name>
            <type>unknown</type>
            <description />
            <parameters />
        </parameter>
    </parameters>
</tool_description>
```

After:
```xml
<tool_description>
    <tool_name>SimpleEnum</tool_name>
    <description>This is the function that must be used to construct the response.</description>
    <parameters>
        <parameter>
            <name>language</name>
            <type>string</type>
            <description />
            <values>
                <value>python</value>
                <value>javascript</value>
                <value>typescript</value>
                <value>unknown</value>
                <value>other</value>
            </values>
        </parameter>
    </parameters>
</tool_description>
```



<!--
ELLIPSIS_HIDDEN
-->




| <a href="https://ellipsis.dev" target="_blank"><img src="https://avatars.githubusercontent.com/u/80834858?s=400&u=31e596315b0d8f7465b3ee670f25cea677299c96&v=4" alt="Ellipsis" width="30px" height="30px"/></a> | :rocket: This PR description was created by [Ellipsis](https://www.ellipsis.dev) for commit d7d223720554c15939f4262416e09e7e14b9f1a3.  | 
|--------|--------|

### Summary:
The pull request adds support for 'enum' types in the `_add_params` function of `/instructor/anthropic_utils.py` by creating a 'values' sub-element for each enum value under the 'parameter' element.

**Key points**:
- Modified `_add_params` function in `/instructor/anthropic_utils.py`.
- Added handling for 'enum' type in the reference dictionary.
- If 'enum' is found, a 'values' sub-element is created under the 'parameter' element.
- Each enum value is added as a 'value' sub-element under 'values'.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)



<!--
ELLIPSIS_HIDDEN
-->


<!--
ELLIPSIS_HIDDEN
-->


----

| <a href="https://ellipsis.dev" target="_blank"><img src="https://avatars.githubusercontent.com/u/80834858?s=400&u=31e596315b0d8f7465b3ee670f25cea677299c96&v=4" alt="Ellipsis" width="30px" height="30px"/></a> | :rocket: This PR description was created by [Ellipsis](https://www.ellipsis.dev) for commit aae13c2d982206e375e97cfff61c4f87e7d3dd51.  | 
|--------|--------|

### Summary:
This PR enhances the `_add_params` function in `/instructor/anthropic_utils.py` to support 'enum' types by creating a 'values' sub-element for each enum value under the 'parameter' element, and tests the changes in `/tests/anthropic/test_anthropic.py`.

**Key points**:
- Modified `_add_params` function in `/instructor/anthropic_utils.py` to handle 'enum' types.
- When 'enum' type is encountered, a 'values' sub-element is created under the 'parameter' element.
- Each enum value is added as a 'value' sub-element under 'values'.
- Changes are tested in `/tests/anthropic/test_anthropic.py`.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)



<!--
ELLIPSIS_HIDDEN
-->
