### PR TITLE
feat: Return the messages as well in response for potentially fewer retries.

### DIFF
--- a/instructor/retry.py
+++ b/instructor/retry.py
@@ -64,7 +64,12 @@ def retry_sync(
     strict: Optional[bool] = None,
     mode: Mode = Mode.TOOLS,
 ) -> T_Model:
-    total_usage = CompletionUsage(completion_tokens=0, prompt_tokens=0, total_tokens=0)
+    total_usage = CompletionUsage(
+        messages=kwargs.get("messages", []),
+        completion_tokens=0,
+        prompt_tokens=0,
+        total_tokens=0,
+    )
 
     # If max_retries is int, then create a Retrying object
     if isinstance(max_retries, int):
@@ -82,7 +87,9 @@ def retry_sync(
                 try:
                     response = func(*args, **kwargs)
                     stream = kwargs.get("stream", False)
-                    response = update_total_usage(response, total_usage)
+                    response = update_total_usage(
+                        response, total_usage, kwargs["messages"]
+                    )
                     return process_response(
                         response,
                         response_model=response_model,
@@ -110,7 +117,12 @@ async def retry_async(
     strict: Optional[bool] = None,
     mode: Mode = Mode.TOOLS,
 ) -> T:
-    total_usage = CompletionUsage(completion_tokens=0, prompt_tokens=0, total_tokens=0)
+    total_usage = CompletionUsage(
+        messages=kwargs.get("messages", []),
+        completion_tokens=0,
+        prompt_tokens=0,
+        total_tokens=0,
+    )
 
     # If max_retries is int, then create a AsyncRetrying object
     if isinstance(max_retries, int):
@@ -131,7 +143,9 @@ async def retry_async(
                 try:
                     response: ChatCompletion = await func(*args, **kwargs)  # type: ignore
                     stream = kwargs.get("stream", False)
-                    response = update_total_usage(response, total_usage)
+                    response = update_total_usage(
+                        response, total_usage, kwargs["messages"]
+                    )
                     return await process_response_async(
                         response,
                         response_model=response_model,

--- a/instructor/utils.py
+++ b/instructor/utils.py
@@ -59,8 +59,11 @@ async def extract_json_from_stream_async(
                 yield char
 
 
-def update_total_usage(response: T_Model, total_usage) -> T_Model | ChatCompletion:
+def update_total_usage(
+    response: T_Model, total_usage, messages
+) -> T_Model | ChatCompletion:
     if isinstance(response, ChatCompletion) and response.usage is not None:
+        total_usage.messages = messages
         total_usage.completion_tokens += response.usage.completion_tokens or 0
         total_usage.prompt_tokens += response.usage.prompt_tokens or 0
         total_usage.total_tokens += response.usage.total_tokens or 0


### PR DESCRIPTION
PR for issue: [522](https://github.com/jxnl/instructor/issues/522)

<!--
ELLIPSIS_HIDDEN
-->


----

| <a href="https://ellipsis.dev" target="_blank"><img src="https://avatars.githubusercontent.com/u/80834858?s=400&u=31e596315b0d8f7465b3ee670f25cea677299c96&v=4" alt="Ellipsis" width="30px" height="30px"/></a> | :rocket: This PR description was created by [Ellipsis](https://www.ellipsis.dev) for commit fd44008121859fa20bc5368c6674432dd3d8e070.  | 
|--------|--------|

### Summary:
This PR modifies the `retry` functions and `update_total_usage` to include messages in the response, potentially reducing the number of retries.

**Key points**:
- Modified `retry_sync` and `retry_async` in `/instructor/retry.py` to include messages in `CompletionUsage`.
- Updated `update_total_usage` in `/instructor/utils.py` to add messages to `total_usage`.
- Aimed at reducing retries by including messages in the response.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)



<!--
ELLIPSIS_HIDDEN
-->
