### PR TITLE
rewrite model schema to xml for anthropic

### DIFF
--- a/tests/anthropic/test_anthropic.py
+++ b/tests/anthropic/test_anthropic.py
@@ -1,11 +1,13 @@
 from enum import Enum
 from typing import List
+from typing_extensions import Literal
 
 import anthropic
 import pytest
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 
 import instructor
+from instructor.anthropic_utils import build_xml_from_schema
 
 create = instructor.patch(
     create=anthropic.Anthropic().messages.create, mode=instructor.Mode.ANTHROPIC_TOOLS
@@ -65,3 +67,86 @@ def test_anthropic_enum():
     )  # type: ignore
 
     assert isinstance(resp, SimpleEnum)
+
+
+def test_simple_model():
+    class SimpleModel(BaseModel):
+        a: int = Field(..., description="idc")
+        b: int = 2
+
+    json_schema = SimpleModel.model_json_schema()
+    output_xml = build_xml_from_schema(json_schema)
+
+    expected = "<tool_description><tool_name>SimpleModel</tool_name><properties><property><name>a</name><type>integer</type></property><property><name>b</name><type>integer</type></property></properties></tool_description>"
+    assert output_xml == expected
+
+
+def test_simple_nested_model():
+    class Number(BaseModel):
+        number: int
+
+    class NestedModel(BaseModel):
+        nested_model: Number = Field(..., description="idc")
+
+    json_schema = NestedModel.model_json_schema()
+    output_xml = build_xml_from_schema(json_schema)
+
+    expected = "<tool_description><tool_name>NestedModel</tool_name><properties><property><name>nested_model</name><type>object</type><properties><property><name>number</name><type>integer</type></property></properties></property></properties></tool_description>"
+    assert output_xml == expected
+
+def test_simple_list_model():
+    class ListSimple(BaseModel):
+        list_of_ints: List[int]
+
+    json_schema = ListSimple.model_json_schema()
+    output_xml = build_xml_from_schema(json_schema)
+
+    expected = "<tool_description><tool_name>ListSimple</tool_name><properties><property><name>list_of_ints</name><type>List[integer]</type></property></properties></tool_description>"
+    assert output_xml == expected
+
+
+def test_complex_list_model():
+    class Properties(BaseModel):
+        name: str
+        value: List[str]
+
+
+    class ListObject(BaseModel):
+        name: str
+        age: int
+        properties: List[Properties]
+
+    json_schema = ListObject.model_json_schema()
+    output_xml = build_xml_from_schema(json_schema)
+
+    expected = "<tool_description><tool_name>ListObject</tool_name><properties><property><name>name</name><type>string</type></property><property><name>age</name><type>integer</type></property><property><name>properties</name><type>List</type><items><properties><property><name>name</name><type>string</type></property><property><name>value</name><type>List[string]</type></property></properties></items></property></properties></tool_description>"
+    assert output_xml == expected
+
+def test_simple_literal():
+    class SimpleLiteral(BaseModel):
+        """Testing"""
+        languages: Literal["python", "javascript", "typescript", "java", "haskell", "php"]
+
+    json_schema = SimpleLiteral.model_json_schema()
+    output_xml = build_xml_from_schema(json_schema)
+
+    expected = "<tool_description><tool_name>SimpleLiteral</tool_name><description>Testing</description><properties><property><name>languages</name><type>string</type><values><value>python</value><value>javascript</value><value>typescript</value><value>java</value><value>haskell</value><value>php</value></values></property></properties></tool_description>"
+    assert output_xml == expected
+
+def test_simple_enum():
+    class ProgrammingLanguage(Enum):
+        PYTHON = "python"
+        JAVASCRIPT = "javascript"
+        TYPESCRIPT = "typescript"
+        UNKNOWN = "unknown"
+        OTHER = "other"
+
+
+    class SimpleEnum(BaseModel):
+        language: ProgrammingLanguage
+
+    json_schema = SimpleEnum.model_json_schema()
+    output_xml = build_xml_from_schema(json_schema)
+
+    expected = "<tool_description><tool_name>SimpleEnum</tool_name><properties><property><name>language</name><type>string</type><values><value>python</value><value>javascript</value><value>typescript</value><value>unknown</value><value>other</value></values></property></properties></tool_description>"
+    assert output_xml == expected


### PR DESCRIPTION
This functionality would replace the current `json_to_xml` functionality which is missing many features (handling Literal, allOf, etc). 

Still needs to support Union cases and probably a few more things. It would be great to get a decent amount of test cases just for the xml schemas as this is the key part to getting results back. So feel free to give me Pydantic Objects that currently don't work, I'll add to the test cases and implement the logic. 

Another thing I want to add is a parameter to generate an example response as Haiku can be Opus level with an example. I'll publish an eval on langsmith against https://smith.langchain.com/public/00f4444c-9460-4a82-b87a-f50096f1cfef/d/compare?selectedSessions=ca7e4461-6e9d-45cc-b347-0fa55193be05 once "feature  complete"