### PR TITLE
Add overloads to support a case where response_model is None

### DIFF
--- a/instructor/client.py
+++ b/instructor/client.py
@@ -78,16 +78,37 @@ class Instructor:
     ) -> T:
         ...
 
-    # TODO: we should overload a case where response_model is None
+    @overload
     def create(
-        self,
-        response_model: type[T],
+        self: AsyncInstructor,
+        response_model: None,
         messages: list[ChatCompletionMessageParam],
         max_retries: int = 3,
         validation_context: dict[str, Any] | None = None,
         strict: bool = True,
         **kwargs: Any,
-    ) -> T | Awaitable[T]:
+    ) -> Awaitable[Any]: ...
+
+    @overload
+    def create(
+        self: Self,
+        response_model: None,
+        messages: list[ChatCompletionMessageParam],
+        max_retries: int = 3,
+        validation_context: dict[str, Any] | None = None,
+        strict: bool = True,
+        **kwargs: Any,
+    ) -> Any: ...
+
+    def create(
+        self,
+        response_model: type[T] | None,
+        messages: list[ChatCompletionMessageParam],
+        max_retries: int = 3,
+        validation_context: dict[str, Any] | None = None,
+        strict: bool = True,
+        **kwargs: Any,
+    ) -> T | Any | Awaitable[T] | Awaitable[Any]:
         kwargs = self.handle_kwargs(kwargs)
 
         return self.create_fn(
@@ -266,13 +287,13 @@ class AsyncInstructor(Instructor):
 
     async def create(
         self,
-        response_model: type[T],
+        response_model: type[T] | None,
         messages: list[ChatCompletionMessageParam],
         max_retries: int = 3,
         validation_context: dict[str, Any] | None = None,
         strict: bool = True,
         **kwargs: Any,
-    ) -> T:
+    ) -> T | Any:
         kwargs = self.handle_kwargs(kwargs)
         return await self.create_fn(
             response_model=response_model,

--- a/tests/llm/test_openai/test_parallel.py
+++ b/tests/llm/test_openai/test_parallel.py
@@ -3,9 +3,10 @@ from __future__ import annotations
 from typing import Literal, Union
 from collections.abc import Iterable
 from pydantic import BaseModel
-
+from itertools import product
 import pytest
 import instructor
+from .util import models, modes
 
 
 class Weather(BaseModel):
@@ -51,8 +52,8 @@ def test_sync_parallel_tools_or(client):
 
 
 @pytest.mark.asyncio
-@pytest.mark.parametrize("model, mode", "aclient", product(models, modes, [cli]))
-async def test_async_parallel_tools_or(model, mode):
+@pytest.mark.parametrize("model, mode", product(models, modes))
+async def test_async_parallel_tools_or(model, mode, aclient):
     client = instructor.from_openai(aclient, mode=mode)
     resp = await client.chat.completions.create(
         model=model,

--- a/tests/llm/test_openai/test_parallel.py
+++ b/tests/llm/test_openai/test_parallel.py
@@ -55,7 +55,7 @@ def test_sync_parallel_tools_or(client):
 async def test_async_parallel_tools_or(model, mode):
     client = instructor.from_openai(aclient, mode=mode)
     resp = await client.chat.completions.create(
-        model="gpt-4-turbo-preview",
+        model=model,
         messages=[
             {"role": "system", "content": "You must always use tools"},
             {


### PR DESCRIPTION
This change adds supports for type hints when `response_model=None`. 

Fixes #749


<!-- ELLIPSIS_HIDDEN -->

----

| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit c1e9ec8be49d01d54adf8711479202583c04b445  | 
|--------|--------|

### Summary:
Added overloads to `create` method in `instructor/client.py` to handle cases where `response_model` is `None`.

**Key points**:
- Added overloads to `instructor/client.py` for `create` method to handle `response_model=None`.
- Updated return types to `Any` or `Awaitable[Any]` for these cases.
- Ensured both `Instructor` and `AsyncInstructor` classes are covered.
- Modified `create` method implementation to support `response_model` being `None`.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)


<!-- ELLIPSIS_HIDDEN -->