### PR TITLE
Added support for response_model = None in cohere

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -9,8 +9,6 @@ _Structured outputs powered by llms. Designed for simplicity, transparency, and 
 [![Downloads](https://img.shields.io/pypi/dm/instructor.svg)](https://pypi.python.org/pypi/instructor)
 [![GPT](https://img.shields.io/badge/docs-InstructorGPT-blue)](https://chat.openai.com/g/g-EvZweRWrE-instructor-gpt)
 
-
-
 Instructor makes it easy to get structured data like JSON from LLMs like GPT-3.5, GPT-4, GPT-4-Vision, and open-source models including [Mistral/Mixtral](./hub/together.md), [Anyscale](./hub/anyscale.md), [Ollama](./hub/ollama.md), and [llama-cpp-python](./hub/llama-cpp-python.md).
 
 It stands out for its simplicity, transparency, and user-centric design, built on top of Pydantic. Instructor helps you manage [validation context](./concepts/reask_validation.md), retries with [Tenacity](./concepts/retrying.md), and streaming [Lists](./concepts/lists.md) and [Partial](./concepts/partial.md) responses.
@@ -220,6 +218,56 @@ resp = client.chat.completions.create(
 )
 
 assert isinstance(resp, User)
+assert resp.name == "Jason"
+assert resp.age == 25
+```
+
+### Using Cohere
+
+We also support users who want to use the Cohere models using the `from_cohere` method.
+
+??? info "Want to get the original Cohere response?"
+
+    If you want to get the original response object from the LLM instead of a structured output, you can pass `response_model=None` to the `create` method. This will return the raw response from the underlying API.
+
+    ```python
+    # This will return the original Cohere response object
+    raw_response = client.chat.completions.create(
+        response_model=None,
+        messages=[
+            {
+                "role": "user",
+                "content": "Extract Jason is 25 years old.",
+            }
+        ],
+    )
+    ```
+
+    This can be useful when you need access to additional metadata or want to handle the raw response yourself.
+
+```python
+import instructor
+from pydantic import BaseModel
+from cohere import Client
+
+
+class User(BaseModel):
+    name: str
+    age: int
+
+
+client = instructor.from_cohere(Client())
+
+resp = client.chat.completions.create(
+    response_model=User,
+    messages=[
+        {
+            "role": "user",
+            "content": "Extract Jason is 25 years old.",
+        }
+    ],
+)
+
 assert resp.name == "Jason"
 assert resp.age == 25
 ```

--- a/instructor/process_response.py
+++ b/instructor/process_response.py
@@ -529,9 +529,9 @@ The output must be a valid JSON object that `{response_model.__name__}.model_val
         new_kwargs["message"] = messages[-1]["content"]
 
         new_kwargs["chat_history"] = chat_history
-        if new_kwargs["model_name"]:
-            new_kwargs["model"] = new_kwargs["model_name"]
-            del new_kwargs["model_name"]
+        if "model_name" in new_kwargs and "model" not in new_kwargs:
+            new_kwargs["model"] = new_kwargs.pop("model_name")
+        new_kwargs.pop("strict", None)
 
     logger.debug(
         f"Instructor Request: {mode.value=}, {response_model=}, {new_kwargs=}",

--- a/instructor/process_response.py
+++ b/instructor/process_response.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 from collections.abc import Iterable
 from textwrap import dedent
+from instructor.mode import Mode
 from instructor.dsl.iterable import IterableBase, IterableModel
 from instructor.dsl.parallel import ParallelBase, ParallelModel, handle_parallel_model
 from instructor.dsl.partial import PartialBase
@@ -509,6 +510,28 @@ The output must be a valid JSON object that `{response_model.__name__}.model_val
             new_kwargs["generation_config"] = generation_config
         else:
             raise ValueError(f"Invalid patch mode: {mode}")
+
+    # Handle Cohere Response Model Case
+    elif response_model is None and mode in {
+        Mode.COHERE_JSON_SCHEMA,
+        Mode.COHERE_TOOLS,
+    }:
+        messages = new_kwargs.pop("messages", [])
+        chat_history = []
+        for message in messages[:-1]:
+            # format in Cohere's ChatMessage format
+            chat_history.append(
+                {
+                    "role": message["role"],
+                    "message": message["content"],
+                }
+            )
+        new_kwargs["message"] = messages[-1]["content"]
+
+        new_kwargs["chat_history"] = chat_history
+        if new_kwargs["model_name"]:
+            new_kwargs["model"] = new_kwargs["model_name"]
+            del new_kwargs["model_name"]
 
     logger.debug(
         f"Instructor Request: {mode.value=}, {response_model=}, {new_kwargs=}",

--- a/instructor/retry.py
+++ b/instructor/retry.py
@@ -247,7 +247,10 @@ async def retry_async(
                     )
                 except (ValidationError, JSONDecodeError, AsyncValidationError) as e:
                     logger.debug(f"Error response: {response}", e)
-                    kwargs["messages"].extend(reask_messages(response, mode, e))
+                    if mode in {Mode.COHERE_JSON_SCHEMA, Mode.COHERE_TOOLS}:
+                        kwargs["chat_history"].extend(reask_messages(response, mode, e))
+                    else:
+                        kwargs["messages"].extend(reask_messages(response, mode, e))
                     if mode in {Mode.ANTHROPIC_TOOLS, Mode.ANTHROPIC_JSON}:
                         kwargs["messages"] = merge_consecutive_messages(
                             kwargs["messages"]

--- a/tests/llm/test_cohere/test_none_response.py
+++ b/tests/llm/test_cohere/test_none_response.py
@@ -1,6 +1,5 @@
 import pytest
 from instructor import from_cohere
-import json
 
 
 def test_none_response_model(client):

--- a/tests/llm/test_cohere/test_none_response.py
+++ b/tests/llm/test_cohere/test_none_response.py
@@ -1,0 +1,28 @@
+import pytest
+from instructor import from_cohere
+import json
+
+
+def test_none_response_model(client):
+    client = from_cohere(client, model_name="command-r", max_tokens=1000)
+
+    response = client.messages.create(
+        messages=[{"role": "user", "content": "Tell me about your day"}],
+        response_model=None,
+        temperature=0,
+    )
+
+    assert response.text
+
+
+@pytest.mark.asyncio()
+async def test_none_response_model_async(aclient):
+    async_client = from_cohere(aclient, model_name="command-r", max_tokens=1000)
+
+    response = await async_client.messages.create(
+        messages=[{"role": "user", "content": "Tell me about your day"}],
+        response_model=None,
+        temperature=0,
+    )
+
+    assert response.text


### PR DESCRIPTION
This adds support for passing in response_model = None for Cohere Sync and Async clients
<!-- ELLIPSIS_HIDDEN -->


----

| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit 0aa258e3b0b155fed660131a87d3f375027c2ca8  | 
|--------|--------|

### Summary:
Added support for `response_model=None` in Cohere Sync and Async clients, updated relevant functions, tests, and documentation.

**Key points**:
- Added support for `response_model=None` in Cohere Sync and Async clients.
- Modified `instructor/retry.py` to handle `response_model=None` in `retry_sync` and `retry_async` functions.
- Updated `reask_messages` function to extend `chat_history` or `messages` based on the mode.
- Formats messages and chat history according to Cohere's requirements.
- Updates `new_kwargs` dictionary with formatted messages and chat history.
- Added tests in `tests/llm/test_cohere/test_none_response.py` and `tests/llm/test_cohere/test_json_schema.py` to verify the new functionality.
- Updated `docs/index.md` with examples demonstrating the new feature.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)



<!-- ELLIPSIS_HIDDEN -->