### PR TITLE
Fixed incorrect/missing arguments

### DIFF
--- a/docs/tutorials/4-validation.ipynb
+++ b/docs/tutorials/4-validation.ipynb
@@ -529,7 +529,7 @@
     "    message: Annotated[str, \n",
     "                       AfterValidator(\n",
     "                           llm_validator(\"don't talk about any other topic except health best practices and topics\", \n",
-    "                                         openai_client=client))]\n",
+    "                                         client=client))]\n",
     "\n",
     "AssistantMessage(message=\"I would suggest you to visit Sicily as they say it is very nice in winter.\")"
    ]
@@ -759,7 +759,7 @@
     "    answer: Annotated[\n",
     "        str,\n",
     "        BeforeValidator(\n",
-    "            llm_validator(\"don't say objectionable things\")\n",
+    "            llm_validator(\"don't say objectionable things\", client=client)\n",
     "        ),\n",
     "    ]\n",
     "\n",


### PR DESCRIPTION
`client` is a required argument for `llm_validator`. Fixed the incorrect `openai_client` argument and, in a second instance, the missing `client` argument.