### PR TITLE
typo fix and rephrasing suggestion

### DIFF
--- a/docs/tutorials/2-tips.ipynb
+++ b/docs/tutorials/2-tips.ipynb
@@ -350,7 +350,7 @@
    "source": [
     "## Defining Relationships\n",
     "\n",
-    "Now only can we define lists of users, with list of properties one of the more interesting things I've learned about prompting is that we can also easily define lists of references.\n"
+    "Not only can we define lists of users, but with lists of properties we can also easily define lists of references. It's one of the more interesting things I've learned about prompting.\n"
    ]
   },
   {


### PR DESCRIPTION
Typo fix and rephrasing suggestion for section "Defining Relationships" in the Tips and Tricks section of the Tutorials. 

https://useinstructor.com/tutorials/2-tips/#defining-relationships