### PR TITLE
Fix the link to use the cloudflare docs

### DIFF
--- a/instructor/cli/cli.py
+++ b/instructor/cli/cli.py
@@ -18,6 +18,6 @@ def docs(query: str = typer.Argument(None, help="Search the documentation")) -> 
     Open the instructor documentation website.
     """
     if query:
-        typer.launch(f"https://jxnl.github.io/instructor/?q={query}")
+        typer.launch(f"https://python.useinstructor.com/?q={query}")
     else:
-        typer.launch("https://jxnl.github.io/instructor")
+        typer.launch("https://python.useinstructor.com/")


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit 2931099fc19cd899d13c008ddcd4e9cb5ce9c907  | 
|--------|--------|

### Summary:
Updated the documentation URLs in the `docs` function of `instructor/cli/cli.py` to point to the new `https://python.useinstructor.com`.

**Key points**:
- Updated the documentation URL in `docs` function of `instructor/cli/cli.py`.
- Changed from `https://jxnl.github.io/instructor` to `https://python.useinstructor.com`.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)


<!-- ELLIPSIS_HIDDEN -->