### PR TITLE
maybe results typo fix

### DIFF
--- a/instructor/dsl/maybe.py
+++ b/instructor/dsl/maybe.py
@@ -56,7 +56,7 @@ def Maybe(model: type[T]) -> type[MaybeBase[T]]:
     return create_model(
         f"Maybe{model.__name__}",
         __base__=MaybeBase,
-        reuslts=(
+        results=(
             Optional[model],
             Field(
                 default=None,


### PR DESCRIPTION
The maybe feature was not populating the results, which fixing the typo rectified.

<!--
ELLIPSIS_HIDDEN
-->


----

| :rocket: This description was created by [Ellipsis](https://www.ellipsis.dev) for commit 54c110fd520cfce189deaf81b278234d0ec888de  | 
|--------|

### Summary:
Fixed a typo in the `Maybe` function of `instructor/dsl/maybe.py` that prevented the 'results' field from being populated correctly.

**Key points**:
- Fixed typo in `instructor/dsl/maybe.py`.
- Changed 'reuslts' to 'results' in `Maybe` function.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)



<!--
ELLIPSIS_HIDDEN
-->
