### PR TITLE
Fix spurious Mode.FUNCTIONS deprecation warnings

### DIFF
--- a/instructor/client.py
+++ b/instructor/client.py
@@ -39,6 +39,8 @@ class Instructor:
         self.client = client
         self.create_fn = create
         self.mode = mode
+        if mode == instructor.Mode.FUNCTIONS:
+            instructor.Mode.warn_mode_functions_deprecation()
         self.kwargs = kwargs
         self.provider = provider
 

--- a/instructor/dsl/iterable.py
+++ b/instructor/dsl/iterable.py
@@ -88,6 +88,7 @@ class IterableBase:
                     yield chunk.text
                 elif chunk.choices:
                     if mode == Mode.FUNCTIONS:
+                        Mode.warn_mode_functions_deprecation()
                         if json_chunk := chunk.choices[0].delta.function_call.arguments:
                             yield json_chunk
                     elif mode in {Mode.JSON, Mode.MD_JSON, Mode.JSON_SCHEMA}:
@@ -116,6 +117,7 @@ class IterableBase:
                     yield chunk.delta.partial_json
                 elif chunk.choices:
                     if mode == Mode.FUNCTIONS:
+                        Mode.warn_mode_functions_deprecation()
                         if json_chunk := chunk.choices[0].delta.function_call.arguments:
                             yield json_chunk
                     elif mode in {Mode.JSON, Mode.MD_JSON, Mode.JSON_SCHEMA}:

--- a/instructor/dsl/partial.py
+++ b/instructor/dsl/partial.py
@@ -164,6 +164,7 @@ class PartialBase(Generic[T_Model]):
                     yield chunk.text
                 elif chunk.choices:
                     if mode == Mode.FUNCTIONS:
+                        Mode.warn_mode_functions_deprecation()
                         if json_chunk := chunk.choices[0].delta.function_call.arguments:
                             yield json_chunk
                     elif mode in {Mode.JSON, Mode.MD_JSON, Mode.JSON_SCHEMA}:
@@ -192,6 +193,7 @@ class PartialBase(Generic[T_Model]):
                     yield chunk.delta.partial_json
                 elif chunk.choices:
                     if mode == Mode.FUNCTIONS:
+                        Mode.warn_mode_functions_deprecation()
                         if json_chunk := chunk.choices[0].delta.function_call.arguments:
                             yield json_chunk
                     elif mode in {Mode.JSON, Mode.MD_JSON, Mode.JSON_SCHEMA}:

--- a/instructor/function_calls.py
+++ b/instructor/function_calls.py
@@ -119,6 +119,7 @@ class OpenAISchema(BaseModel):
             raise IncompleteOutputException(last_completion=completion)
 
         if mode == Mode.FUNCTIONS:
+            Mode.warn_mode_functions_deprecation()
             return cls.parse_functions(completion, validation_context, strict)
 
         if mode in {Mode.TOOLS, Mode.MISTRAL_TOOLS}:

--- a/instructor/mode.py
+++ b/instructor/mode.py
@@ -2,18 +2,7 @@ import enum
 import warnings
 
 
-class _WarnOnFunctionsAccessEnumMeta(enum.EnumMeta):
-    def __getattribute__(cls, name: str):
-        if name == "FUNCTIONS":
-            warnings.warn(
-                "FUNCTIONS is deprecated and will be removed in future versions",
-                DeprecationWarning,
-                stacklevel=2,
-            )
-        return super().__getattribute__(name)
-
-
-class Mode(enum.Enum, metaclass=_WarnOnFunctionsAccessEnumMeta):
+class Mode(enum.Enum):
     """The mode to use for patching the client"""
 
     FUNCTIONS = "function_call"
@@ -29,3 +18,11 @@ class Mode(enum.Enum, metaclass=_WarnOnFunctionsAccessEnumMeta):
     VERTEXAI_TOOLS = "vertexai_tools"
     VERTEXAI_JSON = "vertexai_json"
     GEMINI_JSON = "gemini_json"
+
+    @classmethod
+    def warn_mode_functions_deprecation(cls):
+        warnings.warn(
+            "The FUNCTIONS mode is deprecated and will be removed in future versions",
+            DeprecationWarning,
+            stacklevel=2,
+        )

--- a/instructor/process_response.py
+++ b/instructor/process_response.py
@@ -234,6 +234,7 @@ def handle_response_model(
             )
 
         if mode == Mode.FUNCTIONS:
+            Mode.warn_mode_functions_deprecation()
             new_kwargs["functions"] = [response_model.openai_schema]
             new_kwargs["function_call"] = {"name": response_model.openai_schema["name"]}
         elif mode in {Mode.TOOLS, Mode.MISTRAL_TOOLS}:

--- a/tests/test_function_calls.py
+++ b/tests/test_function_calls.py
@@ -201,3 +201,9 @@ def test_pylance_url_config() -> None:
         Model(**data)  # type: ignore
     except ValidationError as e:
         assert "https://errors.pydantic.dev" not in str(e)
+
+
+def test_mode_functions_deprecation_warning() -> None:
+    from openai import OpenAI
+    with pytest.warns(DeprecationWarning, match="The FUNCTIONS mode is deprecated and will be removed in future versions"):
+        _ = instructor.from_openai(OpenAI(), mode=instructor.Mode.FUNCTIONS)


### PR DESCRIPTION
Instead of warning whenever the enum attribute FUNCTIONS is being called, only warn when Mode.FUNCTIONS is being used. That way, consumers who already updated and avoid using FUNCTIONS don't get warned.

Fixes #679
<!-- ELLIPSIS_HIDDEN -->

----

| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit f3b3c4105eedfb7d014e4b6a01aed03df7f8dfa4  | 
|--------|--------|

### Summary:
Fixes spurious `Mode.FUNCTIONS` deprecation warnings by only issuing warnings when `Mode.FUNCTIONS` is actively used.

**Key points**:
- Updated `instructor/mode.py` to remove `_WarnOnFunctionsAccessEnumMeta` and add `warn_mode_functions_deprecation` method.
- Modified `instructor/client.py` to call `warn_mode_functions_deprecation` when `Mode.FUNCTIONS` is used.
- Updated `instructor/dsl/iterable.py`, `instructor/dsl/partial.py`, `instructor/function_calls.py`, and `instructor/process_response.py` to call `warn_mode_functions_deprecation` when `Mode.FUNCTIONS` is used.
- Added `test_mode_functions_deprecation_warning` in `tests/test_function_calls.py` to verify the deprecation warning.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)


<!-- ELLIPSIS_HIDDEN -->