### PR TITLE
docs: use `async for` instead of `for` for streaming FastAPI resp

### DIFF
--- a/docs/concepts/fastapi.md
+++ b/docs/concepts/fastapi.md
@@ -81,7 +81,7 @@ async def extract(data: UserData):
     )
 
     async def generate():
-        for user in users:
+        async for user in users:
             resp_json = user.model_dump_json()
             yield f"data: {resp_json}"
         yield "data: [DONE]"


### PR DESCRIPTION
Hi 👋🏻 

I tried the docs snippet and found that it should use `async for` instead of `for` to avoid `TypeError: 'async_generator' object is not iterable`

<!--
ELLIPSIS_HIDDEN
-->


----

| <a href="https://ellipsis.dev" target="_blank"><img src="https://avatars.githubusercontent.com/u/80834858?s=400&u=31e596315b0d8f7465b3ee670f25cea677299c96&v=4" alt="Ellipsis" width="30px" height="30px"/></a> | :rocket: This PR description was created by [Ellipsis](https://www.ellipsis.dev) for commit 5f3291dba2a8efab3bc87f5977ac8de089941fd7.  | 
|--------|--------|

### Summary:
This PR updates the `fastapi.md` documentation to use `async for` instead of `for` when iterating over an async generator in the `generate` function within the `extract` function.

**Key points**:
- Updated `fastapi.md` documentation file
- Changed `for` loop to `async for` in `generate` function within `extract` function
- The change is necessary to avoid `TypeError` when iterating over `users`, which is an async generator


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)



<!--
ELLIPSIS_HIDDEN
-->
