### PR TITLE
Added support for MD_JSON for Anyscale and Together

### DIFF
--- a/instructor/client.py
+++ b/instructor/client.py
@@ -280,6 +280,7 @@ def from_openai(
             instructor.Mode.TOOLS,
             instructor.Mode.JSON,
             instructor.Mode.JSON_SCHEMA,
+            instructor.Mode.MD_JSON,
         }
 
     if provider in {Provider.OPENAI}:


### PR DESCRIPTION
Added support for MD_JSON for together/anyscale.

Reason:
Trying to use "mistralai/Mixtral-8x22B-Instruct-v0.1" from together.ai but tool/json mode is not supported. When trying to use `MD_JSON`  the below AssertionError is raised

```
{
	"name": "AssertionError",
	"message": "",
	"stack": "---------------------------------------------------------------------------
AssertionError                            Traceback (most recent call last)
Cell In[4], line 13
      3 from openai import OpenAI
      5 ollama_client = instructor.from_openai(
      6     OpenAI(
      7         base_url=\"http://localhost:11434/v1\",
   (...)
     10     mode=instructor.Mode.TOOLS,
     11 )
---> 13 together_client = instructor.from_openai(
     14     OpenAI(
     15         base_url=\"https://api.together.xyz/v1\",
     16         api_key=TOGETHER_API_KEY,
     17     ),
     18     mode=instructor.Mode.MD_JSON,
     19 )
     21 anthopic_client = instructor.from_anthropic(
     22     Anthropic(
     23         api_key=ANTHROPIC_API_KEY
     24     )
     25 )
     27 openai_client = instructor.from_openai(
     28     OpenAI(
     29         api_key=OPENAI_API_KEY
     30     )
     31 )

File ~/.pyenv/versions/3.11.8/envs/env/lib/python3.11/site-packages/instructor/client.py:279, in from_openai(client, mode, **kwargs)
    274 assert isinstance(
    275     client, (openai.OpenAI, openai.AsyncOpenAI)
    276 ), \"Client must be an instance of openai.OpenAI or openai.AsyncOpenAI\"
    278 if provider in {Provider.ANYSCALE, Provider.TOGETHER}:
--> 279     assert mode in {
    280         instructor.Mode.TOOLS,
    281         instructor.Mode.JSON,
    282         instructor.Mode.JSON_SCHEMA,
    283     }
    285 if provider in {Provider.OPENAI}:
    286     assert mode in {
    287         instructor.Mode.TOOLS,
    288         instructor.Mode.JSON,
   (...)
    291         instructor.Mode.MD_JSON,
    292     }

AssertionError: "
}
```