### PR TITLE
Expand litellm anthropic compatibility

### DIFF
--- a/instructor/process_response.py
+++ b/instructor/process_response.py
@@ -308,8 +308,14 @@ def handle_response_model(
                     },
                 )
             # if it is, system append the schema to the end
-            else:
+            elif isinstance(new_kwargs["messages"][0]["content"], str):
                 new_kwargs["messages"][0]["content"] += f"\n\n{message}"
+            elif isinstance(new_kwargs["messages"][0]["content"], list):
+                new_kwargs["messages"][0]["content"][0]["text"] += f"\n\n{message}"
+            else:
+                raise ValueError(
+                    "Invalid message format, must be a string or a list of messages"
+                )
         elif mode == Mode.ANTHROPIC_TOOLS:
             tool_descriptions = response_model.anthropic_schema
             new_kwargs["tools"] = [tool_descriptions]

--- a/instructor/retry.py
+++ b/instructor/retry.py
@@ -71,10 +71,15 @@ def reask_messages(response: ChatCompletion, mode: Mode, exception: Exception):
     if mode == Mode.ANTHROPIC_JSON:
         from anthropic.types import Message
 
-        assert isinstance(response, Message)
+        if hasattr(response, "choices"):
+            response_text = response.choices[0].message.content
+        else:
+            assert isinstance(response, Message)
+            response_text = response.content[0].text
+
         yield {
             "role": "user",
-            "content": f"""Validation Errors found:\n{exception}\nRecall the function correctly, fix the errors found in the following attempt:\n{response.content[0].text}""",
+            "content": f"""Validation Errors found:\n{exception}\nRecall the function correctly, fix the errors found in the following attempt:\n{response_text}""",
         }
         return
     if mode == Mode.COHERE_TOOLS or mode == Mode.COHERE_JSON_SCHEMA:


### PR DESCRIPTION
Resolves #951 

Two changes regarding the processing of `Mode.ANTHROPIC_JSON` and `Mode.MD_JSON`:

- For `Mode.ANTHROPIC_JSON`; LiteLLM return a type `ModelResponse` (very similar to `ChatCompletion`. Extended `Mode.ANTHROPIC_JSON` to not fail directly with `assert isinstance(completion, Message)`, but to also check for the attribute `choices` to handle either `ModelResponse` or `ChatCompletion` as input.
- For `Mode.MD_JSON`, when extending the system message, check whether the content is of type `str` or `list` and extend the system message accordingly.
<!-- ELLIPSIS_HIDDEN -->

----

| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit 7165ecde528dc2eb933a0d5e322f434cd55d68fe  | 
|--------|--------|

### Summary:
This PR enhances LiteLLM's compatibility with `Mode.ANTHROPIC_JSON` and `Mode.MD_JSON` by handling different response types and content formats.

**Key points**:
- Updated `instructor/function_calls.py` to handle `ModelResponse` and `ChatCompletion` in `Mode.ANTHROPIC_JSON`.
- Modified `parse_anthropic_json` to check for `choices` attribute and handle `finish_reason`.
- Enhanced `instructor/process_response.py` to extend system messages based on content type in `Mode.MD_JSON`.
- Adjusted `handle_response_model` to raise errors for invalid message formats.
- Updated `instructor/retry.py` to handle `choices` attribute in `reask_messages` for `Mode.ANTHROPIC_JSON`.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)


<!-- ELLIPSIS_HIDDEN -->