### PR TITLE
Fix openai_schema_helper so it supports Optional[cls] and Python 3.10+ stye cls | None.

### DIFF
--- a/instructor/function_calls.py
+++ b/instructor/function_calls.py
@@ -470,7 +470,7 @@ def openai_schema_helper(cls: T) -> T:
     if origin is Literal:
         return cls
 
-    # Support for Union[cls, None] and Python 3.10+ stye cls | None
+    # Support for Optional[cls]/Union[cls, None] and Python 3.10+ stye cls | None
     if get_origin(cls) is Union or isinstance(cls, UnionType):
         non_none_args = [arg for arg in get_args(cls) if arg is not type(None)]
         if non_none_args:

--- a/instructor/function_calls.py
+++ b/instructor/function_calls.py
@@ -2,7 +2,18 @@
 import json
 import logging
 from functools import wraps
-from typing import Annotated, Any, Optional, TypeVar, cast, get_origin, Literal
+from typing import (
+    Annotated,
+    Any,
+    Optional,
+    TypeVar,
+    cast,
+    get_origin,
+    Literal,
+    get_args,
+    Union,
+)
+from types import UnionType
 import asyncio
 from docstring_parser import parse
 from openai.types.chat import ChatCompletion
@@ -458,6 +469,11 @@ def openai_schema_helper(cls: T) -> T:
 
     if origin is Literal:
         return cls
+
+    # Support for Union[cls, None] and Python 3.10+ stye cls | None
+    if get_origin(cls) is Union or isinstance(cls, UnionType):
+        for arg in get_args(cls):
+            return openai_schema_helper(arg)
 
     if issubclass(cls, (str, int, bool, float, bytes)):
         return cls

--- a/instructor/function_calls.py
+++ b/instructor/function_calls.py
@@ -472,8 +472,10 @@ def openai_schema_helper(cls: T) -> T:
 
     # Support for Union[cls, None] and Python 3.10+ stye cls | None
     if get_origin(cls) is Union or isinstance(cls, UnionType):
-        for arg in get_args(cls):
-            return openai_schema_helper(arg)
+        non_none_args = [arg for arg in get_args(cls) if arg is not type(None)]
+        if non_none_args:
+            return openai_schema_helper(non_none_args[0])
+        return cls
 
     if issubclass(cls, (str, int, bool, float, bytes)):
         return cls

--- a/tests/test_function_calls.py
+++ b/tests/test_function_calls.py
@@ -4,6 +4,7 @@ import pytest
 from anthropic.types import Message, Usage
 from openai.types.chat.chat_completion import ChatCompletion
 from pydantic import BaseModel, ValidationError
+from typing import Union
 
 import instructor
 from instructor import OpenAISchema, openai_schema
@@ -92,6 +93,17 @@ def test_openai_schema() -> None:
     assert hasattr(Dataframe, "from_response")
     assert hasattr(Dataframe, "to_pandas")
     assert Dataframe.openai_schema["name"] == "Dataframe"
+
+
+def test_openai_schema_supports_optional_none() -> None:
+    @openai_schema
+    class DummyWithOptionalNone(BaseModel):  # type: ignore[misc]
+        """
+        Class with a single attribute that can be a string or None.
+        Validates support of UnionType in schema generation.
+        """
+
+        attr: Union[str, None]  # In python 3.10+ this is written as `attr: str | None`
 
 
 def test_openai_schema_raises_error() -> None:

--- a/tests/test_function_calls.py
+++ b/tests/test_function_calls.py
@@ -1,6 +1,7 @@
 from typing import TypeVar
 
 import pytest
+import sys
 from anthropic.types import Message, Usage
 from openai.types.chat.chat_completion import ChatCompletion
 from pydantic import BaseModel, ValidationError
@@ -104,6 +105,18 @@ def test_openai_schema_supports_optional_none() -> None:
         """
 
         attr: Union[str, None]  # In python 3.10+ this is written as `attr: str | None`
+
+
+@pytest.mark.skipif(sys.version_info < (3, 10), reason="Requires Python 3.10 or higher")
+def test_openai_schema_supports_optional_none_310():
+    @openai_schema
+    class DummyWithOptionalNone(BaseModel):  # type: ignore[misc]
+        """
+        Class with a single attribute that can be a string or None.
+        Validates support of UnionType in schema generation.
+        """
+
+        attr: str | None
 
 
 def test_openai_schema_raises_error() -> None:

--- a/tests/test_function_calls.py
+++ b/tests/test_function_calls.py
@@ -5,7 +5,7 @@ import sys
 from anthropic.types import Message, Usage
 from openai.types.chat.chat_completion import ChatCompletion
 from pydantic import BaseModel, ValidationError
-from typing import Union
+from typing import Union, Optional
 
 import instructor
 from instructor import OpenAISchema, openai_schema
@@ -104,7 +104,8 @@ def test_openai_schema_supports_optional_none() -> None:
         Validates support of UnionType in schema generation.
         """
 
-        attr: Union[str, None]  # In python 3.10+ this is written as `attr: str | None`
+        attr: Optional[str]  # In python 3.10+ this is written as `attr: str | None`
+        attr2: Union[str, None]
 
 
 @pytest.mark.skipif(sys.version_info < (3, 10), reason="Requires Python 3.10 or higher")


### PR DESCRIPTION
This fixes a regression introduced in https://github.com/jxnl/instructor/pull/856.

- Added  tests that validates the new code (verified it fails on the existing code, but passes now)
- Supports both BaseModel style ```Union[cls, None]``` and ```cls | None```

<!-- ELLIPSIS_HIDDEN -->

----

| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit 355aeb25b6019a4c213ae9a76f8a6c573f9e242a  | 
|--------|--------|

### Summary:
Fixes `openai_schema_helper` to support `Union[cls, None]` and `cls | None` for Python 3.10+ with added tests.

**Key points**:
- Fixes regression in `openai_schema_helper` to support `Union[cls, None]` and `cls | None`.
- Updates `instructor/function_calls.py` to handle `UnionType` and `get_args`.
- Adds tests in `tests/test_function_calls.py` to validate support for `Union[cls, None]` and `cls | None`.
- Ensures tests fail on old code and pass with the new changes.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)


<!-- ELLIPSIS_HIDDEN -->