### PR TITLE
Fix anthropic usage and tools

### DIFF
--- a/instructor/function_calls.py
+++ b/instructor/function_calls.py
@@ -119,9 +119,12 @@ class OpenAISchema(BaseModel):  # type: ignore[misc]
         validation_context: Optional[Dict[str, Any]] = None,
         strict: Optional[bool] = None,
     ) -> BaseModel:
-        tool_call = [c.input for c in completion.content if c.type == "tool_use"][0]
+        tool_calls = [c.input for c in completion.content if c.type == "tool_use"]
+        tool_call = tool_calls[0] if tool_calls else {}
 
-        return cls.model_validate(tool_call, context=validation_context, strict=strict)  # type:ignore
+        return cls.model_validate(
+            tool_call, context=validation_context, strict=strict
+        )  # type:ignore
 
     @classmethod
     def parse_anthropic_json(

--- a/instructor/retry.py
+++ b/instructor/retry.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 
 import logging
 
-from anthropic.types import Usage as AnthropicUsage
 from openai.types.chat import ChatCompletion
 from instructor.mode import Mode
 from instructor.process_response import process_response, process_response_async
@@ -135,6 +134,8 @@ def retry_sync(
 ) -> T_Model:
     total_usage = CompletionUsage(completion_tokens=0, prompt_tokens=0, total_tokens=0)
     if mode in {Mode.ANTHROPIC_TOOLS, Mode.ANTHROPIC_JSON}:
+        from anthropic.types import Usage as AnthropicUsage
+
         total_usage = AnthropicUsage(input_tokens=0, output_tokens=0)
 
     # If max_retries is int, then create a Retrying object
@@ -198,6 +199,8 @@ async def retry_async(
 ) -> T:
     total_usage = CompletionUsage(completion_tokens=0, prompt_tokens=0, total_tokens=0)
     if mode in {Mode.ANTHROPIC_TOOLS, Mode.ANTHROPIC_JSON}:
+        from anthropic.types import Usage as AnthropicUsage
+
         total_usage = AnthropicUsage(input_tokens=0, output_tokens=0)
 
     # If max_retries is int, then create a AsyncRetrying object

--- a/instructor/retry.py
+++ b/instructor/retry.py
@@ -241,7 +241,7 @@ async def retry_async(
                     raise InstructorRetryException(
                         e,
                         last_completion=response,
-                        n_attempts=e.attempt_number,
+                        n_attempts=attempt.retry_state.attempt_number,
                         messages=kwargs["messages"],
                         total_usage=total_usage,
                     ) from e
@@ -250,7 +250,7 @@ async def retry_async(
         raise InstructorRetryException(
             e,
             last_completion=response,
-            n_attempts=e.attempt_number,
+            n_attempts=attempt.retry_state.attempt_number,
             messages=kwargs["messages"],
             total_usage=total_usage,
         ) from e

--- a/instructor/utils.py
+++ b/instructor/utils.py
@@ -4,7 +4,6 @@ import inspect
 import json
 from typing import Callable, Generator, Iterable, AsyncGenerator, TypeVar
 
-from anthropic.types import Usage as AnthropicUsage
 from pydantic import BaseModel
 from openai.types import CompletionUsage as OpenAIUsage
 from openai.types.chat import (
@@ -100,10 +99,18 @@ def update_total_usage(response: T_Model, total_usage) -> T_Model | ChatCompleti
         total_usage.prompt_tokens += response_usage.prompt_tokens or 0
         total_usage.total_tokens += response_usage.total_tokens or 0
         response.usage = total_usage  # Replace each response usage with the total usage
-    elif isinstance(response_usage, AnthropicUsage):
-        total_usage.input_tokens += response_usage.input_tokens or 0
-        total_usage.output_tokens += response_usage.output_tokens or 0
-        response.usage = total_usage
+
+    # Anthropic usage
+    try:
+        from anthropic.types import Usage as AnthropicUsage
+
+        if isinstance(response_usage, AnthropicUsage):
+            total_usage.input_tokens += response_usage.input_tokens or 0
+            total_usage.output_tokens += response_usage.output_tokens or 0
+            response.usage = total_usage
+    except ImportError:
+        pass
+
     return response
 
 

--- a/instructor/utils.py
+++ b/instructor/utils.py
@@ -1,8 +1,8 @@
-import logging
 from __future__ import annotations
 
 import inspect
 import json
+import logging
 from typing import Callable, Generator, Iterable, AsyncGenerator, TypeVar
 
 from pydantic import BaseModel

--- a/instructor/utils.py
+++ b/instructor/utils.py
@@ -1,3 +1,4 @@
+import logging
 from __future__ import annotations
 
 import inspect
@@ -12,6 +13,7 @@ from openai.types.chat import (
     ChatCompletionMessageParam,
 )
 
+logger = logging.getLogger("instructor")
 T_Model = TypeVar("T_Model", bound=BaseModel)
 
 from enum import Enum
@@ -99,6 +101,7 @@ def update_total_usage(response: T_Model, total_usage) -> T_Model | ChatCompleti
         total_usage.prompt_tokens += response_usage.prompt_tokens or 0
         total_usage.total_tokens += response_usage.total_tokens or 0
         response.usage = total_usage  # Replace each response usage with the total usage
+        return response
 
     # Anthropic usage
     try:
@@ -108,9 +111,11 @@ def update_total_usage(response: T_Model, total_usage) -> T_Model | ChatCompleti
             total_usage.input_tokens += response_usage.input_tokens or 0
             total_usage.output_tokens += response_usage.output_tokens or 0
             response.usage = total_usage
+            return response
     except ImportError:
         pass
 
+    logger.debug("No compatible response.usage found, token usage not updated.")
     return response
 
 


### PR DESCRIPTION
This PR fixes two issues with the current implementation:
- In `ANTHROPIC_TOOLS` mode when Claude didn't provide a tool invocation, an index error occurs
- `utils.update_total_usage` only works with OpenAI's `ChatCompletion`, so Anthropic's message usage doesn't update

<!--
ELLIPSIS_HIDDEN
-->


----

| :rocket: This description was created by [Ellipsis](https://www.ellipsis.dev) for commit 7ceb1b5fa28bca972bd4d882c27b57e8b9eee1f3  | 
|--------|

### Summary:
This PR fixes issues related to Anthropic's usage and tools, updates the `update_total_usage` function to work with Anthropic's message usage, and adds a test case for retry error scenario.

**Key points**:
- Fixed index error in `parse_anthropic_tools` function in `function_calls.py` when there are no tool calls.
- Updated `update_total_usage` function in `utils.py` to work with Anthropic's message usage.
- Modified `retry.py` to handle cases when there is no tool invocation.
- Added a test case in `test_simple.py` to test the retry error scenario.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)



<!--
ELLIPSIS_HIDDEN
-->
