### PR TITLE
fix: ensure that utf-8 characters are not translated into \uXXXX format

### DIFF
--- a/instructor/process_response.py
+++ b/instructor/process_response.py
@@ -357,11 +357,18 @@ def handle_response_model(
                 new_kwargs["system"] += f"""
                 You must only respond in JSON format that adheres to the following schema:
 
-            <JSON_SCHEMA>
-            {json.dumps(response_model.model_json_schema(), indent=2, ensure_ascii=True)}
-            </JSON_SCHEMA>
-            """
-            new_kwargs["system"] = dedent(new_kwargs["system"])
+                <JSON_SCHEMA>
+                {json.dumps(response_model.model_json_schema(), indent=2, ensure_ascii=False)}
+                </JSON_SCHEMA>
+                """
+                new_kwargs["system"] = dedent(new_kwargs["system"])
+            else:
+                new_kwargs["system"] += dedent(f"""
+                You must only respond in JSON format that adheres to the following schema:
+                <JSON_SCHEMA>
+                 {json.dumps(response_model.model_json_schema(), indent=2, ensure_ascii=False)}
+                </JSON_SCHEMA>
+                """)
 
             new_kwargs["messages"] = [
                 message

--- a/instructor/process_response.py
+++ b/instructor/process_response.py
@@ -270,7 +270,7 @@ def handle_response_model(
                 As a genius expert, your task is to understand the content and provide
                 the parsed objects in json that match the following json_schema:\n
 
-                {json.dumps(response_model.model_json_schema(), indent=2, ensure_ascii=True)}
+                {json.dumps(response_model.model_json_schema(), indent=2, ensure_ascii=False)}
 
                 Make sure to return an instance of the JSON, not the schema itself
                 """
@@ -436,7 +436,7 @@ The output must be a valid JSON object that `{response_model.__name__}.model_val
                 As a genius expert, your task is to understand the content and provide
                 the parsed objects in json that match the following json_schema:\n
 
-                {json.dumps(response_model.model_json_schema(), indent=2, ensure_ascii=True)}
+                {json.dumps(response_model.model_json_schema(), indent=2, ensure_ascii=False)}
 
                 Make sure to return an instance of the JSON, not the schema itself
                 """

--- a/instructor/process_response.py
+++ b/instructor/process_response.py
@@ -270,7 +270,7 @@ def handle_response_model(
                 As a genius expert, your task is to understand the content and provide
                 the parsed objects in json that match the following json_schema:\n
 
-                {json.dumps(response_model.model_json_schema(), indent=2)}
+                {json.dumps(response_model.model_json_schema(), indent=2, ensure_ascii=True)}
 
                 Make sure to return an instance of the JSON, not the schema itself
                 """
@@ -357,19 +357,11 @@ def handle_response_model(
                 new_kwargs["system"] += f"""
                 You must only respond in JSON format that adheres to the following schema:
 
-                <JSON_SCHEMA>
-                {json.dumps(response_model.model_json_schema(), indent=2)}
-                </JSON_SCHEMA>
-                """
-                new_kwargs["system"] = dedent(new_kwargs["system"])
-            else:
-                new_kwargs["system"] += dedent(f"""
-                You must only respond in JSON format that adheres to the following schema:
-
-                <JSON_SCHEMA>
-                {json.dumps(response_model.model_json_schema(), indent=2)}
-                </JSON_SCHEMA>
-                """)
+            <JSON_SCHEMA>
+            {json.dumps(response_model.model_json_schema(), indent=2, ensure_ascii=True)}
+            </JSON_SCHEMA>
+            """
+            new_kwargs["system"] = dedent(new_kwargs["system"])
 
             new_kwargs["messages"] = [
                 message
@@ -437,7 +429,7 @@ The output must be a valid JSON object that `{response_model.__name__}.model_val
                 As a genius expert, your task is to understand the content and provide
                 the parsed objects in json that match the following json_schema:\n
 
-                {json.dumps(response_model.model_json_schema(), indent=2)}
+                {json.dumps(response_model.model_json_schema(), indent=2, ensure_ascii=True)}
 
                 Make sure to return an instance of the JSON, not the schema itself
                 """

--- a/tests/llm/test_vertexai/test_message_parser.py
+++ b/tests/llm/test_vertexai/test_message_parser.py
@@ -2,11 +2,8 @@ import pytest
 import vertexai.generative_models as gm
 from instructor.client_vertexai import vertexai_message_parser
 
-from .util import models, modes
 
-
-@pytest.mark.parametrize("model, mode", [(models[0], modes[0])])
-def test_vertexai_message_parser_string_content(model, mode):
+def test_vertexai_message_parser_string_content():
     message = {"role": "user", "content": "Hello, world!"}
     result = vertexai_message_parser(message)
 
@@ -17,8 +14,7 @@ def test_vertexai_message_parser_string_content(model, mode):
     assert result.parts[0].text == "Hello, world!"
 
 
-@pytest.mark.parametrize("model, mode", [(models[0], modes[0])])
-def test_vertexai_message_parser_list_content(model, mode):
+def test_vertexai_message_parser_list_content():
     message = {
         "role": "user",
         "content": [
@@ -40,16 +36,14 @@ def test_vertexai_message_parser_list_content(model, mode):
     assert result.parts[2].text == " How are you?"
 
 
-@pytest.mark.parametrize("model, mode", [(models[0], modes[0])])
-def test_vertexai_message_parser_invalid_content(model, mode):
+def test_vertexai_message_parser_invalid_content():
     message = {"role": "user", "content": 123}  # Invalid content type
 
     with pytest.raises(ValueError, match="Unsupported message content type"):
         vertexai_message_parser(message)
 
 
-@pytest.mark.parametrize("model, mode", [(models[0], modes[0])])
-def test_vertexai_message_parser_invalid_list_item(model, mode):
+def test_vertexai_message_parser_invalid_list_item():
     message = {"role": "user", "content": ["Hello", 123, gm.Part.from_text("world!")]}
 
     with pytest.raises(ValueError, match="Unsupported content type in list"):

--- a/tests/test_response_model_conversion.py
+++ b/tests/test_response_model_conversion.py
@@ -1,0 +1,23 @@
+from instructor.process_response import handle_response_model
+from pydantic import BaseModel, Field
+import instructor
+
+
+def test_anthropic_json_preserves_description_of_non_english_characters() -> None:
+    class User(BaseModel):
+        name: str = Field(description="用户的名字")
+        age: int = Field(description="用户的年龄")
+
+    _, user_tool_definition = handle_response_model(
+        User, mode=instructor.Mode.ANTHROPIC_JSON
+    )
+    print(user_tool_definition["system"])
+    assert "用户的名字" in user_tool_definition["system"]
+    assert "用户的年龄" in user_tool_definition["system"]
+
+    _, user_tool_definition = handle_response_model(
+        User, mode=instructor.Mode.ANTHROPIC_JSON, system="你是一个AI助手"
+    )
+    print(user_tool_definition["system"])
+    assert "用户的名字" in user_tool_definition["system"]
+    assert "用户的年龄" in user_tool_definition["system"]

--- a/tests/test_response_model_conversion.py
+++ b/tests/test_response_model_conversion.py
@@ -1,23 +1,55 @@
 from instructor.process_response import handle_response_model
 from pydantic import BaseModel, Field
 import instructor
+import pytest
+
+modes = [
+    instructor.Mode.ANTHROPIC_JSON,
+    instructor.Mode.JSON,
+    instructor.Mode.MD_JSON,
+    instructor.Mode.JSON,
+    instructor.Mode.GEMINI_JSON,
+    instructor.Mode.VERTEXAI_JSON,
+]
 
 
-def test_anthropic_json_preserves_description_of_non_english_characters() -> None:
+def get_system_prompt(user_tool_definition, mode):
+    if mode == instructor.Mode.ANTHROPIC_JSON:
+        return user_tool_definition["system"]
+    elif mode == instructor.Mode.GEMINI_JSON:
+        return "\n".join(user_tool_definition["contents"][0]["parts"])
+    elif mode == instructor.Mode.VERTEXAI_JSON:
+        return str(user_tool_definition["generation_config"])
+    return user_tool_definition["messages"][0]["content"]
+
+
+@pytest.mark.parametrize("mode", modes)
+def test_json_preserves_description_of_non_english_characters_in_json_mode(
+    mode,
+) -> None:
+    messages = [
+        {
+            "role": "user",
+            "content": "Extract the user from the text : 张三 20岁",
+        }
+    ]
+
     class User(BaseModel):
         name: str = Field(description="用户的名字")
         age: int = Field(description="用户的年龄")
 
-    _, user_tool_definition = handle_response_model(
-        User, mode=instructor.Mode.ANTHROPIC_JSON
-    )
-    print(user_tool_definition["system"])
-    assert "用户的名字" in user_tool_definition["system"]
-    assert "用户的年龄" in user_tool_definition["system"]
+    _, user_tool_definition = handle_response_model(User, mode=mode, messages=messages)
+
+    system_prompt = get_system_prompt(user_tool_definition, mode)
+    assert "用户的名字" in system_prompt
+    assert "用户的年龄" in system_prompt
 
     _, user_tool_definition = handle_response_model(
-        User, mode=instructor.Mode.ANTHROPIC_JSON, system="你是一个AI助手"
+        User,
+        mode=mode,
+        system="你是一个AI助手",
+        messages=messages,
     )
-    print(user_tool_definition["system"])
-    assert "用户的名字" in user_tool_definition["system"]
-    assert "用户的年龄" in user_tool_definition["system"]
+    system_prompt = get_system_prompt(user_tool_definition, mode)
+    assert "用户的名字" in system_prompt
+    assert "用户的年龄" in system_prompt

--- a/tests/test_response_model_conversion.py
+++ b/tests/test_response_model_conversion.py
@@ -7,7 +7,6 @@ modes = [
     instructor.Mode.ANTHROPIC_JSON,
     instructor.Mode.JSON,
     instructor.Mode.MD_JSON,
-    instructor.Mode.JSON,
     instructor.Mode.GEMINI_JSON,
     instructor.Mode.VERTEXAI_JSON,
 ]


### PR DESCRIPTION
Forked @largomst's PR because I couldn't push suggested changes to it.

This introduces new support for non-english descriptions in Pydantic Models for JSON modes. Also added some tests to verify the changes work - both for system and non-system parameters
<!-- ELLIPSIS_HIDDEN -->


----

| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit e7673aaac875e25ec14587aee31da417d6fe3cf6  | 
|--------|--------|

### Summary:
This PR adds support for non-English descriptions in Pydantic Models and ensures UTF-8 character preservation in JSON outputs, with modifications and tests included.

**Key points**:
- Adds support for non-English descriptions in Pydantic Models.
- Ensures UTF-8 character preservation in JSON outputs.
- Forked @largomst's PR to implement changes.
- Modifies `handle_response_model` to use `json.dumps` with `ensure_ascii=False`.
- Adds tests in `tests/test_response_model_conversion.py` for UTF-8 handling.
- Tests cover modes: `ANTHROPIC_JSON`, `JSON`, `MD_JSON`, `GEMINI_JSON`, `VERTEXAI_JSON`.
- Simplifies tests in `tests/llm/test_vertexai/test_message_parser.py`.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)



<!-- ELLIPSIS_HIDDEN -->