### PR TITLE
Renamed the OpenAI Schema 

### DIFF
--- a/instructor/__init__.py
+++ b/instructor/__init__.py
@@ -11,7 +11,7 @@ from .dsl import (
     llm_validator,
     openai_moderation,
 )
-from .function_calls import OpenAISchema, openai_schema
+from .function_calls import InstructModel, openai_schema
 from .patch import apatch, patch
 from .process_response import handle_parallel_model
 from .client import (
@@ -29,7 +29,7 @@ __all__ = [
     "from_litellm",
     "AsyncInstructor",
     "Provider",
-    "OpenAISchema",
+    "InstructModel",
     "CitationMixin",
     "IterableModel",
     "Maybe",

--- a/instructor/dsl/iterable.py
+++ b/instructor/dsl/iterable.py
@@ -3,7 +3,7 @@ from collections.abc import AsyncGenerator, Generator, Iterable
 
 from pydantic import BaseModel, Field, create_model
 
-from instructor.function_calls import OpenAISchema
+from instructor.function_calls import InstructModel
 from instructor.mode import Mode
 from instructor.utils import extract_json_from_stream, extract_json_from_stream_async
 
@@ -214,7 +214,7 @@ def IterableModel(
         ),
     )
 
-    base_models = cast(tuple[type[BaseModel], ...], (OpenAISchema, IterableBase))
+    base_models = cast(tuple[type[BaseModel], ...], (InstructModel, IterableBase))
     new_cls = create_model(
         name,
         tasks=list_tasks,
@@ -231,6 +231,6 @@ def IterableModel(
         else description
     )
     assert issubclass(
-        new_cls, OpenAISchema
+        new_cls, InstructModel
     ), "The new class should be a subclass of OpenAISchema"
     return new_cls

--- a/instructor/dsl/parallel.py
+++ b/instructor/dsl/parallel.py
@@ -9,16 +9,16 @@ from typing import (
 )
 from collections.abc import Generator
 from pydantic import BaseModel
-from instructor.function_calls import OpenAISchema, openai_schema
+from instructor.function_calls import InstructModel, openai_schema
 from collections.abc import Iterable
 
 from instructor.mode import Mode
 
-T = TypeVar("T", bound=OpenAISchema)
+T = TypeVar("T", bound=InstructModel)
 
 
 class ParallelBase:
-    def __init__(self, *models: type[OpenAISchema]):
+    def __init__(self, *models: type[InstructModel]):
         # Note that for everything else we've created a class, but for parallel base it is an instance
         assert len(models) > 0, "At least one model is required"
         self.models = models

--- a/instructor/dsl/simple_type.py
+++ b/instructor/dsl/simple_type.py
@@ -6,7 +6,7 @@ from enum import Enum
 
 
 from instructor.dsl.partial import Partial
-from instructor.function_calls import OpenAISchema
+from instructor.function_calls import InstructModel
 
 
 T = typing.TypeVar("T")
@@ -27,7 +27,7 @@ class ModelAdapter(typing.Generic[T]):
             "Response",
             content=(response_model, ...),
             __doc__="Correctly Formated and Extracted Response.",
-            __base__=(AdapterBase, OpenAISchema),
+            __base__=(AdapterBase, InstructModel),
         )
 
 

--- a/instructor/dsl/validators.py
+++ b/instructor/dsl/validators.py
@@ -3,11 +3,11 @@ from typing import Callable, Optional
 from openai import OpenAI
 from pydantic import Field
 
-from instructor.function_calls import OpenAISchema
+from instructor.function_calls import InstructModel
 from instructor.client import Instructor
 
 
-class Validator(OpenAISchema):
+class Validator(InstructModel):
     """
     Validate if an attribute is correct and if not,
     return a new value with an error message


### PR DESCRIPTION
Renamed OpenAI Schema to InstructModel so that it's more general purpose and can be used for a greater variety of tasks
<!-- ELLIPSIS_HIDDEN -->

----

| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit 3505740e417ac48c4ad14abe6e0c3b3f47cb9423  | 
|--------|--------|

### Summary:
Renamed `OpenAISchema` to `InstructModel` across multiple files for a more general-purpose naming convention.

**Key points**:
- Renamed `OpenAISchema` to `InstructModel` in `instructor/__init__.py`, `instructor/dsl/iterable.py`, `instructor/dsl/parallel.py`, `instructor/dsl/simple_type.py`, `instructor/dsl/validators.py`, `instructor/function_calls.py`, and `instructor/process_response.py`.
- Updated imports, class definitions, and type hints to use `InstructModel`.
- Ensured consistency across all files by replacing all instances of `OpenAISchema` with `InstructModel`.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)


<!-- ELLIPSIS_HIDDEN -->