### PR TITLE
[fixes #721] Switch away from Anthropic beta interface for tools.

### DIFF
--- a/instructor/client_anthropic.py
+++ b/instructor/client_anthropic.py
@@ -11,7 +11,7 @@ def from_anthropic(
     client: (
         anthropic.Anthropic | anthropic.AnthropicBedrock | anthropic.AnthropicVertex
     ),
-    mode: instructor.Mode = instructor.Mode.ANTHROPIC_JSON,
+    mode: instructor.Mode = instructor.Mode.ANTHROPIC_TOOLS,
     **kwargs: Any,
 ) -> instructor.Instructor:
     ...
@@ -24,7 +24,7 @@ def from_anthropic(
         | anthropic.AsyncAnthropicBedrock
         | anthropic.AsyncAnthropicVertex
     ),
-    mode: instructor.Mode = instructor.Mode.ANTHROPIC_JSON,
+    mode: instructor.Mode = instructor.Mode.ANTHROPIC_TOOLS,
     **kwargs: Any,
 ) -> instructor.AsyncInstructor:
     ...
@@ -39,7 +39,7 @@ def from_anthropic(
         | anthropic.AsyncAnthropicVertex
         | anthropic.AnthropicVertex
     ),
-    mode: instructor.Mode = instructor.Mode.ANTHROPIC_JSON,
+    mode: instructor.Mode = instructor.Mode.ANTHROPIC_TOOLS,
     **kwargs: Any,
 ) -> instructor.Instructor | instructor.AsyncInstructor:
     assert (
@@ -62,10 +62,7 @@ def from_anthropic(
         ),
     ), "Client must be an instance of {anthropic.Anthropic, anthropic.AsyncAnthropic, anthropic.AnthropicBedrock, anthropic.AsyncAnthropicBedrock,  anthropic.AnthropicVertex, anthropic.AsyncAnthropicVertex}"
 
-    if mode == instructor.Mode.ANTHROPIC_TOOLS:
-        create = client.beta.tools.messages.create  # type: ignore - unknown in stubs
-    else:
-        create = client.messages.create
+    create = client.messages.create
 
     if isinstance(
         client,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ pandas = { version = "^2.2.0", optional = true }
 tabulate = { version = "^0.9.0", optional = true }
 pydantic_extra_types = { version = "^2.6.0", optional = true }
 litellm = { version = "^1.35.31", optional = true }
-anthropic = { version = "^0.26.0", optional = true }
+anthropic = { version = "^0.27.0", optional = true }
 xmltodict = { version = "^0.13.0", optional = true }
 groq = { version = "^0.4.2", optional = true }
 cohere = { version = "^5.1.8", optional = true }
@@ -64,7 +64,7 @@ mkdocs-minify-plugin = "^0.8.0"
 mkdocs-redirects = "^1.2.1"
 
 [tool.poetry.group.anthropic.dependencies]
-anthropic = "^0.26.0"
+anthropic = "^0.27.0"
 
 [tool.poetry.group.test-docs.dependencies]
 fastapi = "^0.109.2"
@@ -74,7 +74,7 @@ pandas = "^2.2.0"
 tabulate = "^0.9.0"
 pydantic_extra_types = "^2.6.0"
 litellm = "^1.35.31"
-anthropic = "^0.26.0"
+anthropic = "^0.27.0"
 xmltodict = "^0.13.0"
 groq = "^0.4.2"
 phonenumbers = "^8.13.33"


### PR DESCRIPTION
This PR proposes minimal code changes to address #721.

- Use client.messages.create for create on all code paths.
- [Possibly controversial]: make ANTHROPIC_TOOLS the default mode.
  - Slight risk of breaking user code but brings library behavior more in line with chat-gpt base use case.
- Upgrade Anthropic version to 0.27, in which release tools was moved out of beta on all platforms (Main, Bedrock, Vertex). Source: https://github.com/anthropics/anthropic-sdk-python/releases/tag/v0.27.0
  - Breaking change unless people update.



<!--
ELLIPSIS_HIDDEN
-->


----

| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit 8ec50a6e67359e0f6ff705256a6d95d6f606ffbe  | 
|--------|--------|

### Summary:
This PR updates the default mode, simplifies message creation, and upgrades the `anthropic` dependency to align with the latest stable release.

**Key points**:
- Updated default mode to `ANTHROPIC_TOOLS` in `instructor/client_anthropic.py`.
- Replaced `client.beta.tools.messages.create` with `client.messages.create`.
- Updated `anthropic` dependency to `0.27.0` in `pyproject.toml`.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)



<!--
ELLIPSIS_HIDDEN
-->
