### PR TITLE
results rename

### DIFF
--- a/instructor/dsl/maybe.py
+++ b/instructor/dsl/maybe.py
@@ -56,7 +56,7 @@ def Maybe(model: type[T]) -> type[MaybeBase[T]]:
     return create_model(
         f"Maybe{model.__name__}",
         __base__=MaybeBase,
-        results=(
+        result=(
             Optional[model],
             Field(
                 default=None,


### PR DESCRIPTION
Field changed from 'results' to 'result' to fit with the doc strings. It was very hit or miss as to whether the calls returned any results, but it returns results each time after the change. 

<!--
ELLIPSIS_HIDDEN
-->


----

| :rocket: This description was created by [Ellipsis](https://www.ellipsis.dev) for commit 4b3ebe04adb7566a41d5664fef48e448cea700fa  | 
|--------|

### Summary:
Renamed a field in the `Maybe` model to align with documentation and improve consistency.

**Key points**:
- Renamed field from `results` to `result` in `Maybe` model within `instructor/dsl/maybe.py`.
- Updated field definition in `create_model` function.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)



<!--
ELLIPSIS_HIDDEN
-->
