### PR TITLE
fix: typo textblocks vi-fr  in blog post

### DIFF
--- a/docs/blog/posts/matching-language.md
+++ b/docs/blog/posts/matching-language.md
@@ -54,6 +54,9 @@ If we use a simple instructor prompt, even when we ask for the language to be co
     ---
 
     Mô hình ngôn ngữ đã trở nên tinh vi hơn trong những năm gần đây, cho phép tạo ra các văn bản trôi chảy và tự nhiên, đồng thời thể hiện hiệu suất xuất sắc trong các nhiệm vụ khác nhau như dịch máy, trả lời câu hỏi và tạo văn bản sáng tạo. Các mô hình này được huấn luyện trên các tập dữ liệu văn bản khổng lồ và có thể nắm bắt cấu trúc và sắc thái của ngôn ngữ tự nhiên. Những cải tiến trong mô hình ngôn ngữ có thể mang lại cuộc cách mạng trong giao tiếp giữa máy tính và con người, và người ta kỳ vọng sẽ có những tiến bộ hơn nữa trong tương lai.
+    
+    ---
+
     Les modèles de langage sont devenus de plus en plus sophistiqués ces dernières années, permettant de générer des textes fluides et naturels, et de performer dans une variété de tâches telles que la traduction automatique, la réponse aux questions et la génération de texte créatif. Entraînés sur d'immenses ensembles de données textuelles, ces modèles sont capables de capturer la structure et les nuances du langage naturel, ouvrant la voie à une révolution dans la communication entre les ordinateurs et les humains.
 
     ---
@@ -127,6 +130,7 @@ if __name__ == "__main__":
     Source: sw, Summary: en, Match: False
     Source: tr, Summary: tr, Match: True
     Source: vi, Summary: en, Match: False
+    Source: fr, Summary: fr, Match: True
     Source: zh-cn, Summary: en, Match: False
     Source: de, Summary: de, Match: True
     Source: hi, Summary: en, Match: False
@@ -176,6 +180,9 @@ Dil modelleri son yıllarda daha da gelişti, akıcı ve doğal metinler üretme
 ---
 
 Mô hình ngôn ngữ đã trở nên tinh vi hơn trong những năm gần đây, cho phép tạo ra các văn bản trôi chảy và tự nhiên, đồng thời thể hiện hiệu suất xuất sắc trong các nhiệm vụ khác nhau như dịch máy, trả lời câu hỏi và tạo văn bản sáng tạo. Các mô hình này được huấn luyện trên các tập dữ liệu văn bản khổng lồ và có thể nắm bắt cấu trúc và sắc thái của ngôn ngữ tự nhiên. Những cải tiến trong mô hình ngôn ngữ có thể mang lại cuộc cách mạng trong giao tiếp giữa máy tính và con người, và người ta kỳ vọng sẽ có những tiến bộ hơn nữa trong tương lai.
+
+---
+
 Les modèles de langage sont devenus de plus en plus sophistiqués ces dernières années, permettant de générer des textes fluides et naturels, et de performer dans une variété de tâches telles que la traduction automatique, la réponse aux questions et la génération de texte créatif. Entraînés sur d'immenses ensembles de données textuelles, ces modèles sont capables de capturer la structure et les nuances du langage naturel, ouvrant la voie à une révolution dans la communication entre les ordinateurs et les humains.
 
 ---
@@ -243,6 +250,7 @@ if __name__ == "__main__":
     Source: sw, Summary: sw, Match: True
     Source: tr, Summary: tr, Match: True
     Source: vi, Summary: vi, Match: True
+    Source: fr, Summary: fr, Match: True
     Source: zh-cn, Summary: zh-cn, Match: True
     Source: de, Summary: de, Match: True
     Source: hi, Summary: hi, Match: True


### PR DESCRIPTION
Same PR as yesterday, but also [in the blog post](https://python.useinstructor.com/blog/2024/03/28/matching-language-summaries/?h=langu)

<!--
ELLIPSIS_HIDDEN
-->


----

| <a href="https://ellipsis.dev" target="_blank"><img src="https://avatars.githubusercontent.com/u/80834858?s=400&u=31e596315b0d8f7465b3ee670f25cea677299c96&v=4" alt="Ellipsis" width="30px" height="30px"/></a> | :rocket: This PR description was created by [Ellipsis](https://www.ellipsis.dev) for commit f8c394c92df253cba88ead10954de7be66ae6091.  | 
|--------|--------|

### Summary:
This PR corrects typos in the Vietnamese and French text blocks in the `matching-language.md` blog post and adds a new line of code in the included Python script.

**Key points**:
- Fixed typos in Vietnamese and French text blocks in `matching-language.md`.
- Added a new line of code in the Python script included in the blog post.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)



<!--
ELLIPSIS_HIDDEN
-->
