### PR TITLE
only import cohere when using cohere functionality

### DIFF
--- a/instructor/function_calls.py
+++ b/instructor/function_calls.py
@@ -13,7 +13,6 @@ from pydantic import (
     TypeAdapter,
     create_model,
 )
-from cohere import NonStreamedChatResponse
 
 from instructor.exceptions import IncompleteOutputException
 from instructor.mode import Mode
@@ -276,10 +275,13 @@ class OpenAISchema(BaseModel):
     @classmethod
     def parse_cohere_json_schema(
         cls: type[BaseModel],
-        completion: NonStreamedChatResponse,
+        completion: Any,
         validation_context: Optional[dict[str, Any]] = None,
         strict: Optional[bool] = None,
     ):
+        from cohere import NonStreamedChatResponse
+
+        assert isinstance(completion, NonStreamedChatResponse)
         return cls.model_validate_json(
             completion.text, context=validation_context, strict=strict
         )


### PR DESCRIPTION
https://github.com/jxnl/instructor/pull/866/files breaks non-cohere users. This PR should solve that issue. 

Will separately open a ticket to have tests run on clean installs.
<!-- ELLIPSIS_HIDDEN -->

----

| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit 8e8bf8b6f49b794253962e306f1db8d8bee21b18  | 
|--------|--------|

### Summary:
Import `cohere` only when using its functionality to avoid breaking non-cohere users in `instructor/function_calls.py`.

**Key points**:
- **File**: `instructor/function_calls.py`
- **Class**: `OpenAISchema`
- **Method**: `parse_cohere_json_schema`
- **Change**: Moved the import of `NonStreamedChatResponse` from `cohere` inside the `parse_cohere_json_schema` method to avoid breaking non-cohere users.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)


<!-- ELLIPSIS_HIDDEN -->