### PR TITLE
Add from_groq support #556

### DIFF
--- a/docs/examples/groq.md
+++ b/docs/examples/groq.md
@@ -1,0 +1,67 @@
+# Structured Outputs using Groq
+Instead of using openai or antrophic you can now also use groq for inference by using from_groq.
+
+The examples are using mixtral-8x7b model.
+
+## GroqCloud API
+To use groq you need to obtain a groq API key.
+Goto [groqcloud](https://console.groq.com) and login. Select API Keys from the left menu and then select Create API key to create a new key.
+
+## Use example
+Some pip packages need to be installed to use the example:
+```
+pip install instructor groq pydantic openai anthropic
+```
+You need to export the groq API key:
+```
+export GROQ_API_KEY=<your-api-key>
+```
+
+An example:
+```python
+import os
+from pydantic import BaseModel, Field
+from typing import List
+from groq import Groq
+import instructor
+
+class Character(BaseModel):
+    name: str
+    fact: List[str] = Field(..., description="A list of facts about the subject")
+
+
+client = Groq(
+    api_key=os.environ.get('GROQ_API_KEY'),
+)
+
+client = instructor.from_groq(client, mode=instructor.Mode.JSON)
+
+resp = client.chat.completions.create(
+    model="mixtral-8x7b-32768",
+    messages=[
+        {
+            "role": "user",
+            "content": "Tell me about the company Tesla",
+        }
+    ],
+    response_model=Character,
+)
+print(resp.model_dump_json(indent=2))
+"""
+{
+  "name": "Tesla",
+  "fact": [
+    "An American electric vehicle and clean energy company.",
+    "Co-founded by Elon Musk, JB Straubel, Martin Eberhard, Marc Tarpenning, and Ian Wright in 2003.",
+    "Headquartered in Austin, Texas.",
+    "Produces electric vehicles, energy storage solutions, and more recently, solar energy products.",
+    "Known for its premium electric vehicles, such as the Model S, Model 3, Model X, and Model Y.",
+    "One of the world's most valuable car manufacturers by market capitalization.",
+    "Tesla's CEO, Elon Musk, is also the CEO of SpaceX, Neuralink, and The Boring Company.",
+    "Tesla operates the world's largest global network of electric vehicle supercharging stations.",
+    "The company aims to accelerate the world's transition to sustainable transport and energy through innovative technologies and products."
+  ]
+}
+"""
+```
+You can find another example called groq_example2.py under examples/groq of this repository.

--- a/docs/examples/index.md
+++ b/docs/examples/index.md
@@ -17,5 +17,6 @@
 13. [How to generate advertising copy from image inputs](image_to_ad_copy.md)
 14. [How to use local models from Ollama](ollama.md)
 15. [How to store responses in a database with SQLModel](sqlmodel.md)
+16. [How to use groqcloud api](groq.md)
 
 Explore more!

--- a/examples/groq/groq_example.py
+++ b/examples/groq/groq_example.py
@@ -4,13 +4,14 @@ from typing import List
 from groq import Groq
 import instructor
 
+
 class Character(BaseModel):
     name: str
     fact: List[str] = Field(..., description="A list of facts about the subject")
 
 
 client = Groq(
-    api_key=os.environ.get('GROQ_API_KEY'),
+    api_key=os.environ.get("GROQ_API_KEY"),
 )
 
 client = instructor.from_groq(client, mode=instructor.Mode.JSON)

--- a/examples/groq/groq_example.py
+++ b/examples/groq/groq_example.py
@@ -1,0 +1,44 @@
+import os
+from pydantic import BaseModel, Field
+from typing import List
+from groq import Groq
+import instructor
+
+class Character(BaseModel):
+    name: str
+    fact: List[str] = Field(..., description="A list of facts about the subject")
+
+
+client = Groq(
+    api_key=os.environ.get('GROQ_API_KEY'),
+)
+
+client = instructor.from_groq(client, mode=instructor.Mode.JSON)
+
+resp = client.chat.completions.create(
+    model="mixtral-8x7b-32768",
+    messages=[
+        {
+            "role": "user",
+            "content": "Tell me about the company Tesla",
+        }
+    ],
+    response_model=Character,
+)
+print(resp.model_dump_json(indent=2))
+"""
+{
+  "name": "Tesla",
+  "fact": [
+    "An American electric vehicle and clean energy company.",
+    "Co-founded by Elon Musk, JB Straubel, Martin Eberhard, Marc Tarpenning, and Ian Wright in 2003.",
+    "Headquartered in Austin, Texas.",
+    "Produces electric vehicles, energy storage solutions, and more recently, solar energy products.",
+    "Known for its premium electric vehicles, such as the Model S, Model 3, Model X, and Model Y.",
+    "One of the world's most valuable car manufacturers by market capitalization.",
+    "Tesla's CEO, Elon Musk, is also the CEO of SpaceX, Neuralink, and The Boring Company.",
+    "Tesla operates the world's largest global network of electric vehicle supercharging stations.",
+    "The company aims to accelerate the world's transition to sustainable transport and energy through innovative technologies and products."
+  ]
+}
+"""

--- a/examples/groq/groq_example2.py
+++ b/examples/groq/groq_example2.py
@@ -1,0 +1,36 @@
+import os
+from pydantic import BaseModel, Field
+from typing import List
+from groq import Groq
+import instructor
+
+client = Groq(
+    api_key=os.environ.get('GROQ_API_KEY'),
+)
+
+client = instructor.from_groq(client, mode=instructor.Mode.JSON)
+
+class UserExtract(BaseModel):
+    name: str
+    age: int
+
+
+user: UserExtract = client.chat.completions.create(
+    model="mixtral-8x7b-32768",
+    response_model=UserExtract,
+    messages=[
+        {"role": "user", "content": "Extract jason is 25 years old"},
+    ],
+)
+
+assert isinstance(user, UserExtract), "Should be instance of UserExtract"
+assert user.name.lower() == "jason"
+assert user.age == 25
+
+print(user.model_dump_json(indent=2))
+"""
+{
+  "name": "jason",
+  "age": 25
+}
+"""

--- a/examples/groq/groq_example2.py
+++ b/examples/groq/groq_example2.py
@@ -5,10 +5,11 @@ from groq import Groq
 import instructor
 
 client = Groq(
-    api_key=os.environ.get('GROQ_API_KEY'),
+    api_key=os.environ.get("GROQ_API_KEY"),
 )
 
 client = instructor.from_groq(client, mode=instructor.Mode.JSON)
+
 
 class UserExtract(BaseModel):
     name: str

--- a/instructor/__init__.py
+++ b/instructor/__init__.py
@@ -12,13 +12,14 @@ from .dsl import (
 from .function_calls import OpenAISchema, openai_schema
 from .patch import apatch, patch
 from .process_response import handle_parallel_model
-from .client import Instructor, from_openai, from_anthropic, from_litellm
+from .client import Instructor, from_openai, from_anthropic, from_litellm, from_groq
 
 __all__ = [
     "Instructor",
     "from_openai",
     "from_anthropic",
     "from_litellm",
+    "from_groq",
     "OpenAISchema",
     "CitationMixin",
     "IterableModel",

--- a/instructor/client.py
+++ b/instructor/client.py
@@ -2,6 +2,7 @@ import openai
 import inspect
 import instructor
 import anthropic
+import groq
 from .utils import Provider, get_provider
 from openai.types.chat import ChatCompletion, ChatCompletionMessageParam
 from anthropic.types import Message
@@ -400,3 +401,50 @@ def from_anthropic(
             mode=mode,
             **kwargs,
         )
+
+@overload
+def from_groq(
+    client: groq.Groq,
+    mode: instructor.Mode = instructor.Mode.TOOLS,
+    **kwargs,
+) -> Instructor: ...
+
+@overload
+def from_groq(
+    client: groq.Groq,
+    mode: instructor.Mode = instructor.Mode.TOOLS,
+    **kwargs,
+) -> Instructor: ...
+
+def from_groq(
+    client: groq.Groq,
+    mode: instructor.Mode = instructor.Mode.TOOLS,
+    **kwargs,
+) -> Instructor:
+    assert mode in {
+        instructor.Mode.JSON,
+        instructor.Mode.TOOLS,
+    }, "Mode be one of {instructor.Mode.JSON, instructor.Mode.TOOLS}"
+
+    assert isinstance(
+        client, (groq.Groq)
+    ), "Client must be an instance of groq.GROQ"
+
+    if isinstance(client, groq.Groq):
+        return Instructor(
+            client=client,
+            create=instructor.patch(create=client.chat.completions.create, mode=mode),
+            provider=Provider.GROQ,
+            mode=mode,
+            **kwargs,
+        )
+
+    else:
+        return AsyncInstructor(
+            client=client,
+            create=instructor.patch(create=client.messages.create, mode=mode),
+            provider=Provider.GROQ,
+            mode=mode,
+            **kwargs,
+        )
+

--- a/instructor/client.py
+++ b/instructor/client.py
@@ -402,12 +402,6 @@ def from_anthropic(
             **kwargs,
         )
 
-@overload
-def from_groq(
-    client: groq.Groq,
-    mode: instructor.Mode = instructor.Mode.TOOLS,
-    **kwargs,
-) -> Instructor: ...
 
 @overload
 def from_groq(
@@ -415,6 +409,15 @@ def from_groq(
     mode: instructor.Mode = instructor.Mode.TOOLS,
     **kwargs,
 ) -> Instructor: ...
+
+
+@overload
+def from_groq(
+    client: groq.Groq,
+    mode: instructor.Mode = instructor.Mode.TOOLS,
+    **kwargs,
+) -> Instructor: ...
+
 
 def from_groq(
     client: groq.Groq,
@@ -426,9 +429,7 @@ def from_groq(
         instructor.Mode.TOOLS,
     }, "Mode be one of {instructor.Mode.JSON, instructor.Mode.TOOLS}"
 
-    assert isinstance(
-        client, (groq.Groq)
-    ), "Client must be an instance of groq.GROQ"
+    assert isinstance(client, (groq.Groq)), "Client must be an instance of groq.GROQ"
 
     if isinstance(client, groq.Groq):
         return Instructor(
@@ -447,4 +448,3 @@ def from_groq(
             mode=mode,
             **kwargs,
         )
-

--- a/tests/llm/test_openai/test_validators.py
+++ b/tests/llm/test_openai/test_validators.py
@@ -44,7 +44,6 @@ def test_runmodel_validator_error(model, mode, client):
 
 @pytest.mark.parametrize("model", models)
 def test_runmodel_validator_default_openai_client(model, client):
-
     client = instructor.from_openai(client)
 
     class QuestionAnswerNoEvil(BaseModel):


### PR DESCRIPTION
I've added a from_groq instead of the from_openai used in this https://python.useinstructor.com/hub/groq/#groq-ai link.
Also added two examples under examples/groq with the names:  groq_example.py and groq_example2.py.  The examples also show the expected output I got during testing. I also added groq.md under docs/examples with a small description.


<!--
ELLIPSIS_HIDDEN
-->


----

| <a href="https://ellipsis.dev" target="_blank"><img src="https://avatars.githubusercontent.com/u/80834858?s=400&u=31e596315b0d8f7465b3ee670f25cea677299c96&v=4" alt="Ellipsis" width="30px" height="30px"/></a> | :rocket: This PR description was created by [Ellipsis](https://www.ellipsis.dev) for commit 5ef728a8a2e27dfbb1e5651c5b3445f536abbbb3.  | 
|--------|--------|

### Summary:
This PR adds support for Groq in the Instructor library, including a new `from_groq` function, two example scripts, and a new documentation page.

**Key points**:
- Added `from_groq` function in `instructor/client.py` and `instructor/__init__.py`
- Added two example scripts `groq_example.py` and `groq_example2.py` under `examples/groq`
- Added new documentation page `groq.md` under `docs/examples`
- Updated `docs/examples/index.md` to include the new documentation page


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)



<!--
ELLIPSIS_HIDDEN
-->
