### PR TITLE
Fix ValueError: Unsupported Class of dict[str, typing.Any]

### DIFF
--- a/instructor/function_calls.py
+++ b/instructor/function_calls.py
@@ -466,6 +466,9 @@ def openai_schema_helper(cls: T) -> T:
     if origin is list:
         return list[openai_schema_helper(cls.__args__[0])]
 
+    if origin is dict:
+        return dict[str | int | tuple, openai_schema_helper(cls.__args__[1])]
+
     if origin is Literal:
         return cls
 


### PR DESCRIPTION
Fixing this issue:

![CleanShot 2024-07-28 at 21 36 47](https://github.com/user-attachments/assets/5358559b-1b15-438e-89bf-69cc67c0d6c2)


```
openai = "^1.35.15"
instructor = "^1.3.7"
```

I ran into this when I created a response model like:
```
class ChatResponse(BaseModel):
    action_data: dict[str, Any] | None = Field(
        default=None,
        description="The required data for the action that will be performed.",
    )
    content: str = Field(description="A contextual response to the user's message.")
```
