### PR TITLE
Import typing related imports only when type checking

### DIFF
--- a/instructor/utils.py
+++ b/instructor/utils.py
@@ -15,16 +15,16 @@ from typing import Callable, Protocol, TypeVar
 from collections.abc import Generator, Iterable, AsyncGenerator
 from typing import Any
 
+from openai.types import CompletionUsage as OpenAIUsage
 from openai.types.chat import (
     ChatCompletion,
     ChatCompletionMessage,
     ChatCompletionMessageParam,
 )
+from openai.types.completion_usage import CompletionUsage
 
 if TYPE_CHECKING:
     from anthropic.types import Usage as AnthropicUsage
-    from openai.types import CompletionUsage as OpenAIUsage
-    from openai.types.completion_usage import CompletionUsage
 
 
 logger = logging.getLogger("instructor")

--- a/instructor/utils.py
+++ b/instructor/utils.py
@@ -4,6 +4,7 @@ import inspect
 import json
 import logging
 from typing import (
+    TYPE_CHECKING,
     Callable,
     Generic,
     Protocol,
@@ -12,15 +13,19 @@ from typing import (
 from collections.abc import Generator, Iterable, AsyncGenerator
 from typing import Callable, Protocol, TypeVar
 from collections.abc import Generator, Iterable, AsyncGenerator
-from openai.types.completion_usage import CompletionUsage
-from anthropic.types import Usage as AnthropicUsage
 from typing import Any
-from openai.types import CompletionUsage as OpenAIUsage
+
 from openai.types.chat import (
     ChatCompletion,
     ChatCompletionMessage,
     ChatCompletionMessageParam,
 )
+
+if TYPE_CHECKING:
+    from anthropic.types import Usage as AnthropicUsage
+    from openai.types import CompletionUsage as OpenAIUsage
+    from openai.types.completion_usage import CompletionUsage
+
 
 logger = logging.getLogger("instructor")
 R_co = TypeVar("R_co", covariant=True)

--- a/instructor/utils.py
+++ b/instructor/utils.py
@@ -3,17 +3,15 @@ from __future__ import annotations
 import inspect
 import json
 import logging
+from collections.abc import AsyncGenerator, Generator, Iterable
 from typing import (
     TYPE_CHECKING,
+    Any,
     Callable,
     Generic,
     Protocol,
     TypeVar,
 )
-from collections.abc import Generator, Iterable, AsyncGenerator
-from typing import Callable, Protocol, TypeVar
-from collections.abc import Generator, Iterable, AsyncGenerator
-from typing import Any
 
 from openai.types import CompletionUsage as OpenAIUsage
 from openai.types.chat import (

--- a/instructor/utils.py
+++ b/instructor/utils.py
@@ -21,7 +21,6 @@ from openai.types.chat import (
     ChatCompletionMessage,
     ChatCompletionMessageParam,
 )
-from openai.types.completion_usage import CompletionUsage
 
 if TYPE_CHECKING:
     from anthropic.types import Usage as AnthropicUsage
@@ -115,12 +114,10 @@ async def extract_json_from_stream_async(
 
 def update_total_usage(
     response: T_Model,
-    total_usage: CompletionUsage | AnthropicUsage,
+    total_usage: OpenAIUsage | AnthropicUsage,
 ) -> T_Model | ChatCompletion:
     response_usage = getattr(response, "usage", None)
-    if isinstance(response_usage, OpenAIUsage) and isinstance(
-        total_usage, CompletionUsage
-    ):
+    if isinstance(response_usage, OpenAIUsage) and isinstance(total_usage, OpenAIUsage):
         total_usage.completion_tokens += response_usage.completion_tokens or 0
         total_usage.prompt_tokens += response_usage.prompt_tokens or 0
         total_usage.total_tokens += response_usage.total_tokens or 0


### PR DESCRIPTION
Import anthropic types in `utils.py` only if `typing.TYPE_CHECKING` is true.

This also resolves the issue of `ModuleNotFoundError: No module named 'anthropic'` if anthropic is not installed nor used.

### Minor tweaks
- Remove duplicate `openai.types.CompletionUsage` (same as from `openai.types.completion_usage import CompletionUsage`)
- Sort and remove other duplicate imports

<!--
ELLIPSIS_HIDDEN
-->


----

| :rocket: This description was created by [Ellipsis](https://www.ellipsis.dev) for commit 2162b3b2e48cb8b79bf4effc020c326406ac2af5  | 
|--------|

### Summary:
Conditionally imports type hints in `instructor/utils.py` to prevent runtime errors and ensure type checking enhancements.

**Key points**:
- Modified `instructor/utils.py` to conditionally import `anthropic.types.Usage`, `openai.types.CompletionUsage`, and `openai.types.completion_usage.CompletionUsage` using `TYPE_CHECKING`.
- Resolves `ModuleNotFoundError` for `anthropic` when not installed.
- Ensures type hints are available for static analysis without affecting runtime.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)



<!--
ELLIPSIS_HIDDEN
-->
