### PR TITLE
Fix missing .embeddings and .moderation endpoints

### DIFF
--- a/instructor/client.py
+++ b/instructor/client.py
@@ -42,6 +42,10 @@ class Instructor:
         self.kwargs = kwargs
         self.provider = provider
 
+        if isinstance(self.client, openai.OpenAI):
+            self.embeddings = self.client.embeddings
+            self.moderations = self.client.moderations
+
     @property
     def chat(self) -> Self:
         return self
@@ -63,8 +67,7 @@ class Instructor:
         validation_context: dict[str, Any] | None = None,
         strict: bool = True,
         **kwargs: Any,
-    ) -> Awaitable[T]:
-        ...
+    ) -> Awaitable[T]: ...
 
     @overload
     def create(
@@ -75,8 +78,7 @@ class Instructor:
         validation_context: dict[str, Any] | None = None,
         strict: bool = True,
         **kwargs: Any,
-    ) -> T:
-        ...
+    ) -> T: ...
 
     # TODO: we should overload a case where response_model is None
     def create(
@@ -108,8 +110,7 @@ class Instructor:
         validation_context: dict[str, Any] | None = None,
         strict: bool = True,
         **kwargs: Any,
-    ) -> AsyncGenerator[T, None]:
-        ...
+    ) -> AsyncGenerator[T, None]: ...
 
     @overload
     def create_partial(
@@ -120,8 +121,7 @@ class Instructor:
         validation_context: dict[str, Any] | None = None,
         strict: bool = True,
         **kwargs: Any,
-    ) -> Generator[T, None, None]:
-        ...
+    ) -> Generator[T, None, None]: ...
 
     def create_partial(
         self,
@@ -155,8 +155,7 @@ class Instructor:
         validation_context: dict[str, Any] | None = None,
         strict: bool = True,
         **kwargs: Any,
-    ) -> AsyncGenerator[T, None]:
-        ...
+    ) -> AsyncGenerator[T, None]: ...
 
     @overload
     def create_iterable(
@@ -167,8 +166,7 @@ class Instructor:
         validation_context: dict[str, Any] | None = None,
         strict: bool = True,
         **kwargs: Any,
-    ) -> Generator[T, None, None]:
-        ...
+    ) -> Generator[T, None, None]: ...
 
     def create_iterable(
         self,
@@ -201,8 +199,7 @@ class Instructor:
         validation_context: dict[str, Any] | None = None,
         strict: bool = True,
         **kwargs: Any,
-    ) -> Awaitable[tuple[T, Any]]:
-        ...
+    ) -> Awaitable[tuple[T, Any]]: ...
 
     @overload
     def create_with_completion(
@@ -213,8 +210,7 @@ class Instructor:
         validation_context: dict[str, Any] | None = None,
         strict: bool = True,
         **kwargs: Any,
-    ) -> tuple[T, Any]:
-        ...
+    ) -> tuple[T, Any]: ...
 
     def create_with_completion(
         self,
@@ -263,6 +259,10 @@ class AsyncInstructor(Instructor):
         self.mode = mode
         self.kwargs = kwargs
         self.provider = provider
+
+        if isinstance(self.client, openai.AsyncOpenAI):
+            self.embeddings = self.client.embeddings
+            self.moderations = self.client.moderations
 
     async def create(
         self,
@@ -428,8 +428,7 @@ def from_litellm(
     completion: Callable[..., Any],
     mode: instructor.Mode = instructor.Mode.TOOLS,
     **kwargs: Any,
-) -> Instructor:
-    ...
+) -> Instructor: ...
 
 
 @overload

--- a/tests/llm/test_openai/test_properties.py
+++ b/tests/llm/test_openai/test_properties.py
@@ -2,7 +2,7 @@ import pytest
 import instructor
 from openai import OpenAI, AsyncOpenAI
 from itertools import product
-from .util import models, modes
+from .util import modes
 
 
 @pytest.mark.parametrize("mode", modes)
@@ -29,6 +29,7 @@ def test_wrapped_client_properties(mode):
 @pytest.mark.parametrize("mode", modes)
 async def test_wrapped_async_client_properties(mode):
     client = instructor.from_openai(AsyncOpenAI(), mode=mode)
+    print(mode)
 
     # Check if embeddings.create property exists
     assert hasattr(client, "embeddings"), "Client should have 'embeddings' property"

--- a/tests/llm/test_openai/test_properties.py
+++ b/tests/llm/test_openai/test_properties.py
@@ -5,9 +5,9 @@ from itertools import product
 from .util import models, modes
 
 
-@pytest.mark.parametrize("model, mode", product(models, modes))
-def test_wrapped_client_properties(model, mode):
-    client = instructor.from_openai(OpenAI())
+@pytest.mark.parametrize("mode", modes)
+def test_wrapped_client_properties(mode):
+    client = instructor.from_openai(OpenAI(), mode=mode)
 
     # Check if embeddings.create property exists
     assert hasattr(client, "embeddings"), "Client should have 'embeddings' property"
@@ -26,9 +26,9 @@ def test_wrapped_client_properties(model, mode):
 
 
 @pytest.mark.asyncio
-@pytest.mark.parametrize("model, mode", product(models, modes))
-async def test_wrapped_async_client_properties(model, mode):
-    client = instructor.from_openai(AsyncOpenAI())
+@pytest.mark.parametrize("mode", modes)
+async def test_wrapped_async_client_properties(mode):
+    client = instructor.from_openai(AsyncOpenAI(), mode=mode)
 
     # Check if embeddings.create property exists
     assert hasattr(client, "embeddings"), "Client should have 'embeddings' property"

--- a/tests/llm/test_openai/test_properties.py
+++ b/tests/llm/test_openai/test_properties.py
@@ -1,7 +1,6 @@
 import pytest
 import instructor
 from openai import OpenAI, AsyncOpenAI
-from itertools import product
 from .util import modes
 
 

--- a/tests/llm/test_openai/test_properties.py
+++ b/tests/llm/test_openai/test_properties.py
@@ -29,7 +29,6 @@ def test_wrapped_client_properties(mode):
 @pytest.mark.parametrize("mode", modes)
 async def test_wrapped_async_client_properties(mode):
     client = instructor.from_openai(AsyncOpenAI(), mode=mode)
-    print(mode)
 
     # Check if embeddings.create property exists
     assert hasattr(client, "embeddings"), "Client should have 'embeddings' property"

--- a/tests/llm/test_openai/test_properties.py
+++ b/tests/llm/test_openai/test_properties.py
@@ -1,0 +1,51 @@
+import pytest
+import instructor
+from openai import OpenAI, AsyncOpenAI
+from itertools import product
+from .util import models, modes
+
+
+@pytest.mark.parametrize("model, mode", product(models, modes))
+def test_wrapped_client_properties(model, mode):
+    client = instructor.from_openai(OpenAI())
+
+    # Check if embeddings.create property exists
+    assert hasattr(client, "embeddings"), "Client should have 'embeddings' property"
+    assert hasattr(
+        client.embeddings, "create"
+    ), "Client should have 'embeddings.create' method"
+
+    # Check if moderations property exists
+    assert hasattr(client, "moderations"), "Client should have 'moderations' property"
+
+    # Ensure that these properties are callable (they should be methods)
+    assert callable(client.embeddings.create), "'embeddings.create' should be callable"
+    assert callable(
+        client.moderations.create
+    ), "'moderations.create' should be callable"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("model, mode", product(models, modes))
+async def test_wrapped_async_client_properties(model, mode):
+    client = instructor.from_openai(AsyncOpenAI())
+
+    # Check if embeddings.create property exists
+    assert hasattr(client, "embeddings"), "Client should have 'embeddings' property"
+    assert hasattr(
+        client.embeddings, "create"
+    ), "Client should have 'embeddings.create' method"
+
+    # Check if moderations property exists
+    assert hasattr(client, "moderations"), "Client should have 'moderations' property"
+
+    # Ensure that these properties are callable (they should be methods)
+    assert callable(client.embeddings.create), "'embeddings.create' should be callable"
+    assert callable(
+        client.moderations.create
+    ), "'moderations.create' should be callable"
+
+    # Additional check to ensure the client is async
+    assert isinstance(
+        client, instructor.AsyncInstructor
+    ), "Client should be an AsyncInstructor instance"


### PR DESCRIPTION
the `.from_openai` method doesn't preserve the client moderations and embeddings endpoint. Wrote a test to validate and catch potential such errors and a small modification in the `init` function to manually add these back in
<!-- ELLIPSIS_HIDDEN -->


----

| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit 8d5b3d88b353213797bae48d8275e39641dbdaf1  | 
|--------|--------|

### Summary:
Fixes missing `.embeddings` and `.moderations` endpoints in `Instructor` and `AsyncInstructor` classes and adds tests to validate their presence.

**Key points**:
- Fixes missing `.embeddings` and `.moderations` endpoints in `Instructor` and `AsyncInstructor` classes.
- Adds manual assignment of these endpoints in `instructor/client.py` `__init__` methods.
- Updates `from_openai` function to ensure these endpoints are preserved.
- Adds tests in `tests/llm/test_openai/test_properties.py` to validate the presence and functionality of `.embeddings` and `.moderations` endpoints.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)



<!-- ELLIPSIS_HIDDEN -->