### PR TITLE
fix: Vertex AI: handle "default" in Field

### DIFF
--- a/tests/llm/test_vertexai/test_modes.py
+++ b/tests/llm/test_vertexai/test_modes.py
@@ -14,7 +14,7 @@ class Item(BaseModel):
 
 class Order(BaseModel):
     items: list[Item] = Field(..., default_factory=list)
-    customer: str
+    customer: str = Field(default="")
 
 
 @pytest.mark.parametrize("model, mode", product(models, modes))
@@ -49,13 +49,13 @@ def test_nested(model, mode):
 class Book(BaseModel):
     title: str
     author: str
-    genre: str
+    genre: str = Field(default="")
     isbn: str
 
 
 class LibraryRecord(BaseModel):
     books: list[Book] = Field(..., default_factory=list)
-    visitor: str
+    visitor: str = Field(default="")
     library_id: str
 
 


### PR DESCRIPTION
fixes #837

Adding default in Field (like this: `Field(default="")`) removes that schema property from the list of required properties (`schema_without_refs["required"]`). This is correct but it causes an issue in Vertex AI.

If all schema properties have "default", `schema_without_refs` has no key "required". I handle that with `except KeyError:`.

This is not enough though since my tests still failed (see error below), so I implemented one more change: I add the properties that have "default" to the list of required properties (`schema_without_refs["required"]`). This appears to fix this issue although I only handle it on the top level.

Combining "default" and "required" doesn't make sense normally, but in this case it appears to be a good workaround. If you think it's wrong and causes other issues, we can add in the documentation that you can't use "default" with Vertex AI. Vertex AI documentation says it doesn't support "default" but it appears to work with this workaround.

For testing I added `Field(default="")` to some of the existing tests.

## Errors if I don't add properties with "default" to required properties
### in `VERTEXAI_JSON` mode
```
>       assert resp.visitor.lower() == "jason"
E       assert 'jason", ' == 'jason'
E         
E         - jason
E         + jason", 
E         ?      +++
```

### in `VERTEXAI_TOOLS` mode
sometimes it works but sometimes I get this error:
```
>       assert len(resp.books) == 2
E       AssertionError: assert 0 == 2
E        +  where 0 = len([])
E        +    where [] = LibraryRecord(books=[], visitor='Jason', library_id='LIB123456').books
```
<!-- ELLIPSIS_HIDDEN -->

----

| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit 0b57abed69cd1055bafb5bc5585531ccc7aecf7e  | 
|--------|--------|

### Summary:
Fixed handling of parameters with default values in Vertex AI schema generation and updated tests to verify the fix.

**Key points**:
- Updated `_create_gemini_json_schema` in `instructor/client_vertexai.py` to handle parameters with default values.
- Added parameters with default values to the `required_params` list to prevent KeyError.
- Modified `Order` and `LibraryRecord` models in `tests/llm/test_vertexai/test_modes.py` to include default values for some fields.
- Ensured tests pass by verifying the correct handling of default values in different modes.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)


<!-- ELLIPSIS_HIDDEN -->