### PR TITLE
Fixed Cohere retries

### DIFF
--- a/instructor/retry.py
+++ b/instructor/retry.py
@@ -80,7 +80,7 @@ def reask_messages(response: ChatCompletion, mode: Mode, exception: Exception):
     if mode == Mode.COHERE_TOOLS:
         yield {
             "role": "user",
-            "content": f"Validation Error found:\n{exception}\nRecall the function correctly, fix the errors",
+            "message": f"Validation Error found:\n{exception}\nRecall the function correctly, fix the errors",
         }
         return
     if mode == Mode.GEMINI_JSON:
@@ -166,6 +166,8 @@ def retry_sync(
                     logger.debug(f"Error response: {response}")
                     if mode in {Mode.GEMINI_JSON, Mode.VERTEXAI_TOOLS}:
                         kwargs["contents"].extend(reask_messages(response, mode, e))
+                    elif mode in {Mode.COHERE_TOOLS}:
+                        kwargs["chat_history"].extend(reask_messages(response, mode, e))
                     else:
                         kwargs["messages"].extend(reask_messages(response, mode, e))
                     if mode in {Mode.ANTHROPIC_TOOLS, Mode.ANTHROPIC_JSON}:


### PR DESCRIPTION
Retries did not work for Cohere client because it was not appending the right `kwargs` value for Cohere chat history and the validation error message to be appended had the wrong object definition.

Related to but not directly: https://github.com/jxnl/instructor/issues/584