### PR TITLE
Testing Refusal Attribute on this branch

### DIFF
--- a/instructor/function_calls.py
+++ b/instructor/function_calls.py
@@ -315,9 +315,12 @@ class OpenAISchema(BaseModel):
         assert (
             len(message.tool_calls or []) == 1
         ), "Instructor does not support multiple tool calls, use List[Model] instead."
-        assert (
-            message.refusal is None
-        ), f"Unable to generate a response due to {message.refusal}"
+        # this field seems to be missing when using instructor with some other tools (e.g. litellm)
+        # trying to fix this by adding a check
+        if hasattr(message, "refusal"):
+            assert (
+                message.refusal is None
+            ), f"Unable to generate a response due to {message.refusal}"
         tool_call = message.tool_calls[0]  # type: ignore
         assert (
             tool_call.function.name == cls.openai_schema["name"]  # type: ignore[index]

--- a/instructor/function_calls.py
+++ b/instructor/function_calls.py
@@ -309,15 +309,15 @@ class OpenAISchema(BaseModel):
         strict: Optional[bool] = None,
     ) -> BaseModel:
         message = completion.choices[0].message
-        assert (
-            len(message.tool_calls or []) == 1
-        ), "Instructor does not support multiple tool calls, use List[Model] instead."
         # this field seems to be missing when using instructor with some other tools (e.g. litellm)
         # trying to fix this by adding a check
         if hasattr(message, "refusal"):
             assert (
                 message.refusal is None
             ), f"Unable to generate a response due to {message.refusal}"
+        assert (
+            len(message.tool_calls or []) == 1
+        ), "Instructor does not support multiple tool calls, use List[Model] instead."
         tool_call = message.tool_calls[0]  # type: ignore
         assert (
             tool_call.function.name == cls.openai_schema["name"]  # type: ignore[index]

--- a/tests/test_function_calls.py
+++ b/tests/test_function_calls.py
@@ -238,7 +238,7 @@ def test_refusal_attribute(test_model: type[OpenAISchema]):
         assert "Unable to generate a response due to test_refusal" in str(e)
 
 
-def test_no_refusal_attribute(test_model: type[OpenAISchema]):
+def test_successful_response_with_null_refusal(test_model: type[OpenAISchema]):
     completion = ChatCompletion(
         id="test_id",
         created=1234567890,

--- a/tests/test_function_calls.py
+++ b/tests/test_function_calls.py
@@ -237,6 +237,42 @@ def test_refusal_attribute(test_model: type[OpenAISchema]):
     except Exception as e:
         assert "Unable to generate a response due to test_refusal" in str(e)
 
+
+def test_no_refusal_attribute(test_model: type[OpenAISchema]):
+    completion = ChatCompletion(
+        id="test_id",
+        created=1234567890,
+        model="gpt-3.5-turbo",
+        object="chat.completion",
+        choices=[
+            Choice(
+                index=0,
+                message=ChatCompletionMessage(
+                    content="test_content",
+                    refusal=None,
+                    role="assistant",
+                    tool_calls=[
+                        ChatCompletionMessageToolCall(
+                            id="test_id",
+                            function=Function(
+                                name="TestModel",
+                                arguments='{"data": "test_data", "name": "TestModel"}',
+                            ),
+                            type="function",
+                        )
+                    ],
+                ),
+                finish_reason="stop",
+                logprobs=None,
+            )
+        ],
+    )
+
+    resp = test_model.from_response(completion, mode=instructor.Mode.TOOLS)
+    assert resp.data == "test_data"
+    assert resp.name == "TestModel"
+
+
 def test_missing_refusal_attribute(test_model: type[OpenAISchema]):
     message_without_refusal_attribute = ChatCompletionMessage(
         content="test_content",
@@ -246,7 +282,8 @@ def test_missing_refusal_attribute(test_model: type[OpenAISchema]):
             ChatCompletionMessageToolCall(
                 id="test_id",
                 function=Function(
-                    name="TestModel", arguments='{"data": "test_data", "name": "TestModel"}'
+                    name="TestModel",
+                    arguments='{"data": "test_data", "name": "TestModel"}',
                 ),
                 type="function",
             )
@@ -270,13 +307,7 @@ def test_missing_refusal_attribute(test_model: type[OpenAISchema]):
             )
         ],
     )
-    
+
     resp = test_model.from_response(completion, mode=instructor.Mode.TOOLS)
     assert resp.data == "test_data"
     assert resp.name == "TestModel"
-
-
-# class User(BaseModel):
-#     name: str
-#     age: int
-#schema = openai_schema(User)


### PR DESCRIPTION
This is a temporary PR to check a branch
<!-- ELLIPSIS_HIDDEN -->


----

| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit 05c41eb758793fe53aa8b36f7dd2ccc56359cda8  | 
|--------|--------|

### Summary:
Added checks for 'refusal' attribute in `parse_tools` and updated tests for missing or None cases.

**Key points**:
- Added check for 'refusal' attribute in `instructor/function_calls.py:parse_tools` to handle missing cases.
- Modified assertion to check `refusal` is None only if attribute exists.
- Added `test_refusal_attribute`, `test_no_refusal_attribute`, and `test_missing_refusal_attribute` in `tests/test_function_calls.py` to verify behavior with different `refusal` attribute states.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)



<!-- ELLIPSIS_HIDDEN -->