### PR TITLE
Update maybe.md

### DIFF
--- a/docs/concepts/maybe.md
+++ b/docs/concepts/maybe.md
@@ -88,8 +88,8 @@ print(user2.model_dump_json(indent=2))
 """
 {
   "result": null,
-  "error": false,
-  "message": null
+  "error": true,
+  "message": "User details could not be extracted"
 }
 """
 ```


### PR DESCRIPTION
Update Maybe pattern documentation to accurately reflect error handling behavior. "When an error occurs, the error field is set to True, and the message field contains the error message." statement is not reflected in the given example.

- Corrected the example output for `MaybeUser` to accurately set `error` to `true` and include an error message when extraction fails. 
<!-- ELLIPSIS_HIDDEN -->

----

| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit 5360a1dfd48f3fde317650641bd8986b489ac486  | 
|--------|--------|

### Summary:
Corrected the example output for `MaybeUser` in `docs/concepts/maybe.md` to accurately reflect error handling behavior.

**Key points**:
- Updated `docs/concepts/maybe.md` to correct the example output for `MaybeUser`.
- Set `error` to `true` and included an error message when extraction fails.
- Ensured documentation accurately reflects error handling behavior.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)


<!-- ELLIPSIS_HIDDEN -->