### PR TITLE
Preserve async function type when patching async functions

### DIFF
--- a/instructor/patch.py
+++ b/instructor/patch.py
@@ -38,6 +38,17 @@ class InstructorChatCompletionCreate(Protocol):
     ) -> T_Model: ...
 
 
+class AsyncInstructorChatCompletionCreate(Protocol):
+    async def __call__(
+        self,
+        response_model: Type[T_Model] = None,
+        validation_context: dict = None,
+        max_retries: int = 1,
+        *args: T_ParamSpec.args,
+        **kwargs: T_ParamSpec.kwargs,
+    ) -> T_Model: ...
+
+
 @overload
 def patch(
     client: OpenAI,

--- a/instructor/patch.py
+++ b/instructor/patch.py
@@ -1,6 +1,7 @@
 # type: ignore[all]
 from functools import wraps
 from typing import (
+    Awaitable,
     Callable,
     ParamSpec,
     Protocol,
@@ -61,6 +62,13 @@ def patch(
     client: AsyncOpenAI,
     mode: Mode = Mode.TOOLS,
 ) -> AsyncOpenAI: ...
+
+
+@overload
+def patch(
+    create: Callable[T_ParamSpec, Awaitable[T_Retval]],
+    mode: Mode = Mode.TOOLS,
+) -> AsyncInstructorChatCompletionCreate: ...
 
 
 @overload


### PR DESCRIPTION
Currently if you `patch` an async function (e.g. from `AsyncOpenAI`), the function is returned as **NOT** async. This pull requests preserves the async nature of the function (meaning fixes type checking).

Example
```python
import instructor
from openai import AsyncOpenAI

client = AsyncOpenAI()
acreate = instructor.patch(create=client.chat.completions.create)

async def main():
    response = await acreate(...)
```

Maybe there is a more clever way to do this, I don't know how.

Motivation: it's quite annoying if your type checker misleads you into removing an `await` statement which is really needed - took me way too long to the issue.

<!--
ELLIPSIS_HIDDEN
-->


----

| <a href="https://ellipsis.dev" target="_blank"><img src="https://avatars.githubusercontent.com/u/80834858?s=400&u=31e596315b0d8f7465b3ee670f25cea677299c96&v=4" alt="Ellipsis" width="30px" height="30px"/></a> | :rocket: This PR description was created by [Ellipsis](https://www.ellipsis.dev) for commit 60740f1a30a8288ab20c204cfd0612a9435469e3.  | 
|--------|--------|

### Summary:
This PR modifies the `patch` function in `instructor/patch.py` to preserve the async nature of a function when it is patched, by introducing a new protocol and a new overload for the function.

**Key points**:
- Introduced a new protocol `AsyncInstructorChatCompletionCreate` in `instructor/patch.py`.
- Added a new overload for the `patch` function that returns `AsyncInstructorChatCompletionCreate` when an async function is patched.
- The changes preserve the async nature of a function when it is patched.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)



<!--
ELLIPSIS_HIDDEN
-->
