### PR TITLE
Fix typo in handle_response_model (anthropic system message): responsd -> respond

### DIFF
--- a/instructor/process_response.py
+++ b/instructor/process_response.py
@@ -356,7 +356,7 @@ def handle_response_model(
                 )
 
                 new_kwargs["system"] += f"""
-                You must only responsd in JSON format that adheres to the following schema:
+                You must only respond in JSON format that adheres to the following schema:
 
                 <JSON_SCHEMA>
                 {json.dumps(response_model.model_json_schema(), indent=2)}
@@ -365,7 +365,7 @@ def handle_response_model(
                 new_kwargs["system"] = dedent(new_kwargs["system"])
             else:
                 new_kwargs["system"] += dedent(f"""
-                You must only responsd in JSON format that adheres to the following schema:
+                You must only respond in JSON format that adheres to the following schema:
 
                 <JSON_SCHEMA>
                 {json.dumps(response_model.model_json_schema(), indent=2)}


### PR DESCRIPTION
I was briefly reading the code and this jumped out to me - nothing critical at all but probably worth correcting.
<!-- ELLIPSIS_HIDDEN -->

----

| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit ddfcded1827dd542bf539c6235695fde8671379b  | 
|--------|--------|

### Summary:
Fixed typo in `handle_response_model` function in `instructor/process_response.py`, correcting 'responsd' to 'respond'.

**Key points**:
- Fixed typo in `handle_response_model` function in `instructor/process_response.py`.
- Corrected 'responsd' to 'respond' in system messages.
- Ensures accurate spelling in generated system messages.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)


<!-- ELLIPSIS_HIDDEN -->