### PR TITLE
Update mode.py to warn in `Mode.FUNCTIONS` access vs. in `__new__`

### DIFF
--- a/instructor/mode.py
+++ b/instructor/mode.py
@@ -2,7 +2,18 @@ import enum
 import warnings
 
 
-class Mode(enum.Enum):
+class _WarnOnFunctionsAccessEnumMeta(enum.EnumMeta):
+    def __getattribute__(cls, name):
+        if name == "FUNCTIONS":
+            warnings.warn(
+                "FUNCTIONS is deprecated and will be removed in future versions",
+                DeprecationWarning,
+                stacklevel=2,
+            )
+        return super().__getattribute__(name)
+
+
+class Mode(enum.Enum, metaclass=_WarnOnFunctionsAccessEnumMeta):
     """The mode to use for patching the client"""
 
     FUNCTIONS = "function_call"
@@ -15,17 +26,3 @@ class Mode(enum.Enum):
     ANTHROPIC_TOOLS = "anthropic_tools"
     ANTHROPIC_JSON = "anthropic_json"
     COHERE_TOOLS = "cohere_tools"
-
-    def __new__(cls, value: str) -> "Mode":
-        member = object.__new__(cls)
-        member._value_ = value
-
-        # Deprecation warning for FUNCTIONS
-        if value == "function_call":
-            warnings.warn(
-                "FUNCTIONS is deprecated and will be removed in future versions",
-                DeprecationWarning,
-                stacklevel=2,
-            )
-
-        return member


### PR DESCRIPTION
Currently, any import of `instructor` raises a `DeprecationWarning`. This is noisy and also makes it impossible to have test suites raise an error on `DeprecationWarning`. Example code:

```python3
import warnings
warnings.simplefilter("default")

import instructor  # raises `DeprecationWarning: FUNCTIONS is deprecated and will be removed in future versionss enum_member = enum_class._new_member_(enum_class, *args)`
```

<!--
ELLIPSIS_HIDDEN
-->


----

| :rocket: This description was created by [Ellipsis](https://www.ellipsis.dev) for commit 90edc70cefc2ee9f30870f5f510ad2f33ace54eb  | 
|--------|

### Summary:
This PR moves the deprecation warning for `FUNCTIONS` in `Mode` class to only trigger when accessed, reducing import-time noise.

**Key points**:
- Moved `DeprecationWarning` for `FUNCTIONS` from `__new__` to `__getattribute__` in a `Mode` metaclass.
- Reduces warning noise at import time.
- Allows better handling of `DeprecationWarning` in test suites.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)



<!--
ELLIPSIS_HIDDEN
-->


<!--
ELLIPSIS_HIDDEN
-->


----

| :rocket: This description was created by [Ellipsis](https://www.ellipsis.dev) for commit 9ef6f1aa5d17baeada3febcc5fb7ef98813d86ac  | 
|--------|

### Summary:
This PR moves the deprecation warning for `FUNCTIONS` in the `Mode` class to only trigger when accessed, reducing import-time noise.

**Key points**:
- Moved `DeprecationWarning` for `FUNCTIONS` from `__new__` to `__getattribute__` in `Mode` class using `_WarnOnFunctionsAccessEnumMeta` metaclass.
- Reduces warning noise at import time.
- Allows better handling of `DeprecationWarning` in test suites.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)



<!--
ELLIPSIS_HIDDEN
-->
