### PR TITLE
Document use of SkipJsonSchema for omitting fields

### DIFF
--- a/docs/concepts/fields.md
+++ b/docs/concepts/fields.md
@@ -86,6 +86,24 @@ print(date_range.model_dump_json())
 #> {"start_date":"2021-01-01","end_date":"2021-01-30"}
 ```
 
+## Omitting fields from schema sent to the language model
+
+In some cases, you may wish to have the language model ignore certain fields in your model. You can do this by using Pydantic's `SkipJsonSchema` annotation. This omits a field from the JSON schema emitted by Pydantic (which `instructor` uses for constructing its prompts and tool definitions). For example:
+
+```py
+from pydantic import BaseModel
+from pydantic.json_schema import SkipJsonSchema
+
+class Response(BaseModel):
+    question: str
+    answer: str
+    private_field: SkipJsonSchema[str | None] = None
+
+assert "private_field" not in Response.model_json_schema()["properties"]
+```
+
+Note that because the language model will never return a value for `private_field`, you'll need a default value (this can be a generator via a declared Pydantic `Field`). 
+
 ## Customizing JSON Schema
 
 There are some fields that are exclusively used to customise the generated JSON Schema:

--- a/docs/concepts/models.md
+++ b/docs/concepts/models.md
@@ -30,7 +30,7 @@ Here all docstrings, types, and field annotations will be used to generate the p
 
 ## Optional Values
 
-If we use `Optional` and `default`, they will be considered not required when sent to the language model
+If we use `Optional` and `default`, they will be considered not required when sent to the language model.
 
 ```python
 from pydantic import BaseModel, Field
@@ -42,6 +42,8 @@ class User(BaseModel):
     age: int = Field(description="The age of the user.")
     email: Optional[str] = Field(description="The email of the user.", default=None)
 ```
+
+Note that fields can also be omitted entirely from being sent to the language model by using Pydantic's `SkipJsonSchema` annotation. See [Fields](fields.md#omitting-fields-from-schema-sent-to-the-language-model) for additional details.
 
 ## Dynamic model creation
 


### PR DESCRIPTION


<!--
ELLIPSIS_HIDDEN
-->




| <a href="https://ellipsis.dev" target="_blank"><img src="https://avatars.githubusercontent.com/u/80834858?s=400&u=31e596315b0d8f7465b3ee670f25cea677299c96&v=4" alt="Ellipsis" width="30px" height="30px"/></a> | :rocket: This PR description was created by [Ellipsis](https://www.ellipsis.dev) for commit 503ad3213395cb8c191dcdd5405ad22154e8535b.  | 
|--------|--------|

### Summary:
This PR adds documentation for the use of `SkipJsonSchema` to omit fields from the JSON schema in Pydantic models.

**Key points**:
- Added documentation for `SkipJsonSchema` usage in `/docs/concepts/fields.md`.
- Updated `/docs/concepts/models.md` to reference the new section in `fields.md`.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)



<!--
ELLIPSIS_HIDDEN
-->
