### PR TITLE
Update usage.md 'constructor usage list' command documentation

### DIFF
--- a/docs/cli/usage.md
+++ b/docs/cli/usage.md
@@ -26,7 +26,7 @@ $ instructor usage --help
 To display API usage for the past 3 days, use the following command:
 
 ```sh
-$ instructor usage list -n 3
+$ instructor usage list --n 3
 ```
 
 This will output a table similar to:


### PR DESCRIPTION
Usage tracking list command is missing a '-' in its -n flag. Listing the available options with 'instructor usage list --help' will hint the correct flag is '--n' instead of '-n'