### PR TITLE
feat: basic sentiment analysis eval tests

### DIFF
--- a/tests/llm/test_openai/evals/test_sentiment_analysis.py
+++ b/tests/llm/test_openai/evals/test_sentiment_analysis.py
@@ -1,0 +1,51 @@
+import enum
+from itertools import product
+from pydantic import BaseModel
+import pytest
+import instructor
+from instructor.function_calls import Mode
+from ..util import models, modes
+
+
+class Sentiment(str, enum.Enum):
+    POSITIVE = "positive"
+    NEGATIVE = "negative"
+    NEUTRAL = "neutral"
+
+
+class SentimentAnalysis(BaseModel):
+    sentiment: Sentiment
+
+
+test_data = [
+    ("I absolutely love this product! It has exceeded all my expectations.", Sentiment.POSITIVE),
+    ("The service was terrible. I will never use this company again.", Sentiment.NEGATIVE),
+    ("The movie was okay. It had some good moments but overall it was average.", Sentiment.NEUTRAL),
+]
+
+
+@pytest.mark.parametrize("model, data, mode", product(models, test_data, modes))
+def test_sentiment_analysis(model, data, mode, client):
+    sample_data, expected_sentiment = data
+
+    if (mode, model) in {
+        (Mode.JSON, "gpt-3.5-turbo"),
+        (Mode.JSON, "gpt-4"),
+    }:
+        pytest.skip(f"{mode} mode is not supported for {model}, skipping test")
+
+    client = instructor.patch(client, mode=mode)
+
+    response = client.chat.completions.create(
+        model=model,
+        response_model=SentimentAnalysis,
+        messages=[
+            {
+                "role": "system",
+                "content": "You are a sentiment analysis model. Analyze the sentiment of the given text and provide the sentiment (positive, negative, or neutral).",
+            },
+            {"role": "user", "content": sample_data},
+        ],
+    )
+
+    assert response.sentiment == expected_sentiment


### PR DESCRIPTION
The pull request introduces a new test case for basic sentiment analysis using enums to represent sentiment labels. The test case focuses on interpreting and analyzing sentiment from text input while also providing a different scenario that complements the existing data extraction tests of this kind.

Key changes:

1.  New file created by adding `test_sentiment_analysis.py` into the tests directory.
2.  Created `Sentiment` enum class and `SentimentAnalysis` class using pydantic.
3.  Provided sample inputs with expected sentiment values as test data.

This sentiment analysis test case expands the coverage of the library's functionality and ensures accurate interpretation and analysis of sentiment from text input.

**Note**: the test data was generated using AI.

<!--
ELLIPSIS_HIDDEN
-->


----

| <a href="https://ellipsis.dev" target="_blank"><img src="https://avatars.githubusercontent.com/u/80834858?s=400&u=31e596315b0d8f7465b3ee670f25cea677299c96&v=4" alt="Ellipsis" width="30px" height="30px"/></a> | :rocket: This PR description was created by [Ellipsis](https://www.ellipsis.dev) for commit 16acb2aa9863805714aae3a68a228682fb46c076.  | 
|--------|--------|

### Summary:
The PR introduces a new sentiment analysis test case in `test_sentiment_analysis.py`, using an enum class to represent sentiment labels, a pydantic class to model the sentiment analysis, and parameterized test data to ensure accurate interpretation and analysis of sentiment from text input.

**Key points**:
- New file `test_sentiment_analysis.py` added to `tests` directory.
- Created `Sentiment` enum class and `SentimentAnalysis` pydantic class.
- Provided sample inputs with expected sentiment values as test data.
- Parameterized test function `test_sentiment_analysis` with different models, test data, and modes.
- Skips test for certain combinations of mode and model.
- Sends a chat completion request to the client in the test function.
- Asserts that the response sentiment matches the expected sentiment.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)



<!--
ELLIPSIS_HIDDEN
-->
