### PR TITLE
Avoid deprecated class property stacking

### DIFF
--- a/.ruff.toml
+++ b/.ruff.toml
@@ -55,7 +55,7 @@ unfixable = [
 ]
 ignore-init-module-imports = true
 
-[extend-per-file-ignores]
+[lint.extend-per-file-ignores]
 "instructor/distil.py" = ["ARG002"]
 "tests/test_distil.py" = ["ARG001"]
 "tests/test_patch.py" = ["ARG001"]

--- a/instructor/function_calls.py
+++ b/instructor/function_calls.py
@@ -20,7 +20,7 @@ class OpenAISchema(BaseModel):
     model_config = ConfigDict(ignored_types=(classproperty,))
 
     @classproperty
-    def openai_schema(self) -> dict[str, Any]:
+    def openai_schema(cls) -> dict[str, Any]:
         """
         Return the schema in the format of OpenAI's schema as jsonschema
 
@@ -30,8 +30,8 @@ class OpenAISchema(BaseModel):
         Returns:
             model_json_schema (dict): A dictionary in the format of OpenAI's schema as jsonschema
         """
-        schema = self.model_json_schema()
-        docstring = parse(self.__doc__ or "")
+        schema = cls.model_json_schema()
+        docstring = parse(cls.__doc__ or "")
         parameters = {
             k: v for k, v in schema.items() if k not in ("title", "description")
         }
@@ -51,7 +51,7 @@ class OpenAISchema(BaseModel):
                 schema["description"] = docstring.short_description
             else:
                 schema["description"] = (
-                    f"Correctly extracted `{self.__name__}` with all "
+                    f"Correctly extracted `{cls.__name__}` with all "
                     f"the required parameters with correct types"
                 )
 
@@ -62,11 +62,11 @@ class OpenAISchema(BaseModel):
         }
 
     @classproperty
-    def anthropic_schema(self) -> dict[str, Any]:
+    def anthropic_schema(cls) -> dict[str, Any]:
         return {
-            "name": self.openai_schema["name"],
-            "description": self.openai_schema["description"],
-            "input_schema": self.model_json_schema(),
+            "name": cls.openai_schema["name"],
+            "description": cls.openai_schema["description"],
+            "input_schema": cls.model_json_schema(),
         }
 
     @classmethod

--- a/instructor/utils.py
+++ b/instructor/utils.py
@@ -3,7 +3,15 @@ from __future__ import annotations
 import inspect
 import json
 import logging
-from typing import Callable, Generator, Iterable, AsyncGenerator, Protocol, TypeVar
+from typing import (
+    Callable,
+    Generator,
+    Generic,
+    Iterable,
+    AsyncGenerator,
+    Protocol,
+    TypeVar,
+)
 from openai.types.completion_usage import CompletionUsage
 from anthropic.types import Usage as AnthropicUsage
 from typing import Any
@@ -15,6 +23,7 @@ from openai.types.chat import (
 )
 
 logger = logging.getLogger("instructor")
+R_co = TypeVar("R_co", covariant=True)
 T_Model = TypeVar("T_Model", bound="Response")
 
 from enum import Enum
@@ -179,3 +188,24 @@ def merge_consecutive_messages(messages: list[dict[str, Any]]) -> list[dict[str,
             )
 
     return new_messages
+
+
+class classproperty(Generic[R_co]):
+    """Descriptor for class-level properties.
+
+    Examples:
+        >>> from instructor.utils import classproperty
+
+        >>> class MyClass:
+        ...     @classproperty
+        ...     def my_property(cls):
+        ...         return cls
+
+        >>> assert MyClass.my_property
+    """
+
+    def __init__(self, method: Callable[[Any], R_co]) -> None:
+        self.cproperty = method
+
+    def __get__(self, instance: object, cls: type[Any]) -> R_co:
+        return self.cproperty(cls)

--- a/instructor/utils.py
+++ b/instructor/utils.py
@@ -5,13 +5,11 @@ import json
 import logging
 from typing import (
     Callable,
-    Generator,
     Generic,
-    Iterable,
-    AsyncGenerator,
     Protocol,
     TypeVar,
 )
+from collections.abc import Generator, Iterable, AsyncGenerator
 from typing import Callable, Protocol, TypeVar
 from collections.abc import Generator, Iterable, AsyncGenerator
 from openai.types.completion_usage import CompletionUsage

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -100,4 +100,3 @@ typeCheckingMode = "strict"
 # Allow "redundant" runtime type-checking.
 reportUnnecessaryIsInstance = "none"
 reportUnnecessaryTypeIgnoreComment = "error"
-reportDeprecated = "warning"

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,6 +1,7 @@
 import json
 import pytest
 from instructor.utils import (
+    classproperty,
     extract_json_from_codeblock,
     extract_json_from_stream,
     extract_json_from_stream_async,
@@ -170,3 +171,23 @@ def test_merge_consecutive_messages_single():
         {"role": "user", "content": [{"type": "text", "text": "Hello"}]},
         {"role": "assistant", "content": [{"type": "text", "text": "Hello"}]},
     ]
+
+
+def test_classproperty():
+    """Test custom `classproperty` descriptor."""
+
+    class MyClass:
+        @classproperty
+        def my_property(cls):
+            return cls
+
+    assert MyClass.my_property is MyClass
+
+    class MyClass:
+        clvar = 1
+
+        @classproperty
+        def my_property(cls):
+            return cls.clvar
+
+    assert MyClass.my_property == 1


### PR DESCRIPTION
This PR removes stacking of `property` and `classmethod`, which is currently deprecated, and to be removed in Python 3.13. We simply create a custom `classmethod` decorator, which can replace this functionality as is.

<!--
ELLIPSIS_HIDDEN
-->


----

| :rocket: This description was created by [Ellipsis](https://www.ellipsis.dev) for commit 3e00eaa03f950e1207caf72351ee0beeb96bdf80  | 
|--------|

### Summary:
Introduces a custom `classproperty` decorator to replace deprecated stacking of `property` and `classmethod`, ensuring compatibility with future Python versions.

**Key points**:
- Introduced `classproperty` to replace deprecated stacking of `property` and `classmethod`.
- Modified `OpenAISchema` in `/instructor/function_calls.py` to use `classproperty`.
- Defined `classproperty` in `/instructor/utils.py` with a detailed docstring.
- Added tests for `classproperty` in `/tests/test_utils.py`.
- Updated `.ruff.toml` and `pyproject.toml` for configuration changes.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)



<!--
ELLIPSIS_HIDDEN
-->
