### PR TITLE
Disabling Pydantic Error

### DIFF
--- a/instructor/utils.py
+++ b/instructor/utils.py
@@ -12,6 +12,7 @@ from typing import (
     Protocol,
     TypeVar,
 )
+import os
 
 from openai.types import CompletionUsage as OpenAIUsage
 from openai.types.chat import (
@@ -249,3 +250,7 @@ def transform_to_gemini_prompt(
         messages_gemini[0]["parts"].insert(0, f"*{system_prompt}*")
 
     return messages_gemini
+
+
+def disable_pydantic_error_url():
+    os.environ["PYDANTIC_ERRORS_INCLUDE_URL"] = "0"

--- a/tests/llm/test_openai/test_retries.py
+++ b/tests/llm/test_openai/test_retries.py
@@ -6,9 +6,11 @@ from itertools import product
 from .util import models, modes
 
 
-def uppercase_validator(v):
+def uppercase_validator(v: str):
     if v.islower():
-        raise ValueError("Name must be ALL CAPS, please fix this.")
+        raise ValueError(
+            "All letters in the name should be in uppercase (Eg. TOM, JONES ) instead of tom, jones"
+        )
     return v
 
 


### PR DESCRIPTION


<!-- ELLIPSIS_HIDDEN -->


| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit fde08d02c556dc9330802fce91f06321cda40e71  | 
|--------|--------|

### Summary:
Added a function to disable URLs in Pydantic error messages, updated documentation, and included tests.

**Key points**:
- Added `disable_pydantic_error_url` function in `instructor/utils.py` to disable URLs in Pydantic error messages by setting `PYDANTIC_ERRORS_INCLUDE_URL` to `0`.
- Updated `docs/concepts/reask_validation.md` with a section on optimizing token usage by disabling Pydantic error URLs.
- Added `test_pylance_url_config` in `tests/test_function_calls.py` to verify the removal of URLs from Pydantic error messages.
- Modified example in `docs/concepts/reask_validation.md` to demonstrate the usage of `disable_pydantic_error_url`.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)



<!-- ELLIPSIS_HIDDEN -->