### PR TITLE
feat: Expose retry attempt number to validation context

### DIFF
--- a/instructor/retry.py
+++ b/instructor/retry.py
@@ -81,6 +81,8 @@ def retry_sync(
             with attempt:
                 if validation_context is None: 
                     validation_context = {}
+
+                retry_state = attempt.retry_state
                 validation_context["retry_attempt_number"] = retry_state.attempt_number
                 validation_context["max_attempt_number"] = retry_state.retry_object.stop.max_attempt_number
                 try:
@@ -133,6 +135,8 @@ async def retry_async(
             logger.debug(f"Retrying, attempt: {attempt}")
             if validation_context is None: 
                 validation_context = {}
+
+            retry_state = attempt.retry_state
             validation_context["retry_attempt_number"] = retry_state.attempt_number
             validation_context["max_attempt_number"] = retry_state.retry_object.stop.max_attempt_number
             with attempt:

--- a/instructor/retry.py
+++ b/instructor/retry.py
@@ -79,6 +79,10 @@ def retry_sync(
     try:
         for attempt in max_retries:
             with attempt:
+                if validation_context is None: 
+                    validation_context = {}
+                validation_context["retry_attempt_number"] = retry_state.attempt_number
+                validation_context["max_attempt_number"] = retry_state.retry_object.stop.max_attempt_number
                 try:
                     response = func(*args, **kwargs)
                     stream = kwargs.get("stream", False)
@@ -127,6 +131,10 @@ async def retry_async(
     try:
         async for attempt in max_retries:
             logger.debug(f"Retrying, attempt: {attempt}")
+            if validation_context is None: 
+                validation_context = {}
+            validation_context["retry_attempt_number"] = retry_state.attempt_number
+            validation_context["max_attempt_number"] = retry_state.retry_object.stop.max_attempt_number
             with attempt:
                 try:
                     response: ChatCompletion = await func(*args, **kwargs)  # type: ignore


### PR DESCRIPTION
## Just give up

Sometimes I need my validation to give up and just return whatever the generated value is, and just accept that the output is good enough. e.g. in cases where I'm processing a lot of examples and don't want a RetryError to kill everything.

This PR exposes some of the `retry_state` in the `validation_context` during retries in order to determine if my `field_validator` should throw an error and trigger a retry, or whether it should just pass.

### Other retry state fields available to expose

<img width="503" alt="Screenshot 2024-03-29 at 12 56 03" src="https://github.com/jxnl/instructor/assets/20516801/b5c8460a-cfbd-4577-82ec-c11462661116">

Possibly exposing `attempt.retry_state.start_time` might be helpful if people have a time-bound threshold on how long they're willing to accept retries? Just a thought, haven't included it here for now.
