### PR TITLE
Update vertex example

### DIFF
--- a/docs/hub/vertexai.md
+++ b/docs/hub/vertexai.md
@@ -37,17 +37,16 @@ The Vertex AI client employs a different client than OpenAI, making the patching
 
 ```python
 import instructor
-
-from pydantic import BaseModel
-import vertexai.generative_models as gm
 import vertexai
+import vertexai.generative_models as gm
+from pydantic import BaseModel
 
 vertexai.init()
 
-client = gm.GenerativeModel("gemini-1.5-pro-preview-0409")
-
 # enables `response_model` in chat call
-patched_chat = instructor.from_vertexai(client)
+client = instructor.from_vertexai(
+    client=gm.GenerativeModel("gemini-1.5-pro-preview-0409")
+)
 
 
 if __name__ == "__main__":
@@ -56,12 +55,12 @@ if __name__ == "__main__":
         name: str
         age: int
 
-    resp = patched_chat(
+    resp = client.create(
         response_model=UserDetails,
         messages=[
             {
                 "role": "user",
-                "content": f'Extract the following entities: "Jason is 20"',
+                "content": "Extract the following entities: 'Jason is 20'",
             },
         ],
     )


### PR DESCRIPTION
## Summary 
This update modifies the vertex example to use the `.create()` method instead of directly calling the `Instructor` object. The previous approach raised a `TypeError`, which a Discord user reported. 


<!-- ELLIPSIS_HIDDEN -->

----

| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit 320d67c624ef8f074e4a16f317398fd10559ee02  | 
|--------|--------|

### Summary:
Updated the Vertex AI example in `vertexai.md` to use the `.create()` method and directly initialize the `GenerativeModel` client, fixing a reported `TypeError`.

**Key points**:
- Updated `vertexai.md` to use `.create()` method.
- Initialized `GenerativeModel` client directly in `from_vertexai`.
- Fixed `TypeError` reported by Discord user.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)


<!-- ELLIPSIS_HIDDEN -->