### PR TITLE
fix: remove URLs in pydantic error messages

### DIFF
--- a/instructor/__init__.py
+++ b/instructor/__init__.py
@@ -1,7 +1,6 @@
 import importlib.util
 
 from .mode import Mode
-from .utils import set_env_variable
 from .process_response import handle_response_model
 from .distil import FinetuneFormat, Instructions
 from .dsl import (
@@ -23,7 +22,6 @@ from .client import (
     Provider,
 )
 
-set_env_variable()
 
 __all__ = [
     "Instructor",

--- a/instructor/__init__.py
+++ b/instructor/__init__.py
@@ -1,6 +1,7 @@
 import importlib.util
 
 from .mode import Mode
+from .utils import set_env_variable
 from .process_response import handle_response_model
 from .distil import FinetuneFormat, Instructions
 from .dsl import (
@@ -22,6 +23,7 @@ from .client import (
     Provider,
 )
 
+set_env_variable()
 
 __all__ = [
     "Instructor",

--- a/instructor/utils.py
+++ b/instructor/utils.py
@@ -230,6 +230,10 @@ class classproperty(Generic[R_co]):
         return self.cproperty(cls)
 
 
+def disable_pydantic_error_url():
+    os.environ["PYDANTIC_ERRORS_INCLUDE_URL"] = "0"
+
+
 def transform_to_gemini_prompt(
     messages_chatgpt: list[ChatCompletionMessageParam],
 ) -> list[dict[str, Any]]:
@@ -250,7 +254,3 @@ def transform_to_gemini_prompt(
         messages_gemini[0]["parts"].insert(0, f"*{system_prompt}*")
 
     return messages_gemini
-
-
-def set_env_variable():
-    os.environ["PYDANTIC_ERRORS_INCLUDE_URL"] = "0"

--- a/instructor/utils.py
+++ b/instructor/utils.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import inspect
+import os
 import json
 import logging
 from collections.abc import AsyncGenerator, Generator, Iterable
@@ -249,3 +250,7 @@ def transform_to_gemini_prompt(
         messages_gemini[0]["parts"].insert(0, f"*{system_prompt}*")
 
     return messages_gemini
+
+
+def set_env_variable():
+    os.environ["PYDANTIC_ERRORS_INCLUDE_URL"] = "0"

--- a/tests/test_function_calls.py
+++ b/tests/test_function_calls.py
@@ -8,6 +8,7 @@ from pydantic import BaseModel, ValidationError
 import instructor
 from instructor import OpenAISchema, openai_schema
 from instructor.exceptions import IncompleteOutputException
+from instructor.utils import disable_pydantic_error_url
 
 T = TypeVar("T")
 
@@ -190,12 +191,13 @@ def test_control_characters_allowed_in_anthropic_json_non_strict_mode(
 
 def test_pylance_url_config() -> None:
     class Model(BaseModel):
-        list_of_ints: List[int] = None
-        a_float: float = None
+        list_of_ints: list[int]
+        a_float: float
 
+    disable_pydantic_error_url()
     data = dict(list_of_ints=["1", 2, "bad"], a_float="Not a float")
 
     try:
-        Model(**data)
+        Model(**data)  # type: ignore
     except ValidationError as e:
         assert "https://errors.pydantic.dev" not in str(e)

--- a/tests/test_function_calls.py
+++ b/tests/test_function_calls.py
@@ -1,4 +1,4 @@
-from typing import TypeVar
+from typing import TypeVar, List
 
 import pytest
 from anthropic.types import Message, Usage
@@ -186,3 +186,16 @@ def test_control_characters_allowed_in_anthropic_json_non_strict_mode(
         mock_anthropic_message, mode=instructor.Mode.ANTHROPIC_JSON, strict=False
     )
     assert test_model_instance.data == "Claude likes\ncontrol\ncharacters"
+
+
+def test_pylance_url_config() -> None:
+    class Model(BaseModel):
+        list_of_ints: List[int] = None
+        a_float: float = None
+
+    data = dict(list_of_ints=["1", 2, "bad"], a_float="Not a float")
+
+    try:
+        Model(**data)
+    except ValidationError as e:
+        assert "https://errors.pydantic.dev" not in str(e)

--- a/tests/test_function_calls.py
+++ b/tests/test_function_calls.py
@@ -1,8 +1,8 @@
-from typing import TypeVar, List
+from typing import TypeVar
 
 import pytest
 from anthropic.types import Message, Usage
-from openai.resources.chat.completions import ChatCompletion
+from openai.types.chat.chat_completion import ChatCompletion
 from pydantic import BaseModel, ValidationError
 
 import instructor


### PR DESCRIPTION
Fixes #509

Pydantic includes error URLs in ValidationErrors which means extra tokens used in LLM calls.

Pydantic relies on an environment variable to control this setting and is on by default. https://github.com/pydantic/pydantic-core/blob/e1fc99dd3207157aad77defc20ab6873fd268b5b/python/pydantic_core/_pydantic_core.pyi#L818

This change sets the environment variable dynamically when the package is invoked.

<!--
ELLIPSIS_HIDDEN
-->


----

| :rocket: This description was created by [Ellipsis](https://www.ellipsis.dev) for commit 5c2a35961c141c39afd1c83286195548dbf86b24  | 
|--------|

### Summary:
This PR sets an environment variable to remove URLs from Pydantic error messages and includes a test to verify the change.

**Key points**:
- Set `PYDANTIC_ERRORS_INCLUDE_URL` to `0` in `set_env_variable` in `/instructor/utils.py`
- Call `set_env_variable` in `/instructor/__init__.py`
- Add test in `/tests/test_function_calls.py` to verify URLs are not in Pydantic error messages


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)



<!--
ELLIPSIS_HIDDEN
-->
