### PR TITLE
feat: update and allow strict mode

### DIFF
--- a/instructor/client.py
+++ b/instructor/client.py
@@ -67,6 +67,7 @@ class Instructor:
         messages: List[ChatCompletionMessageParam],
         max_retries: int = 3,
         validation_context: dict | None = None,
+        strict: bool = True,
         **kwargs,
     ) -> T:
         kwargs = self.handle_kwargs(kwargs)
@@ -76,6 +77,7 @@ class Instructor:
             messages=messages,
             max_retries=max_retries,
             validation_context=validation_context,
+            strict=strict,
             **kwargs,
         )
 
@@ -85,6 +87,7 @@ class Instructor:
         messages: List[ChatCompletionMessageParam],
         max_retries: int = 3,
         validation_context: dict | None = None,
+        strict: bool = True,
         **kwargs,
     ) -> Generator[T, None, None]:
         assert self.provider != Provider.ANTHROPIC, "Anthropic doesn't support partial"
@@ -99,6 +102,7 @@ class Instructor:
             response_model=response_model,
             max_retries=max_retries,
             validation_context=validation_context,
+            strict=strict,
             **kwargs,
         )
 
@@ -108,6 +112,7 @@ class Instructor:
         response_model: Type[T],
         max_retries: int = 3,
         validation_context: dict | None = None,
+        strict: bool = True,
         **kwargs,
     ) -> Iterable[T]:
         assert self.provider != Provider.ANTHROPIC, "Anthropic doesn't support iterable"
@@ -121,6 +126,7 @@ class Instructor:
             response_model=response_model,
             max_retries=max_retries,
             validation_context=validation_context,
+            strict=strict,
             **kwargs,
         )
 
@@ -130,6 +136,7 @@ class Instructor:
         response_model: Type[T],
         max_retries: int = 3,
         validation_context: dict | None = None,
+        strict: bool = True,
         **kwargs,
     ) -> Tuple[T, ChatCompletion | Any]:
         kwargs = self.handle_kwargs(kwargs)
@@ -138,6 +145,7 @@ class Instructor:
             response_model=response_model,
             max_retries=max_retries,
             validation_context=validation_context,
+            strict=strict,
             **kwargs,
         )
         return model, model._raw_response
@@ -176,6 +184,7 @@ class AsyncInstructor(Instructor):
         response_model: Type[T],
         validation_context: dict | None = None,
         max_retries: int = 3,
+        strict: bool = True,
         **kwargs,
     ) -> T:
         kwargs = self.handle_kwargs(kwargs)
@@ -184,6 +193,7 @@ class AsyncInstructor(Instructor):
             validation_context=validation_context,
             max_retries=max_retries,
             messages=messages,
+            strict=strict,
             **kwargs,
         )
 
@@ -193,6 +203,7 @@ class AsyncInstructor(Instructor):
         messages: List[ChatCompletionMessageParam],
         validation_context: dict | None = None,
         max_retries: int = 3,
+        strict: bool = True,
         **kwargs,
     ) -> AsyncGenerator[T, None]:
         assert self.provider != Provider.ANTHROPIC, "Anthropic doesn't support partial"
@@ -204,6 +215,7 @@ class AsyncInstructor(Instructor):
             validation_context=validation_context,
             max_retries=max_retries,
             messages=messages,
+            strict=strict,
             **kwargs,
         ):
             yield item
@@ -214,6 +226,7 @@ class AsyncInstructor(Instructor):
         messages: List[ChatCompletionMessageParam],
         validation_context: dict | None = None,
         max_retries: int = 3,
+        strict: bool = True,
         **kwargs,
     ) -> AsyncGenerator[T, None]:
         assert self.provider != Provider.ANTHROPIC, "Anthropic doesn't support iterable"
@@ -225,6 +238,7 @@ class AsyncInstructor(Instructor):
             validation_context=validation_context,
             max_retries=max_retries,
             messages=messages,
+            strict=strict,
             **kwargs,
         ):
             yield item
@@ -235,6 +249,7 @@ class AsyncInstructor(Instructor):
         messages: List[ChatCompletionMessageParam],
         validation_context: dict | None = None,
         max_retries: int = 3,
+        strict: bool = True,
         **kwargs,
     ) -> Tuple[T, dict]:
         kwargs = self.handle_kwargs(kwargs)
@@ -243,6 +258,7 @@ class AsyncInstructor(Instructor):
             validation_context=validation_context,
             max_retries=max_retries,
             messages=messages,
+            strict=strict,
             **kwargs,
         )
         return response, response._raw_response

--- a/instructor/patch.py
+++ b/instructor/patch.py
@@ -116,6 +116,7 @@ def patch(
         response_model: Type[T_Model] = None,
         validation_context: dict = None,
         max_retries: int = 1,
+        strict: bool = True,
         *args: T_ParamSpec.args,
         **kwargs: T_ParamSpec.kwargs,
     ) -> T_Model:
@@ -129,6 +130,7 @@ def patch(
             max_retries=max_retries,
             args=args,
             kwargs=new_kwargs,
+            strict=strict,
             mode=mode,
         )  # type: ignore
         return response
@@ -138,6 +140,7 @@ def patch(
         response_model: Type[T_Model] = None,
         validation_context: dict = None,
         max_retries: int = 1,
+        strict: bool = True,
         *args: T_ParamSpec.args,
         **kwargs: T_ParamSpec.kwargs,
     ) -> T_Model:
@@ -150,6 +153,7 @@ def patch(
             validation_context=validation_context,
             max_retries=max_retries,
             args=args,
+            strict=strict,
             kwargs=new_kwargs,
             mode=mode,
         )


### PR DESCRIPTION
addresses #612 

<!--
ELLIPSIS_HIDDEN
-->


----

| :rocket: This description was created by [Ellipsis](https://www.ellipsis.dev) for commit 291e3e59f937417d5dae99b3786850a40d091e41  | 
|--------|

### Summary:
The pull request introduces a new `strict` parameter, defaulting to `True`, to several methods in the `Instructor` and `AsyncInstructor` classes and to the `new_create_async` and `new_create_sync` functions.

**Key points**:
- Added a `strict` parameter to several methods in the `Instructor` and `AsyncInstructor` classes in `instructor/client.py`.
- Added a `strict` parameter to the `new_create_async` and `new_create_sync` functions in `instructor/patch.py`.
- The `strict` parameter is a boolean that defaults to `True`.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)



<!--
ELLIPSIS_HIDDEN
-->
