### PR TITLE
Fix response UnboundError when request fails and custom `tenacity.Retrying` is used

### DIFF
--- a/instructor/retry.py
+++ b/instructor/retry.py
@@ -141,6 +141,7 @@ def retry_sync(
         raise ValueError("max_retries must be an int or a `tenacity.Retrying` object")
 
     try:
+        response = None
         for attempt in max_retries:
             with attempt:
                 try:
@@ -165,13 +166,7 @@ def retry_sync(
                         kwargs["messages"] = merge_consecutive_messages(
                             kwargs["messages"]
                         )
-                    raise InstructorRetryException(
-                        e,
-                        last_completion=response,
-                        n_attempts=attempt.retry_state.attempt_number,
-                        messages=kwargs.get("messages", kwargs.get("contents")),
-                        total_usage=total_usage,
-                    ) from e
+                    raise e
     except RetryError as e:
         raise InstructorRetryException(
             e,
@@ -211,6 +206,7 @@ async def retry_async(
         )
 
     try:
+        response = None
         async for attempt in max_retries:
             logger.debug(f"Retrying, attempt: {attempt}")
             with attempt:
@@ -233,13 +229,7 @@ async def retry_async(
                         kwargs["messages"] = merge_consecutive_messages(
                             kwargs["messages"]
                         )
-                    raise InstructorRetryException(
-                        e,
-                        last_completion=response,
-                        n_attempts=attempt.retry_state.attempt_number,
-                        messages=kwargs["messages"],
-                        total_usage=total_usage,
-                    ) from e
+                    raise e
     except RetryError as e:
         logger.exception(f"Failed after retries: {e.last_attempt.exception}")
         raise InstructorRetryException(

--- a/tests/llm/test_openai/test_retries.py
+++ b/tests/llm/test_openai/test_retries.py
@@ -89,3 +89,32 @@ def test_upper_case_tenacity(model, mode, client):
         max_retries=retries,
     )
     assert response.name == "JASON"
+
+
+@pytest.mark.parametrize("model, mode", product(models, modes))
+def test_custom_retry_response_error(model, mode, client):
+    client = instructor.patch(client, mode=mode)
+    client.api_key = "incorrect_key"
+
+    from openai import AuthenticationError
+    from instructor.exceptions import InstructorRetryException
+    from tenacity import Retrying, retry_if_not_exception_type, stop_after_attempt
+
+    retries = Retrying(
+        retry=retry_if_not_exception_type(ZeroDivisionError), stop=stop_after_attempt(1)
+    )
+    try:
+        client.chat.completions.create(
+            model=model,
+            max_retries=retries,
+            messages=[
+                {
+                    "role": "user",
+                    "content": "Jason is 25 years old",
+                }
+            ],
+            response_model=UserDetail,
+        )
+    except InstructorRetryException as e:
+        assert isinstance(e.__cause__.__cause__, AuthenticationError)
+        assert e.last_completion is None


### PR DESCRIPTION
This PR closes #693
It also removes `InstructorRetryException` inside `with attempts` clause as it seems redundant.

<!--
ELLIPSIS_HIDDEN
-->


----

| :rocket: This description was created by [Ellipsis](https://www.ellipsis.dev) for commit dc467ddc499c09c5b51222a8f9166b70bcb80dfa  | 
|--------|

### Summary:
This PR fixes an UnboundError by initializing `response` to `None` in retry functions and simplifies error handling by removing redundant exception raising, with added tests for verification.

**Key points**:
- Initialize `response` to `None` in `retry_sync` and `retry_async` functions in `instructor/retry.py` to prevent `UnboundError`.
- Remove redundant `InstructorRetryException` raising within retry loops, simplifying error handling.
- Update `test_openai/test_retries.py` with a new test case `test_custom_retry_response_error` to verify correct error handling with custom retry strategy.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)



<!--
ELLIPSIS_HIDDEN
-->
