### PR TITLE
fix typo about Enum 'and' → 'an'

### DIFF
--- a/docs/concepts/enums.md
+++ b/docs/concepts/enums.md
@@ -20,7 +20,7 @@ class UserDetail(BaseModel):
     )
 ```
 
-If you're having a hard time with `Enum` and alternative is to use `Literal` instead.
+If you're having a hard time with `Enum` an alternative is to use `Literal` instead.
 
 ```python hl_lines="4"
 from typing import Literal

--- a/docs/concepts/prompting.md
+++ b/docs/concepts/prompting.md
@@ -115,7 +115,7 @@ class UserDetail(BaseModel):
     )
 ```
 
-If you're having a hard time with `Enum` and alternative is to use `Literal`
+If you're having a hard time with `Enum` an alternative is to use `Literal`
 
 ```python hl_lines="4"
 from typing import Literal


### PR DESCRIPTION
Fixed typo in 2 lines

<!--
ELLIPSIS_HIDDEN
-->


----

| :rocket: This description was created by [Ellipsis](https://www.ellipsis.dev) for commit 1fd0e1d0143c68c2bd759762948b38e8ed28181d  | 
|--------|

### Summary:
This PR corrects a typo in two documentation files, changing 'and' to 'an' in a sentence about using `Enum` and `Literal`.

**Key points**:
- Fixed a typo in `/docs/concepts/enums.md`
- Fixed the same typo in `/docs/concepts/prompting.md`


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)



<!--
ELLIPSIS_HIDDEN
-->
