### PR TITLE
Fix failure checking for "google.generativeai' import spec

### DIFF
--- a/instructor/__init__.py
+++ b/instructor/__init__.py
@@ -52,7 +52,7 @@ if importlib.util.find_spec("anthropic") is not None:
 
     __all__ += ["from_anthropic"]
 
-if importlib.util.find_spec("google.generativeai") is not None:
+if importlib.util.find_spec("google") and importlib.util.find_spec("google.generativeai") is not None:
     from .client_gemini import from_gemini
 
     __all__ += ["from_gemini"]


### PR DESCRIPTION
Fixes https://github.com/jxnl/instructor/issues/697

**Describe the bug**

On Instructor version 1.3.0, the `__init__.py` file tries to use the `importlib.util.find_spec("google.generativeai")`. `google-generativeai` is an optional dependency, so I do not have the `google` parent package installed.

[Git blame
link](https://github.com/jxnl/instructor/blame/92d0271af27c9107954c78005e16f10c4a1d2161/instructor/__init__.py#L55)

**To Reproduce**

Install the latest version to a new virtualenv, then in a Python repl:

```
import instructor

```

You can verify the problem:

```
import importlib

assert importlib.util.find_spec('google') is None

found_err = False
try:
    importlib.util.find_spec('google.generativeai')
except ModuleNotFoundError:
    found_err = True
assert found_err
```

**Expected behavior**

We should not need any optional dependencies installed to use the package.

<!--
ELLIPSIS_HIDDEN
-->


----

| :rocket: This description was created by [Ellipsis](https://www.ellipsis.dev) for commit 5b4507ef0d8ebf44b4ee2de2e9b16ec5ae799b8b  | 
|--------|

### Summary:
Fixes a bug in `instructor/__init__.py` to prevent errors when optional dependency 'google.generativeai' is not installed.

**Key points**:
- Updated import check in `instructor/__init__.py` to ensure 'google' package is present before checking for 'google.generativeai'.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)



<!--
ELLIPSIS_HIDDEN
-->
