### PR TITLE
Handle partial object being an empty string

### DIFF
--- a/instructor/dsl/partial.py
+++ b/instructor/dsl/partial.py
@@ -122,13 +122,12 @@ class PartialBase(Generic[T_Model]):
     def model_from_chunks(
         cls, json_chunks: Iterable[Any], **kwargs: Any
     ) -> Generator[T_Model, None, None]:
-        prev_obj = None
         potential_object = ""
         partial_model = cls.get_partial_model()
         for chunk in json_chunks:
             potential_object += chunk
 
-            obj = pydantic_core.from_json(potential_object, allow_partial=True)
+            obj = pydantic_core.from_json(potential_object or "{}", allow_partial=True)
             obj = partial_model.model_validate(obj, strict=None, **kwargs)  # type: ignore[attr-defined]
             yield obj
 
@@ -137,11 +136,10 @@ class PartialBase(Generic[T_Model]):
         cls, json_chunks: AsyncGenerator[str, None], **kwargs: Any
     ) -> AsyncGenerator[T_Model, None]:
         potential_object = ""
-        prev_obj = None
         partial_model = cls.get_partial_model()
         async for chunk in json_chunks:
             potential_object += chunk
-            obj = pydantic_core.from_json(potential_object, allow_partial=True)
+            obj = pydantic_core.from_json(potential_object or "{}", allow_partial=True)
             obj = partial_model.model_validate(obj, strict=None, **kwargs)
             yield obj
 

--- a/tests/dsl/test_partial.py
+++ b/tests/dsl/test_partial.py
@@ -66,3 +66,9 @@ def test_partial():
 
     for model in partial.model_from_chunks(['{"b": {"b": 1}}']):
         assert model.model_dump() == {"a": None, "b": {"b": 1}}
+
+
+def test_partial_empty_string():
+    partial = Partial[SamplePartial]
+    for model in partial.model_from_chunks([""]):
+        assert model.model_dump() == {"a": None, "b": {}}


### PR DESCRIPTION
Not sure if it's better to handle this here or within pydantic but I ran into an error with partials where the partial object was `''` and it threw an EOF error. 

<!--
ELLIPSIS_HIDDEN
-->


----

| <a href="https://ellipsis.dev" target="_blank"><img src="https://avatars.githubusercontent.com/u/80834858?s=400&u=31e596315b0d8f7465b3ee670f25cea677299c96&v=4" alt="Ellipsis" width="30px" height="30px"/></a> | :rocket: This PR description was created by [Ellipsis](https://www.ellipsis.dev) for commit b7ceded8b42850373ec3b383fd49e60671131b59.  | 
|--------|--------|

### Summary:
This PR modifies the `PartialBase` class in `/instructor/dsl/partial.py` to handle cases where the partial object is an empty string, and adds a corresponding test case in `/tests/dsl/test_partial.py`.

**Key points**:
- Updated `model_from_chunks` and `model_from_chunks_async` methods in `PartialBase` class in `/instructor/dsl/partial.py` to handle empty string partial objects.
- Added a new test case `test_partial_empty_string` in `/tests/dsl/test_partial.py` to validate the changes.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)



<!--
ELLIPSIS_HIDDEN
-->
