### PR TITLE
fix: parallel unions

### DIFF
--- a/instructor/dsl/parallel.py
+++ b/instructor/dsl/parallel.py
@@ -1,3 +1,4 @@
+import sys
 from typing import (
     Any,
     Optional,
@@ -44,18 +45,22 @@ class ParallelBase:
             )
 
 
+if sys.version_info >= (3, 10):
+    from types import UnionType
+    def is_union_type(typehint: type[Iterable[T]]) -> bool:
+        return get_origin(get_args(typehint)[0]) in (Union, UnionType)
+else:
+    def is_union_type(typehint: type[Iterable[T]]) -> bool:
+        return get_origin(get_args(typehint)[0]) is Union
+
+
 def get_types_array(typehint: type[Iterable[T]]) -> tuple[type[T], ...]:
     should_be_iterable = get_origin(typehint)
     if should_be_iterable is not Iterable:
         raise TypeError(f"Model should be with Iterable instead if {typehint}")
 
-    if get_origin(get_args(typehint)[0]) is Union:
-        # works for Iterable[Union[int, str]]
-        the_types = get_args(get_args(typehint)[0])
-        return the_types
-
-    if get_origin(get_args(typehint)[0]) is Union:
-        # works for Iterable[Union[int, str]]
+    if is_union_type(typehint):
+        # works for Iterable[Union[int, str]], Iterable[int | str]
         the_types = get_args(get_args(typehint)[0])
         return the_types
 


### PR DESCRIPTION
This example in the docs is broken: https://python.useinstructor.com/concepts/parallel/#parallel-tools
Trace:
```
  File ".../.pyenv/versions/3.10.12/lib/python3.10/runpy.py", line 196, in _run_module_as_main
    return _run_code(code, main_globals, None,
  File ".../.pyenv/versions/3.10.12/lib/python3.10/runpy.py", line 86, in _run_code
    exec(code, run_globals)
  File ".../git/instructor/dev/parallel.py", line 25, in <module>
    function_calls = client.chat.completions.create(
  File ".../git/instructor/instructor/client.py", line 93, in create
    return self.create_fn(
  File ".../git/instructor/instructor/patch.py", line 146, in new_create_sync
    response_model, new_kwargs = handle_response_model(
  File ".../git/instructor/instructor/process_response.py", line 201, in handle_response_model
    new_kwargs["tools"] = handle_parallel_model(response_model)
  File ".../git/instructor/instructor/dsl/parallel.py", line 69, in handle_parallel_model
    return [
  File ".../git/instructor/instructor/dsl/parallel.py", line 70, in <listcomp>
    {"type": "function", "function": openai_schema(model).openai_schema}
  File ".../git/instructor/instructor/function_calls.py", line 281, in openai_schema
    if not issubclass(cls, BaseModel):
  File ".../.pyenv/versions/3.10.12/lib/python3.10/abc.py", line 123, in __subclasscheck__
    return _abc_subclasscheck(cls, subclass)
TypeError: issubclass() arg 1 must be a class
```

Only works if using the old union syntax:
```
response_model=Iterable[Union[Weather, GoogleSearch]]
```


<!--
ELLIPSIS_HIDDEN
-->


----

| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit bf5db358989d14cbd5fc1652d8ba7d72c7fff7f9  | 
|--------|--------|

### Summary:
This PR fixes an issue with union type handling in Python 3.10+ by introducing a new compatibility function and updating related functions.

**Key points**:
- Added `is_union_type` function to handle new union syntax in Python 3.10+
- Updated `get_types_array` to support both old and new union syntaxes
- Ensured compatibility of `ParallelModel` with Python 3.10+


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)



<!--
ELLIPSIS_HIDDEN
-->
