### PR TITLE
Adding support for multi-modal file input for Vertex AI

### DIFF
--- a/instructor/client_vertexai.py
+++ b/instructor/client_vertexai.py
@@ -33,7 +33,7 @@ def _create_vertexai_tool(model: BaseModel) -> gm.Tool:
 
 
 def vertexai_message_parser(
-    message: dict[str, str | list[str | gm.Part]],
+    message: dict[str, str | gm.Part | list[str | gm.Part]],
 ) -> gm.Content:
     if isinstance(message["content"], str):
         return gm.Content(
@@ -54,7 +54,7 @@ def vertexai_message_parser(
 
 
 def _vertexai_message_list_parser(
-    messages: list[dict[str, str | list[str | gm.Part]]],
+    messages: list[dict[str, str | gm.Part | list[str | gm.Part]]],
 ) -> list[gm.Content]:
     contents = [
         vertexai_message_parser(message) if isinstance(message, dict) else message

--- a/instructor/client_vertexai.py
+++ b/instructor/client_vertexai.py
@@ -32,13 +32,30 @@ def _create_vertexai_tool(model: BaseModel) -> gm.Tool:
     return tool
 
 
-def vertexai_message_parser(message: dict[str, str]) -> gm.Content:
-    return gm.Content(
-        role=message["role"], parts=[gm.Part.from_text(message["content"])]
-    )
+def vertexai_message_parser(
+    message: dict[str, str | list[str | gm.Part]],
+) -> gm.Content:
+    if isinstance(message["content"], str):
+        return gm.Content(
+            role=message["role"], parts=[gm.Part.from_text(message["content"])]
+        )
+    elif isinstance(message["content"], list):
+        parts = []
+        for item in message["content"]:
+            if isinstance(item, str):
+                parts.append(gm.Part.from_text(item))
+            elif isinstance(item, gm.Part):
+                parts.append(item)
+            else:
+                raise ValueError(f"Unsupported content type in list: {type(item)}")
+        return gm.Content(role=message["role"], parts=parts)
+    else:
+        raise ValueError("Unsupported message content type")
 
 
-def _vertexai_message_list_parser(messages: list[dict[str, str]]) -> list[gm.Content]:
+def _vertexai_message_list_parser(
+    messages: list[dict[str, str | list[str | gm.Part]]],
+) -> list[gm.Content]:
     contents = [
         vertexai_message_parser(message) if isinstance(message, dict) else message
         for message in messages

--- a/tests/llm/test_vertexai/test_message_parser.py
+++ b/tests/llm/test_vertexai/test_message_parser.py
@@ -1,0 +1,56 @@
+import pytest
+import vertexai.generative_models as gm
+from instructor.client_vertexai import vertexai_message_parser
+
+from .util import models, modes
+
+
+@pytest.mark.parametrize("model, mode", [(models[0], modes[0])])
+def test_vertexai_message_parser_string_content(model, mode):
+    message = {"role": "user", "content": "Hello, world!"}
+    result = vertexai_message_parser(message)
+
+    assert isinstance(result, gm.Content)
+    assert result.role == "user"
+    assert len(result.parts) == 1
+    assert isinstance(result.parts[0], gm.Part)
+    assert result.parts[0].text == "Hello, world!"
+
+
+@pytest.mark.parametrize("model, mode", [(models[0], modes[0])])
+def test_vertexai_message_parser_list_content(model, mode):
+    message = {
+        "role": "user",
+        "content": [
+            "Hello, ",
+            gm.Part.from_text("world!"),
+            gm.Part.from_text(" How are you?"),
+        ],
+    }
+    result = vertexai_message_parser(message)
+
+    assert isinstance(result, gm.Content)
+    assert result.role == "user"
+    assert len(result.parts) == 3
+    assert isinstance(result.parts[0], gm.Part)
+    assert isinstance(result.parts[1], gm.Part)
+    assert isinstance(result.parts[2], gm.Part)
+    assert result.parts[0].text == "Hello, "
+    assert result.parts[1].text == "world!"
+    assert result.parts[2].text == " How are you?"
+
+
+@pytest.mark.parametrize("model, mode", [(models[0], modes[0])])
+def test_vertexai_message_parser_invalid_content(model, mode):
+    message = {"role": "user", "content": 123}  # Invalid content type
+
+    with pytest.raises(ValueError, match="Unsupported message content type"):
+        vertexai_message_parser(message)
+
+
+@pytest.mark.parametrize("model, mode", [(models[0], modes[0])])
+def test_vertexai_message_parser_invalid_list_item(model, mode):
+    message = {"role": "user", "content": ["Hello", 123, gm.Part.from_text("world!")]}
+
+    with pytest.raises(ValueError, match="Unsupported content type in list"):
+        vertexai_message_parser(message)


### PR DESCRIPTION
### Context and Motivation

The existing `vertexai_message_parser` function only supports messages with either string content or a list of string content. This limits the flexibility of the Vertex AI client, as it cannot handle messages containing both strings and `gm.Part` objects, which are necessary for including images, videos, documents, and audio files.

This PR introduces support for providing `Part` objects, enhancing the flexibility and functionality of the Vertex AI client.

### Summary of Changes 

- Modified `vertexai_message_parser` to handle messages with mixed content types, including strings and `gm.Part` objects.
- Added unit tests to ensure the correct parsing of messages with mixed content types.

### Detailed Explanation

The updated `vertexai_message_parser` now checks for list content, and if found, iterates through the list items. For each item, it checks if it's a string or a `gm.Part` object. If it's a string, it converts it to a `gm.Part` object. Otherwise, it simply appends the existing `gm.Part` object to the list of parts. This ensures that the final `gm.Content` object contains a list of `gm.Part` objects, correctly representing the message content.

### Testing

New unit tests have been added to `tests/llm/test_vertexai/test_message_parser.py` to cover the following scenarios:

- Parsing a message with string content.
- Parsing a message with a list of string content.
- Parsing a message with a list containing both strings and `gm.Part` objects.
- Handling invalid content types.
- Handling invalid items in a list.


### Relevant Links

- [Issue #946 ](https://github.com/jxnl/instructor/issues/946)
- [Image understanding  |  Generative AI on Vertex AI](https://cloud.google.com/vertex-ai/generative-ai/docs/multimodal/image-understanding)
<!-- ELLIPSIS_HIDDEN -->

----

| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit 8de32adcfab67844aa6c50cccdf9c28fcef2656b  | 
|--------|--------|

### Summary:
Enhanced `vertexai_message_parser` to support mixed content types, adding tests for validation.

**Key points**:
- Updated `vertexai_message_parser` in `instructor/client_vertexai.py` to handle mixed content types: strings and `gm.Part` objects.
- Added error handling for unsupported content types in `vertexai_message_parser`.
- Modified `_vertexai_message_list_parser` to support the updated `vertexai_message_parser`.
- Added unit tests in `tests/llm/test_vertexai/test_message_parser.py` for various content scenarios, including mixed content types.
- Added integration tests in `tests/llm/test_vertexai/test_modes.py` to validate mixed content handling in real scenarios.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)


<!-- ELLIPSIS_HIDDEN -->