### PR TITLE
Enrich IncompleteOutputException with completion context

### DIFF
--- a/docs/concepts/usage.md
+++ b/docs/concepts/usage.md
@@ -25,3 +25,15 @@ user, completion = client.chat.completions.create_with_completion(
 print(completion.usage)
 #> CompletionUsage(completion_tokens=9, prompt_tokens=82, total_tokens=91)
 ```
+
+You can catch an IncompleteOutputException whenever the context length is exceeded and react accordingly, such as by trimming your prompt by the number of exceeding tokens.
+
+```python
+from instructor.exceptions import IncompleteOutputException
+
+try:
+    # call to your model
+except IncompleteOutputException as e:
+    token_count = e.last_completion.usage.total_tokens
+    # your logic here
+```

--- a/instructor/exceptions.py
+++ b/instructor/exceptions.py
@@ -9,6 +9,6 @@ class IncompleteOutputException(Exception):
         **kwargs,
     ):
         self.last_completion = last_completion
-        self.message = message
+        super().__init__(message, *args, **kwargs)
         super().__init__(*args, **kwargs)
 

--- a/instructor/exceptions.py
+++ b/instructor/exceptions.py
@@ -3,7 +3,12 @@ class IncompleteOutputException(Exception):
 
     def __init__(
         self,
+        *args,
+        last_completion,
         message: str = "The output is incomplete due to a max_tokens length limit.",
-    ) -> None:
+        **kwargs,
+    ):
+        self.last_completion = last_completion
         self.message = message
-        super().__init__(self.message)
+        super().__init__(*args, **kwargs)
+

--- a/instructor/exceptions.py
+++ b/instructor/exceptions.py
@@ -4,7 +4,7 @@ class IncompleteOutputException(Exception):
     def __init__(
         self,
         *args,
-        last_completion,
+        last_completion = None,
         message: str = "The output is incomplete due to a max_tokens length limit.",
         **kwargs,
     ):

--- a/instructor/function_calls.py
+++ b/instructor/function_calls.py
@@ -106,7 +106,7 @@ class OpenAISchema(BaseModel):
             return cls.parse_cohere_tools(completion, validation_context, strict)
 
         if completion.choices[0].finish_reason == "length":
-            raise IncompleteOutputException()
+            raise IncompleteOutputException(last_completion=completion)
 
         if mode == Mode.FUNCTIONS:
             return cls.parse_functions(completion, validation_context, strict)


### PR DESCRIPTION
I'm currently trying to catch exceptions related to exceeding the context length of the model and noticed a few things:
There's a dedicated exception called IncompleteOutputException but, it only outputs the message and not the last_completion as it is a case with InstructorRetryException.
This makes it difficult to handle errors related to exceeding the context length as it's unknown what was the total token count that caused the exception.
If we can modify the exception to pass the completion to IncompleteOutputException, we could retrieve the total token count with something like:
except IncompleteOutputException as e: token_count = e.last_completion.usage.total_tokens
and react accordingly e.g. cut the prompt by exceeding number of tokens.

<!--
ELLIPSIS_HIDDEN
-->


----

| :rocket: This description was created by [Ellipsis](https://www.ellipsis.dev) for commit f226089a60d4796c090f5cb977dd8294a75ea739  | 
|--------|

### Summary:
This PR enhances the `IncompleteOutputException` by including completion context, improving error handling capabilities.

**Key points**:
- Modified `IncompleteOutputException` in `instructor/exceptions.py` to include `last_completion` parameter.
- Updated `from_response` method in `instructor/function_calls.py` to raise `IncompleteOutputException` with `last_completion`.
- Allows retrieval of token count causing the exception for better error handling.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)



<!--
ELLIPSIS_HIDDEN
-->
