### PR TITLE
skip test if version less than 3.10

### DIFF
--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -2,7 +2,6 @@ from typing import TypeVar
 
 
 from datetime import datetime, date, time
-from pydantic import BaseModel
 from instructor import openai_schema
 from decimal import Decimal
 from uuid import UUID

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -8,7 +8,8 @@ from decimal import Decimal
 from uuid import UUID
 from typing import Annotated, Union, Optional, Literal, Any
 from collections import OrderedDict
-
+import pytest
+import sys
 from pydantic import BaseModel, Field
 
 T = TypeVar("T")
@@ -107,7 +108,7 @@ def test_openai_schema_ordered_dict_mapping():
 
     assert openai_schema(TestModel).model_json_schema() == TestModel.model_json_schema()
 
-
+@pytest.mark.skipif(sys.version_info < (3, 10), reason="requires python3.10 or higher")
 def test_openai_schema_supports_optional_none_310():
     class DummyWithOptionalNone(BaseModel):
         """


### PR DESCRIPTION
Currently this test fails on python 3.9 
<!-- ELLIPSIS_HIDDEN -->

----

| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit 119ad9e3ce8f1a6a9b3130f63525eaa4827df6aa  | 
|--------|--------|

### Summary:
This PR skips `test_openai_schema_supports_optional_none_310` in `tests/test_schema.py` for Python versions below 3.10 to prevent test failures.

**Key points**:
- Added `import sys` and `import pytest` to `tests/test_schema.py`.
- Applied `@pytest.mark.skipif` decorator to `test_openai_schema_supports_optional_none_310`.
- Skips `test_openai_schema_supports_optional_none_310` if Python version is less than 3.10.
- Ensures compatibility by avoiding test execution on unsupported Python versions.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)


<!-- ELLIPSIS_HIDDEN -->