### PR TITLE
Added gpt-4o to model costs and model names

### DIFF
--- a/instructor/_types/_alias.py
+++ b/instructor/_types/_alias.py
@@ -3,6 +3,7 @@ from typing import Literal
 from typing_extensions import TypeAlias
 
 ModelNames: TypeAlias = Literal[
+    "gpt-4o",
     "gpt-4-0125-preview",
     "gpt-4-turbo-preview",
     "gpt-4-1106-preview",

--- a/instructor/cli/usage.py
+++ b/instructor/cli/usage.py
@@ -49,6 +49,7 @@ async def get_usage_for_past_n_days(n_days: int) -> list[dict[str, Any]]:
 
 # Define the cost per unit for each model
 MODEL_COSTS = {
+    "gpt-4o": {"prompt": 0.005 / 1000, "completion": 0.015 / 1000},
     "gpt-4-0125-preview": {"prompt": 0.01 / 1000, "completion": 0.03 / 1000},
     "gpt-4-turbo-preview": {"prompt": 0.01 / 1000, "completion": 0.03 / 1000},
     "gpt-4-1106-preview": {"prompt": 0.01 / 1000, "completion": 0.03 / 1000},


### PR DESCRIPTION
Added gpt-4o to model costs and model names.

<!--
ELLIPSIS_HIDDEN
-->


----

| :rocket: This description was created by [Ellipsis](https://www.ellipsis.dev) for commit d5556d8dc81da3d3801e804ff2ccde27fb52088f  | 
|--------|

### Summary:
Added the model 'gpt-4o' to recognized models and defined its cost structure in the codebase.

**Key points**:
- Added `gpt-4o` to `ModelNames` type alias in `instructor/_types/_alias.py`.
- Defined cost per unit for `gpt-4o` in `MODEL_COSTS` in `instructor/cli/usage.py`.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)



<!--
ELLIPSIS_HIDDEN
-->
