### PR TITLE
fix: resolve create_model() TypeError in Partial class by pinning pydantic version to ^2.8.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "instructor"
-version = "1.3.5"
+version = "1.3.6"
 description = "structured outputs for llm"
 authors = ["Jason Liu <jason@jxnl.co>"]
 license = "MIT"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ repository = "https://github.com/jxnl/instructor"
 [tool.poetry.dependencies]
 python = "^3.9"
 openai = "^1.1.0"
-pydantic = "^2.7.0"
+pydantic = "^2.8.0"
 docstring-parser = "^0.16"
 typer = ">=0.9.0,<1.0.0"
 rich = "^13.7.0"


### PR DESCRIPTION
Reference: 
```https://github.com/jxnl/instructor/pull/801```
<!-- ELLIPSIS_HIDDEN -->

----

| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit 42f08b7d6895b0243b1fab90680ba5c1d51e03a8  | 
|--------|--------|

### Summary:
Update `pydantic` version to `^2.8.0` in `pyproject.toml` to resolve `TypeError` in `Partial` class's `create_model()` function.

**Key points**:
- Update `pydantic` version in `pyproject.toml` from `^2.7.0` to `^2.8.0`
- Resolves `TypeError` in `Partial` class's `create_model()` function


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)


<!-- ELLIPSIS_HIDDEN -->