### PR TITLE
fix broken link to evals

### DIFF
--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -1,8 +1,8 @@
 We would love for you to contribute to `Instructor`.
 
-## [Evals](https://github.com/jxnl/instructor/tree/main/tests/openai/evals)
+## [Evals](https://github.com/jxnl/instructor/tree/main/tests/llm/test_openai/evals)
 
-We invite you to contribute evals in pytest as a way to monitor the quality of the openai models and the instructor library. To get started check out the [jxnl/instructor/tests/evals](https://github.com/jxnl/instructor/tree/main/tests/openai/evals) and contribute your own evals in the form of pytest tests. These evals will be run once a week and the results will be posted.
+We invite you to contribute evals in pytest as a way to monitor the quality of the openai models and the instructor library. To get started check out the [jxnl/instructor/tests/llm/test_openai/evals](https://github.com/jxnl/instructor/tree/main/tests/llm/test_openai/evals) and contribute your own evals in the form of pytest tests. These evals will be run once a week and the results will be posted.
 
 ## Issues
 


### PR DESCRIPTION


<!--
ELLIPSIS_HIDDEN
-->




| <a href="https://ellipsis.dev" target="_blank"><img src="https://avatars.githubusercontent.com/u/80834858?s=400&u=31e596315b0d8f7465b3ee670f25cea677299c96&v=4" alt="Ellipsis" width="30px" height="30px"/></a> | :rocket: This PR description was created by [Ellipsis](https://www.ellipsis.dev) for commit ba2b07bd74740d87d61e1158407a06a81fc96d00.  | 
|--------|--------|

### Summary:
This PR corrects a broken link in the `contributing.md` file, ensuring it points to the correct `Evals` path.

**Key points**:
- Fixed broken link in `contributing.md`.
- The link to `Evals` now points to the correct path.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)



<!--
ELLIPSIS_HIDDEN
-->
