### PR TITLE
Changed asserts in partial tests

### DIFF
--- a/tests/dsl/test_partial.py
+++ b/tests/dsl/test_partial.py
@@ -99,7 +99,7 @@ def test_summary_extraction():
             updates += 1
         previous_summary = extraction.summary
 
-    assert updates > 1
+    assert updates == 1
 
 
 @pytest.mark.asyncio
@@ -127,4 +127,4 @@ async def test_summary_extraction_async():
             updates += 1
         previous_summary = extraction.summary
 
-    assert updates > 1
+    assert updates == 1


### PR DESCRIPTION
In #948 , we modified the way that we handle streaming to support literals. This means that now if we have a field like the following 

```
from pydantic import BaseModel


class Summary(BaseModel):
    summary_passage: str
```

Previously we would have streamed the summary passage out chunk by chunk ( so a few characters at at time) but now we will only assign the field once the entire field's value has been streamed.

Therefore we should update our tests to reflect this
<!-- ELLIPSIS_HIDDEN -->

----

| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit a04fa655ffcf3658e158ca9accfb6285b4fa8cfe  | 
|--------|--------|

### Summary:
Updated assertions in `tests/dsl/test_partial.py` to expect a single update during streaming, reflecting new behavior for handling literals.

**Key points**:
- Updated `assert` statements in `tests/dsl/test_partial.py`.
- Changed `assert updates > 1` to `assert updates == 1` in `test_summary_extraction` and `test_summary_extraction_async`.
- Reflects new streaming behavior where fields are assigned once the entire value is streamed.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)


<!-- ELLIPSIS_HIDDEN -->