### PR TITLE
adding AnthropicVertex

### DIFF
--- a/instructor/client_anthropic.py
+++ b/instructor/client_anthropic.py
@@ -6,7 +6,7 @@ from typing import overload
 
 @overload
 def from_anthropic(
-    client: anthropic.Anthropic | anthropic.AnthropicBedrock,
+    client: anthropic.Anthropic | anthropic.AnthropicBedrock | anthropic.AnthropicVertex,
     mode: instructor.Mode = instructor.Mode.ANTHROPIC_JSON,
     **kwargs,
 ) -> instructor.Instructor: ...
@@ -14,7 +14,7 @@ def from_anthropic(
 
 @overload
 def from_anthropic(
-    client: anthropic.AsyncAnthropic | anthropic.AsyncAnthropicBedrock,
+    client: anthropic.AsyncAnthropic | anthropic.AsyncAnthropicBedrock | anthropic.AsyncAnthropicVertex,
     mode: instructor.Mode = instructor.Mode.ANTHROPIC_JSON,
     **kwargs,
 ) -> instructor.Instructor: ...
@@ -26,6 +26,7 @@ def from_anthropic(
         | anthropic.AsyncAnthropic
         | anthropic.AnthropicBedrock
         | anthropic.AsyncAnthropicBedrock
+        | anthropic.AsyncAnthropicVertex
     ),
     mode: instructor.Mode = instructor.Mode.ANTHROPIC_JSON,
     **kwargs,
@@ -41,16 +42,18 @@ def from_anthropic(
             anthropic.Anthropic,
             anthropic.AsyncAnthropic,
             anthropic.AnthropicBedrock,
+            anthropic.AnthropicVertex,
             anthropic.AsyncAnthropicBedrock,
+            anthropic.AsyncAnthropicVertex,
         ),
-    ), "Client must be an instance of {anthropic.Anthropic, anthropic.AsyncAnthropic, anthropic.AnthropicBedrock, anthropic.AsyncAnthropicBedrock}"
+    ), "Client must be an instance of {anthropic.Anthropic, anthropic.AsyncAnthropic, anthropic.AnthropicBedrock, anthropic.AsyncAnthropicBedrock,  anthropic.AnthropicVertex, anthropic.AsyncAnthropicVertex}"
 
     if mode == instructor.Mode.ANTHROPIC_TOOLS:
         create = client.beta.tools.messages.create
     else:
         create = client.messages.create
 
-    if isinstance(client, (anthropic.Anthropic, anthropic.AnthropicBedrock)):
+    if isinstance(client, (anthropic.Anthropic, anthropic.AnthropicBedrock, anthropic.AnthropicVertex)):
         return instructor.Instructor(
             client=client,
             create=instructor.patch(create=create, mode=mode),


### PR DESCRIPTION
![image](https://github.com/jxnl/instructor/assets/5931841/bf14f76b-1a05-43bc-9972-1c90562a38dd)


<!--
ELLIPSIS_HIDDEN
-->


----

| <a href="https://ellipsis.dev" target="_blank"><img src="https://avatars.githubusercontent.com/u/80834858?s=400&u=31e596315b0d8f7465b3ee670f25cea677299c96&v=4" alt="Ellipsis" width="30px" height="30px"/></a> | :rocket: This PR description was created by [Ellipsis](https://www.ellipsis.dev) for commit 2e750f18dc0dc9881a132d8a78fa262158c5244b.  | 
|--------|--------|

### Summary:
This PR extends the `from_anthropic` function in `client_anthropic.py` to accept `AnthropicVertex` and `AsyncAnthropicVertex` as valid client types.

**Key points**:
- Added `AnthropicVertex` and `AsyncAnthropicVertex` as valid client types in `from_anthropic` function in `client_anthropic.py`.
- Updated assertion error message to include new client types.
- Updated `isinstance` check to include `AnthropicVertex`.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)



<!--
ELLIPSIS_HIDDEN
-->
