### PR TITLE
Fix debug log exception in retry_async

### DIFF
--- a/instructor/retry.py
+++ b/instructor/retry.py
@@ -248,7 +248,7 @@ async def retry_async(
                         mode=mode,
                     )
                 except (ValidationError, JSONDecodeError, AsyncValidationError) as e:
-                    logger.debug(f"Error response: {response}", e)
+                    logger.debug(f"Error response: {response}")
                     if mode in {Mode.COHERE_JSON_SCHEMA, Mode.COHERE_TOOLS}:
                         if attempt.retry_state.attempt_number == 1:
                             kwargs["chat_history"].extend(

--- a/instructor/retry.py
+++ b/instructor/retry.py
@@ -233,7 +233,7 @@ async def retry_async(
     try:
         response = None
         async for attempt in max_retries:
-            logger.debug(f"Retrying, attempt: {attempt}")
+            logger.debug(f"Retrying, attempt: {attempt.retry_state.attempt_number}")
             with attempt:
                 try:
                     response: ChatCompletion = await func(*args, **kwargs)


### PR DESCRIPTION
Two very small fixes for debug logging in `retry_async`, the first of which is throwing an exception:

1. When an error response is returned, the debug log had a mix of string interpolation (both an f-string, but also an additional parameter specified with no `%s` in the string), which caused an exception to be thrown in the logging library. I've updated this to just debug log the error response, which matches the behaviour in `retry_sync`.
2. When debug logging the attempt retry this was outputting the attempt object and not the attempt number (eg `DEBUG    instructor:retry.py:234 Retrying, attempt: <tenacity.AttemptManager object at 0x13b091f10>` instead of `Retrying, attempt: 2`
<!-- ELLIPSIS_HIDDEN -->

----

| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit 2966d6eaeb3574207904de9a8d109186a077352a  | 
|--------|--------|

### Summary:
Fixes logging issues in `retry_async` function in `instructor/retry.py` to prevent exceptions and log correct attempt numbers.

**Key points**:
- **File**: `instructor/retry.py`
- **Function**: `retry_async`
- **Fix 1**: Corrected debug log for error response to avoid logging exception by removing improper string interpolation.
- **Fix 2**: Updated debug log to display the attempt number instead of the attempt object.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)


<!-- ELLIPSIS_HIDDEN -->