### PR TITLE
Reverting OpenAI Back to the original Schema 

### DIFF
--- a/instructor/function_calls.py
+++ b/instructor/function_calls.py
@@ -2,8 +2,8 @@
 import json
 import logging
 from functools import wraps
-from typing import Annotated, Any, Optional, TypeVar, cast, get_origin, Literal, Union
-from enum import Enum
+from typing import Annotated, Any, Optional, TypeVar, cast
+
 import asyncio
 from docstring_parser import parse
 from openai.types.chat import ChatCompletion
@@ -295,7 +295,8 @@ class OpenAISchema(BaseModel):
         strict: Optional[bool] = None,
     ) -> BaseModel:
         from anthropic.types import Message
-        if isinstance(completion, Message) and completion.stop_reason == 'max_tokens':
+
+        if isinstance(completion, Message) and completion.stop_reason == "max_tokens":
             raise IncompleteOutputException(last_completion=completion)
 
         # Anthropic returns arguments as a dict, dump to json for model validation below
@@ -323,7 +324,7 @@ class OpenAISchema(BaseModel):
 
         assert isinstance(completion, Message)
 
-        if completion.stop_reason == 'max_tokens':
+        if completion.stop_reason == "max_tokens":
             raise IncompleteOutputException(last_completion=completion)
 
         text = completion.content[0].text


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit 0bfda0269f61dca42d323ee2b9e791d3b0c2d20c  | 
|--------|--------|

### Summary:
Reverted `openai_schema` function to its original implementation, removed `openai_schema_helper`, and simplified schema creation.

**Key points**:
- Reverted `openai_schema` function to its original implementation in `instructor/function_calls.py`.
- Removed `openai_schema_helper` function from `instructor/function_calls.py`.
- Simplified schema creation by directly wrapping the class with `OpenAISchema`.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)



<!-- ELLIPSIS_HIDDEN -->