### PR TITLE
Add explicit check for jsonref dep in vertexai client import guard

### DIFF
--- a/instructor/__init__.py
+++ b/instructor/__init__.py
@@ -75,7 +75,7 @@ if importlib.util.find_spec("cohere") is not None:
 
     __all__ += ["from_cohere"]
 
-if importlib.util.find_spec("vertexai") is not None:
+if all(importlib.util.find_spec(pkg) for pkg in ("vertexai", "jsonref")):
     from .client_vertexai import from_vertexai
 
     __all__ += ["from_vertexai"]


### PR DESCRIPTION
https://github.com/jxnl/instructor/commit/b8ceaf6e114cb6d67c2f92ebd16a0bbd43c95154 introduced a dependency on jsonref in client_vertexai.py. This dependency is not present in a standard vertexai installation. The top-level \_\_init\_\_.py tries to export client_vertex.ai regardless of whether jsonref is installed, triggering an import error (https://github.com/jxnl/instructor/issues/772).

This can be quite puzzling for users who may have vertexai installed in their environment for different reasons.

I ran into this issue as well because I'm using the AnthropicVertex client from Anthropic's SDK. The [Anthropic docs](https://docs.anthropic.com/en/api/claude-on-vertex-ai) say to pip install both anthropic[vertex] and google-cloud-aiplatform. The second package adds vertexai to my environment. As a result, even though I don't want to use Instructor's Vertex AI client, Instructor will try to import it.

The proposed solution is a tiny tweak to the import guard so that it explicitly checks whether jsonref is installed. When instructor is installed with the 'vertexai' extra, this check is guaranteed to pass. In other cases, unless a different depedency has happened to install jsonref, it will fail.
<!-- ELLIPSIS_HIDDEN -->

----

| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit 933cc8570b38476c05b7a16d2c113f4aa2cc3630  | 
|--------|--------|

### Summary:
Add explicit check for `jsonref` dependency in `vertexai` import guard in `instructor/__init__.py`.

**Key points**:
- Update `instructor/__init__.py` to check for both `vertexai` and `jsonref` before importing `from_vertexai`.
- Prevents import errors when `jsonref` is not installed but `vertexai` is present.
- Ensures `from_vertexai` is only added to `__all__` if both dependencies are available.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)


<!-- ELLIPSIS_HIDDEN -->