### PR TITLE
Fix: Resolve create_model() TypeError in Partial class

### DIFF
--- a/instructor/dsl/partial.py
+++ b/instructor/dsl/partial.py
@@ -83,12 +83,14 @@ class PartialBase(Generic[T_Model]):
             cls, BaseModel
         ), f"{cls.__name__} must be a subclass of BaseModel"
 
+        model_name = (
+            cls.__name__
+            if cls.__name__.startswith("Partial")
+            else f"Partial{cls.__name__}"
+        )
+
         return create_model(
-            __model_name=(
-                cls.__name__
-                if cls.__name__.startswith("Partial")
-                else f"Partial{cls.__name__}"
-            ),
+            model_name,
             __base__=cls,
             __module__=cls.__module__,
             **{
@@ -289,12 +291,14 @@ class Partial(Generic[T_Model]):
                 tmp_field.annotation = Partial[annotation]
             return tmp_field.annotation, tmp_field
 
+        model_name = (
+            wrapped_class.__name__
+            if wrapped_class.__name__.startswith("Partial")
+            else f"Partial{wrapped_class.__name__}"
+        )
+
         return create_model(
-            __model_name=(
-                wrapped_class.__name__
-                if wrapped_class.__name__.startswith("Partial")
-                else f"Partial{wrapped_class.__name__}"
-            ),
+            model_name,
             __base__=(wrapped_class, PartialBase),
             __module__=wrapped_class.__module__,
             **{


### PR DESCRIPTION
This pull request addresses an issue with the `create_model()` function in the `Partial` and `PartialBase` classes. The error was encountered while following the streaming partial responses example in the [Instructor documentation](https://python.useinstructor.com/concepts/partial/).

### Changes Made:

- Added missing 'model_name' argument to `create_model()` calls in both `PartialBase` and `Partial` classes
- Refactored model name creation for better readability and consistency
- Fixed errors in `PartialBase` and `Partial` classes that were causing TypeError exceptions

### Problem Description:

When trying to use the `create_partial` functionality as described in the documentation, the following error was encountered:

```python
TypeError: create_model() missing 1 required positional argument: 'model_name'
```

This error prevented the proper functioning of the partial streaming feature, which is crucial for providing incremental snapshots of the response model state.

### Impact:

This fix ensures that the partial streaming functionality works as expected, allowing users to:

- Create dynamic classes that treat all original model fields as Optional
- Stream partial responses for immediate use in contexts like UI rendering
- Iterate over incremental updates of the response model

<!-- ELLIPSIS_HIDDEN -->

----

| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit d6c5e085a0862466f2741baeae5336199174f5f2  | 
|--------|--------|

### Summary:
Fixes `TypeError` in `Partial` and `PartialBase` by adding missing `model_name` argument to `create_model()` calls.

**Key points**:
- Fixes `TypeError` in `Partial` and `PartialBase` classes by adding missing `model_name` argument to `create_model()` calls.
- Refactors model name creation for readability and consistency.
- Ensures partial streaming functionality works as expected.
- Changes made in `instructor/dsl/partial.py` file.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)


<!-- ELLIPSIS_HIDDEN -->