### PR TITLE
add client parameter to instructor.Intructions

### DIFF
--- a/examples/distilations/three_digit_mul_dispatch.py
+++ b/examples/distilations/three_digit_mul_dispatch.py
@@ -3,8 +3,9 @@ import logging
 from pydantic import BaseModel, Field
 from instructor import Instructions
 import instructor
+from openai import OpenAI
 
-instructor.from_openai()
+client = instructor.from_openai(OpenAI())
 
 logging.basicConfig(level=logging.INFO)
 
@@ -16,6 +17,7 @@ instructions = Instructions(
     log_handlers=[
         logging.FileHandler("math_finetunes.jsonl"),
     ],
+    openai_client=client
 )
 
 
@@ -25,7 +27,7 @@ class Multiply(BaseModel):
     result: int = Field(..., description="The result of the multiplication")
 
 
-@instructions.distil(mode="dispatch", model="ft:gpt-3.5-turbo-0613:personal::8CazU0uq")
+@instructions.distil(mode="dispatch", model="ft:gpt-3.5-turbo-0125:personal::9i1JeuxJ")
 def fn(a: int, b: int) -> Multiply:
     """Return the result of the multiplication as an integer"""
     resp = a * b


### PR DESCRIPTION
The original code had just instructor.from_openai(). In the doc else where, I saw an example of just patch(). Neither of them worked. 

Not sure  if this is the only way to fix this code, but these changes definitely allowed
python three_digit_mul_dispatch.py 
to run. 
<!-- ELLIPSIS_HIDDEN -->

----

| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit 16e373a8f62965aa7d89cb4dcb07c7283bb2fb23  | 
|--------|--------|

### Summary:
Added `openai_client` parameter to `Instructions` in `examples/distilations/three_digit_mul_dispatch.py` and updated model identifier.

**Key points**:
- Updated `examples/distilations/three_digit_mul_dispatch.py` to include an `openai_client` parameter in `Instructions`.
- Added `client = instructor.from_openai(OpenAI())` to initialize the OpenAI client.
- Changed model identifier in `@instructions.distil` decorator from `ft:gpt-3.5-turbo-0613:personal::8CazU0uq` to `ft:gpt-3.5-turbo-0125:personal::9i1JeuxJ`.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)


<!-- ELLIPSIS_HIDDEN -->