### PR TITLE
remove prettying xml

### DIFF
--- a/instructor/function_calls.py
+++ b/instructor/function_calls.py
@@ -64,10 +64,7 @@ class OpenAISchema(BaseModel):  # type: ignore[misc]
     def anthropic_schema(cls) -> str:
         from instructor.anthropic_utils import json_to_xml
 
-        return "\n".join(
-            line.lstrip()
-            for line in parseString(json_to_xml(cls)).toprettyxml().splitlines()[1:]
-        )
+        return json_to_xml(cls)
 
 
     @classmethod

--- a/instructor/function_calls.py
+++ b/instructor/function_calls.py
@@ -1,5 +1,4 @@
 from typing import Any, Dict, Optional, Type, TypeVar
-from xml.dom.minidom import parseString
 from docstring_parser import parse
 from functools import wraps
 from pydantic import BaseModel, create_model


### PR DESCRIPTION


<!--
ELLIPSIS_HIDDEN
-->




| <a href="https://ellipsis.dev" target="_blank"><img src="https://avatars.githubusercontent.com/u/80834858?s=400&u=31e596315b0d8f7465b3ee670f25cea677299c96&v=4" alt="Ellipsis" width="30px" height="30px"/></a> | :rocket: This PR description was created by [Ellipsis](https://www.ellipsis.dev) for commit 47e162f4c6e51bcca10f7fb9662d1b213f61a6c0.  | 
|--------|--------|

### Summary:
This PR simplifies the `anthropic_schema` method in `function_calls.py` by removing the pretty-printing of its XML output.

**Key points**:
- Removed pretty-printing of XML in `anthropic_schema` method in `function_calls.py`.
- The method now directly returns the output of `json_to_xml` function.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)



<!--
ELLIPSIS_HIDDEN
-->
