### PR TITLE
fix: Update llama-cpp-python examples to use `patch` instead of `from_openai`

### DIFF
--- a/docs/blog/posts/open_source.md
+++ b/docs/blog/posts/open_source.md
@@ -104,7 +104,7 @@ llama = llama_cpp.Llama(
 )
 
 
-create = instructor.from_openai(
+create = instructor.patch(
     create=llama.create_chat_completion_openai_v1,
     mode=instructor.Mode.JSON_SCHEMA, 
 )

--- a/docs/hub/llama-cpp-python.md
+++ b/docs/hub/llama-cpp-python.md
@@ -59,7 +59,7 @@ llama = llama_cpp.Llama(
 )
 
 
-create = instructor.from_openai(
+create = instructor.patch(
     create=llama.create_chat_completion_openai_v1,
     mode=instructor.Mode.JSON_SCHEMA,  # (2)!
 )


### PR DESCRIPTION


<!--
ELLIPSIS_HIDDEN
-->




| :rocket: This description was created by [Ellipsis](https://www.ellipsis.dev) for commit 54105fede6571b3b6285add926ea684954054726  | 
|--------|

### Summary:
This PR updates the method used in llama-cpp-python examples from `from_openai` to `patch` in two documentation files.

**Key points**:
- Updated method from `from_openai` to `patch` in `llama-cpp-python` examples.
- Affected files: `/docs/blog/posts/open_source.md`, `/docs/hub/llama-cpp-python.md`.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)



<!--
ELLIPSIS_HIDDEN
-->
