### PR TITLE
Fixed up a warning for the relevant clients

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -49,6 +49,17 @@ instructor docs [QUERY]
 
 You can also check out our [cookbooks](./examples/index.md) and [concepts](./concepts/models.md) to learn more about how to use Instructor.
 
+??? info "Make sure you've installed the dependencies for your specific client"
+
+    To keep the bundle size small, `instructor` only ships with the OpenAI client. You can install the rest with the following:
+
+    1. Anthropic : `pip install instructor[anthropic]`
+    2. Google Generative AI: `pip install instructor[google-generativeai]`
+    3. Vertex AI: `pip install instructor[vertexai]`
+    4. Cohere: `pip install instructor[cohere]`
+    5. Litellm: `pip install instructor[litellm]`
+    6. Mistral: `pip install instructor[mistralai]`
+
 Now, let's see Instructor in action with a simple example:
 
 ### Using OpenAI

--- a/docs/index.md
+++ b/docs/index.md
@@ -51,14 +51,14 @@ You can also check out our [cookbooks](./examples/index.md) and [concepts](./con
 
 ??? info "Make sure you've installed the dependencies for your specific client"
 
-    To keep the bundle size small, `instructor` only ships with the OpenAI client. You can install the rest with the following:
+    To keep the bundle size small, `instructor` only ships with the OpenAI client. Before using the other clients and their respective `from_xx` method, make sure you've installed the dependencies following the instructions below.
 
-    1. Anthropic : `pip install instructor[anthropic]`
-    2. Google Generative AI: `pip install instructor[google-generativeai]`
-    3. Vertex AI: `pip install instructor[vertexai]`
-    4. Cohere: `pip install instructor[cohere]`
-    5. Litellm: `pip install instructor[litellm]`
-    6. Mistral: `pip install instructor[mistralai]`
+    1. Anthropic : `pip install "instructor[anthropic]"`
+    2. Google Generative AI: `pip install "instructor[google-generativeai]"`
+    3. Vertex AI: `pip install "instructor[vertexai]"`
+    4. Cohere: `pip install "instructor[cohere]"`
+    5. Litellm: `pip install "instructor[litellm]"`
+    6. Mistral: `pip install "instructor[mistralai]"`
 
 Now, let's see Instructor in action with a simple example:
 


### PR DESCRIPTION
Added a small section in the index file which tells people they need to install the client depencies using the `instructor[client]` format in order to use the clients.
<!-- ELLIPSIS_HIDDEN -->

----

| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit 349e7cdf3d33661588caef8f00aff9a9895dc650  | 
|--------|--------|

### Summary:
Added instructions in `docs/index.md` for installing client-specific dependencies for using various clients with `instructor`.

**Key points**:
- Added a section in `docs/index.md` to inform users about installing client-specific dependencies.
- Lists installation commands for Anthropic, Google Generative AI, Vertex AI, Cohere, Litellm, and Mistral clients.
- Ensures users are aware that `instructor` only ships with the OpenAI client by default.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)


<!-- ELLIPSIS_HIDDEN -->