### PR TITLE
restore async groq functionality

### DIFF
--- a/instructor/client_groq.py
+++ b/instructor/client_groq.py
@@ -20,7 +20,7 @@ def from_groq(
     client: groq.AsyncGroq,
     mode: instructor.Mode = instructor.Mode.TOOLS,
     **kwargs: Any,
-) -> instructor.Instructor:
+) -> instructor.AsyncInstructor:
     ...
 
 
@@ -28,7 +28,7 @@ def from_groq(
     client: groq.Groq | groq.AsyncGroq,
     mode: instructor.Mode = instructor.Mode.TOOLS,
     **kwargs: Any,
-) -> instructor.Instructor:
+) -> instructor.Instructor | instructor.AsyncInstructor:
     assert mode in {
         instructor.Mode.JSON,
         instructor.Mode.TOOLS,
@@ -48,7 +48,7 @@ def from_groq(
         )
 
     else:
-        return instructor.Instructor(
+        return instructor.AsyncInstructor(
             client=client,
             create=instructor.patch(create=client.chat.completions.create, mode=mode),
             provider=instructor.Provider.GROQ,


### PR DESCRIPTION
Restoring the ability to use Groq async. Was accidentally broken during [this refactor](https://github.com/jxnl/instructor/commit/213317da6d5fb2804449c1dda648100103b9984c). 

Tested it locally and groq requests now trigger in parallel (assuming one passed in `AsyncGroq`). Using sync `Groq` works the same. 

<!--
ELLIPSIS_HIDDEN
-->


----

| :rocket: This description was created by [Ellipsis](https://www.ellipsis.dev) for commit 5d0bcf73f74882e0ab08e9f16385b9eccebdde37  | 
|--------|

### Summary:
Restores asynchronous functionality for Groq in `instructor/client_groq.py` by correctly handling `groq.AsyncGroq` clients.

**Key points**:
- Restored async functionality for Groq in `instructor/client_groq.py`.
- Updated return types in overloaded `from_groq` functions to handle `groq.AsyncGroq` correctly.
- Ensured parallel processing of Groq requests.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)



<!--
ELLIPSIS_HIDDEN
-->
