### PR TITLE
bugfix: update tenacity config to raise RetryError

### DIFF
--- a/instructor/retry.py
+++ b/instructor/retry.py
@@ -152,7 +152,6 @@ def retry_sync(
         logger.debug(f"max_retries: {max_retries}")
         max_retries = Retrying(
             stop=stop_after_attempt(max_retries),
-            reraise=True,
         )
     if not isinstance(max_retries, (Retrying, AsyncRetrying)):
         raise ValueError("max_retries must be an int or a `tenacity.Retrying` object")
@@ -221,7 +220,6 @@ async def retry_async(
         logger.debug(f"max_retries: {max_retries}")
         max_retries = AsyncRetrying(
             stop=stop_after_attempt(max_retries),
-            reraise=True,
         )
     if not isinstance(max_retries, (AsyncRetrying, Retrying)):
         raise ValueError(


### PR DESCRIPTION
Tenacity raises the exception that triggered the retry failure if `reraise=True` https://tenacity.readthedocs.io/en/latest/#error-handling

Fixes #769
<!-- ELLIPSIS_HIDDEN -->

----

| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit 5fce9c00e06665c238e3aa06aa966be30717841f  | 
|--------|--------|

### Summary:
Removed `reraise=True` from `Retrying` and `AsyncRetrying` configurations to ensure `RetryError` is raised.

**Key points**:
- Removed `reraise=True` from `Retrying` and `AsyncRetrying` configurations in `instructor/retry.py`.
- Ensures `RetryError` is raised instead of the original exception.
- Affects `retry_sync` and `retry_async` functions.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)


<!-- ELLIPSIS_HIDDEN -->