### PR TITLE
Add structured output tests

### DIFF
--- a/tests/llm/test_openai/evals/test_entities.py
+++ b/tests/llm/test_openai/evals/test_entities.py
@@ -87,7 +87,7 @@ The contract can be terminated with a 30-day notice, unless there are outstandin
 
 @pytest.mark.parametrize("model, mode", product(models, modes))
 def test_extract(model, mode, client):
-    client = instructor.patch(client, mode=mode)
+    client = instructor.from_openai(client, mode=mode)
     if (mode, model) in {
         (Mode.JSON, "gpt-3.5-turbo"),
         (Mode.JSON, "gpt-4"),

--- a/tests/llm/test_openai/evals/test_extract_users.py
+++ b/tests/llm/test_openai/evals/test_extract_users.py
@@ -30,7 +30,7 @@ def test_extract(model, data, mode, client):
         pytest.skip(f"{mode} mode is not supported for {model}, skipping test")
 
     # Setting up the client with the instructor patch
-    client = instructor.patch(client, mode=mode)
+    client = instructor.from_openai(client, mode=mode)
 
     # Calling the extract function with the provided model, sample data, and mode
     response = client.chat.completions.create(

--- a/tests/llm/test_openai/evals/test_sentiment_analysis.py
+++ b/tests/llm/test_openai/evals/test_sentiment_analysis.py
@@ -43,7 +43,7 @@ def test_sentiment_analysis(model, data, mode, client):
     }:
         pytest.skip(f"{mode} mode is not supported for {model}, skipping test")
 
-    client = instructor.patch(client, mode=mode)
+    client = instructor.from_openai(client, mode=mode)
 
     response = client.chat.completions.create(
         model=model,

--- a/tests/llm/test_openai/test_modes.py
+++ b/tests/llm/test_openai/test_modes.py
@@ -19,7 +19,7 @@ class Order(BaseModel):
 
 @pytest.mark.parametrize("model, mode", product(models, modes))
 def test_nested(model, mode, client):
-    client = instructor.patch(client, mode=mode)
+    client = instructor.from_openai(client, mode=mode)
     content = """
     Order Details:
     Customer: Jason
@@ -62,7 +62,7 @@ class LibraryRecord(BaseModel):
 
 @pytest.mark.parametrize("model, mode", product(models, modes))
 def test_complex_nested_model(model, mode, client):
-    client = instructor.patch(client, mode=mode)
+    client = instructor.from_openai(client, mode=mode)
 
     content = """
     Library visit details:

--- a/tests/llm/test_openai/test_stream.py
+++ b/tests/llm/test_openai/test_stream.py
@@ -15,7 +15,12 @@ class UserExtract(BaseModel):
 
 @pytest.mark.parametrize("model, mode, stream", product(models, modes, [True, False]))
 def test_iterable_model(model, mode, stream, client):
-    client = instructor.patch(client, mode=mode)
+    client = instructor.from_openai(client, mode=mode)
+
+    # TODO: Remove this once we support streaming for structured outputs
+    if mode == instructor.Mode.STRUCTURED_OUTPUTS:
+        pytest.skip("Skipping test for structured outputs mode")
+
     model = client.chat.completions.create(
         model=model,
         response_model=Iterable[UserExtract],
@@ -32,7 +37,12 @@ def test_iterable_model(model, mode, stream, client):
 @pytest.mark.parametrize("model, mode, stream", product(models, modes, [True, False]))
 @pytest.mark.asyncio
 async def test_iterable_model_async(model, mode, stream, aclient):
-    aclient = instructor.patch(aclient, mode=mode)
+    aclient = instructor.from_openai(aclient, mode=mode)
+
+    # TODO: Remove this once we support streaming for structured outputs
+    if mode == instructor.Mode.STRUCTURED_OUTPUTS:
+        pytest.skip("Skipping test for structured outputs mode")
+
     model = await aclient.chat.completions.create(
         model=model,
         response_model=Iterable[UserExtract],
@@ -53,6 +63,11 @@ async def test_iterable_model_async(model, mode, stream, aclient):
 @pytest.mark.parametrize("model,mode", product(models, modes))
 def test_partial_model(model, mode, client):
     client = instructor.patch(client, mode=mode)
+
+    # TODO: Remove this once we support streaming for structured outputs
+    if mode == instructor.Mode.STRUCTURED_OUTPUTS:
+        pytest.skip("Skipping test for structured outputs mode")
+
     model = client.chat.completions.create(
         model=model,
         response_model=Partial[UserExtract],
@@ -70,6 +85,11 @@ def test_partial_model(model, mode, client):
 @pytest.mark.asyncio
 async def test_partial_model_async(model, mode, aclient):
     aclient = instructor.patch(aclient, mode=mode)
+
+    # TODO: Remove this once we support streaming for structured outputs
+    if mode == instructor.Mode.STRUCTURED_OUTPUTS:
+        pytest.skip("Skipping test for structured outputs mode")
+
     model = await aclient.chat.completions.create(
         model=model,
         response_model=Partial[UserExtract],

--- a/tests/llm/test_openai/util.py
+++ b/tests/llm/test_openai/util.py
@@ -1,6 +1,4 @@
 import instructor
 
 models = ["gpt-4o-mini"]
-modes = [
-    instructor.Mode.TOOLS,
-]
+modes = [instructor.Mode.TOOLS, instructor.Mode.STRUCTURED_OUTPUTS]


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit b87f741527a8603116f08527ef7b7c61ad3501ce  | 
|--------|--------|

### Summary:
This PR introduces `STRUCTURED_OUTPUTS` mode, updates related files, includes tests, and replaces `instructor.patch` with `instructor.from_openai` in test files.

**Key points**:
- Introduces `STRUCTURED_OUTPUTS` mode in `instructor/mode.py`.
- Updates `instructor/client.py` to handle `STRUCTURED_OUTPUTS` with `client.beta.chat.completions.parse`.
- Implements `parse_structured_output` in `instructor/function_calls.py`.
- Modifies `instructor/retry.py` for `STRUCTURED_OUTPUTS` retries.
- Updates `instructor/process_response.py` to set `response_format` for `STRUCTURED_OUTPUTS`.
- Updates `pyproject.toml` to version `1.4.0` and `openai` dependency to `^1.40.0`.
- Adds tests for `STRUCTURED_OUTPUTS` in `tests/llm/test_openai/util.py`.
- Skips streaming tests for `STRUCTURED_OUTPUTS` in `tests/llm/test_openai/test_stream.py`.
- Replaces `instructor.patch` with `instructor.from_openai` in test files for mode handling.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)



<!-- ELLIPSIS_HIDDEN -->