### PR TITLE
Fix handling of snapshot_ids ("gpt-4-turbo-2024-04-09" and "gpt-4o-2024-05-13") and alias "gpt-4-turbo".

### DIFF
--- a/instructor/cli/usage.py
+++ b/instructor/cli/usage.py
@@ -50,6 +50,9 @@ async def get_usage_for_past_n_days(n_days: int) -> list[dict[str, Any]]:
 # Define the cost per unit for each model
 MODEL_COSTS = {
     "gpt-4o": {"prompt": 0.005 / 1000, "completion": 0.015 / 1000},
+    "gpt-4o-2024-05-13": {"prompt": 0.005 / 1000, "completion": 0.015 / 1000},
+    "gpt-4-turbo": {"prompt": 0.01 / 1000, "completion": 0.03 / 1000},
+    "gpt-4-turbo-2024-04-09": {"prompt": 0.01 / 1000, "completion": 0.03 / 1000},
     "gpt-4-0125-preview": {"prompt": 0.01 / 1000, "completion": 0.03 / 1000},
     "gpt-4-turbo-preview": {"prompt": 0.01 / 1000, "completion": 0.03 / 1000},
     "gpt-4-1106-preview": {"prompt": 0.01 / 1000, "completion": 0.03 / 1000},

--- a/instructor/cli/usage.py
+++ b/instructor/cli/usage.py
@@ -87,6 +87,8 @@ def get_model_cost(
         return MODEL_COSTS["gpt-3.5-turbo"]
     elif model.startswith("gpt-4-32k"):
         return MODEL_COSTS["gpt-4-32k"]
+    elif model.startswith("gpt-4o"):
+        return MODEL_COSTS["gpt-4o"]
     elif model.startswith("gpt-4"):
         return MODEL_COSTS["gpt-4"]
     else:

--- a/instructor/cli/usage.py
+++ b/instructor/cli/usage.py
@@ -85,6 +85,8 @@ def get_model_cost(
         return MODEL_COSTS["gpt-3.5-turbo-16k"]
     elif model.startswith("gpt-3.5-turbo"):
         return MODEL_COSTS["gpt-3.5-turbo"]
+    elif model.startswith("gpt-4-turbo"):
+        return MODEL_COSTS["gpt-4-turbo-preview"]
     elif model.startswith("gpt-4-32k"):
         return MODEL_COSTS["gpt-4-32k"]
     elif model.startswith("gpt-4o"):


### PR DESCRIPTION
Currently snapshots "gpt-4o-2024-05-13" and "gpt-4-turbo-2024-04-09" wrongfully return model costs for "gpt-4".
The same is the case for "gpt-4-turbo", which is inconsistent with the OpenAI API that has "gpt-4-turbo" pointing to "gpt-4-turbo-2024-04-09" (https://platform.openai.com/docs/models/gpt-4-turbo-and-gpt-4).

These commits would fix these issue for now. However, if OpenAI decides to change pricing so that "gpt-4-turbo-2024-04-09" and "gpt-4-turbo-preview" (pointing to "gpt-4-0125-preview") will differ in cost, the logic will not hold. I suggest adding costs for each snapshot_id and adding tests to ensure that they are correct. 

If you agree, I'd be more than happy to prepare a PR.

<!--
ELLIPSIS_HIDDEN
-->


----

| :rocket: This description was created by [Ellipsis](https://www.ellipsis.dev) for commit 665596a65e11b7c859d235f0971f7dcfa4024743  | 
|--------|

### Summary:
This PR fixes incorrect cost retrieval for specific GPT-4 model snapshots and aliases, ensuring consistency with OpenAI's API.

**Key points**:
- Updated `get_model_cost` in `instructor/cli/usage.py` to correctly handle costs for `gpt-4-turbo-2024-04-09`, `gpt-4o-2024-05-13`, and alias `gpt-4-turbo`.
- Suggested future improvements for dynamic cost handling based on potential changes in OpenAI's pricing.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)



<!--
ELLIPSIS_HIDDEN
-->
