### PR TITLE
Call `model.validate_async()` during async response processing (if it exists)

### DIFF
--- a/instructor/process_response.py
+++ b/instructor/process_response.py
@@ -81,6 +81,9 @@ async def process_response_async(
         mode=mode,
     )
 
+    if hasattr(model, "validate_async") and callable(model.validate_async):
+        await model.validate_async()
+
     # ? This really hints at the fact that we need a better way of
     # ? attaching usage data and the raw response to the model we return.
     if isinstance(model, IterableBase):

--- a/instructor/retry.py
+++ b/instructor/retry.py
@@ -246,7 +246,7 @@ async def retry_async(
                         mode=mode,
                     )
                 except (ValidationError, JSONDecodeError) as e:
-                    logger.debug(f"Error response: {response}", e)
+                    logger.debug(f"Error response: {response}")
                     kwargs["messages"].extend(reask_messages(response, mode, e))
                     if mode in {Mode.ANTHROPIC_TOOLS, Mode.ANTHROPIC_JSON}:
                         kwargs["messages"] = merge_consecutive_messages(

--- a/tests/test_process_response.py
+++ b/tests/test_process_response.py
@@ -1,6 +1,9 @@
+from typing import Any
 from typing_extensions import TypedDict
+from unittest.mock import AsyncMock, patch
 from pydantic import BaseModel
-from instructor.process_response import handle_response_model
+import pytest
+from instructor.process_response import handle_response_model, process_response_async
 
 
 def test_typed_dict_conversion() -> None:
@@ -16,3 +19,26 @@ def test_typed_dict_conversion() -> None:
 
     _, pydantic_user_tool_definition = handle_response_model(User)
     assert user_tool_definition == pydantic_user_tool_definition
+
+
+@pytest.mark.asyncio
+async def test_process_response_async_calls_validate_async():
+
+    class TestModel(BaseModel):
+        async def validate_async(self) -> None:
+            pass
+
+        @classmethod
+        def from_response(cls, response: Any) -> "TestModel":
+            return cls()
+
+    mock_response = AsyncMock()
+
+    with patch.object(
+        TestModel, "validate_async", new_callable=AsyncMock
+    ) as mock_validate_async:
+        with patch.object(TestModel, "from_response", return_value=TestModel()):
+            await process_response_async(
+                mock_response, response_model=TestModel
+            )
+        mock_validate_async.assert_called_once_with()


### PR DESCRIPTION
This PR makes instructor call `model.validate_async()` during response processing, if such a method exists.

**Context:**

We often have multiple LLM based validators on a single response model, so we want to run the validators asynchronously in parallel.

This is not possible using pydantic's built-in validation mechanism, because this runs during a model's `__init__`, which is never asynchronous.

In our model base class, we've implemented the following API for defining async validators:

```python
class Model(HexModel):
    foo: str
    bar: str

    @async_field_validator("foo", "bar")
    @classmethod
    async def validate_foobar(cls, v: str) -> str:
        return v + "_123"

    @async_model_validator
    async def validate_model(self):
        if self.foo != self.bar:
            raise ValueError("foo must be equal to bar")

m = Model(foo="abc", bar="def")
await m.validate_async() # raises a ValidationError just like pydantic's synchronous validators
```

To benefit from instructors retry loop, we need instructor to call `validate_async()` for us.

I'm opening this as a PR, because a) we believe this functionality would be useful for other users who make heavy use of `llm_validator` and b) we don't want to maintain an instructor fork

We're happy to change the implementation to be more to your liking, too. 

Happy to share the implementation of the validation logic itself, too, if useful. 
<!-- ELLIPSIS_HIDDEN -->

----

| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit bd6e7720e1a41c127882253703e5ce8e26008256  | 
|--------|--------|

### Summary:
Add hook to call `model.validate_async()` if it exists during response processing in `instructor/process_response.py`.

**Key points**:
- **Feature Added**: Call `model.validate_async()` if it exists in `instructor/process_response.py`.
- **File Affected**: `instructor/process_response.py`.
- **Function Modified**: `process_response_async`.
- **Behavior**: If `model` has a `validate_async` method, it is called asynchronously during response processing.
- **Use Case**: Enables asynchronous validation for models, useful for running multiple LLM-based validators in parallel.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)


<!-- ELLIPSIS_HIDDEN -->