### PR TITLE
Fix heading indentation in the getting started section of the docs

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -110,9 +110,9 @@ assert resp.name == "Jason"
 assert resp.age == 25
 ```
 
-## Using Gemini
+### Using Gemini
 
-### Google AI
+#### Google AI
 
 ```python
 import instructor
@@ -148,7 +148,7 @@ assert resp.name == "Jason"
 assert resp.age == 25
 ```
 
-### Vertex AI
+#### Vertex AI
 
 **Note**: Gemini Tool Calling is still in preview, and there are some limitations. You can learn more about them in the [Vertex AI examples notebook](../hub/vertexai.md).
 


### PR DESCRIPTION
This PR suggests a fix heading levels for getting started section. They were inconsistent across sub-sections.

It's a small fix but I noticed the inconsistency when I was reading the docs. Hope you appreciate it

**Before:**
(note how `Using Gemini` is at the same level as `Getting Started`)
![image](https://github.com/jxnl/instructor/assets/9828683/85289e9f-22d1-4e6f-aa1b-496ebe128513)

**After:**
![image](https://github.com/jxnl/instructor/assets/9828683/2b27a4ca-52a2-40b3-892a-6d794dcec1d3)


