### PR TITLE
removing deprecated Mistral Client

### DIFF
--- a/instructor/client_mistral.py
+++ b/instructor/client_mistral.py
@@ -24,7 +24,8 @@ def from_mistral(
 
 
 def from_mistral(
-    client: mistralai.client.MistralClient | mistralaiasynccli.MistralAsyncClient,
+    # deprecated from MistralClient, MistralAsyncClient to Mistral (https://github.com/mistralai/client-python/blob/main/MIGRATION.md)
+    client: mistralai.client.Mistral | mistralaiasynccli.Mistral,
     mode: instructor.Mode = instructor.Mode.MISTRAL_TOOLS,
     **kwargs: Any,
 ) -> instructor.Instructor | instructor.AsyncInstructor:


### PR DESCRIPTION
Fixing simple issue: #969 using MistralClient https://github.com/mistralai/client-python/blob/main/MIGRATION.md
<!-- ELLIPSIS_HIDDEN -->

----

| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit 77b1cbf352ba7b7036ed143c8cf559d38c9670f5  | 
|--------|--------|

### Summary:
Replaced deprecated `MistralClient` and `MistralAsyncClient` with `Mistral` in `from_mistral` function of `instructor/client_mistral.py`.

**Key points**:
- Updated `from_mistral` function in `instructor/client_mistral.py`.
- Replaced deprecated `MistralClient` and `MistralAsyncClient` with `Mistral`.
- Ensures compatibility with the latest Mistral client library as per migration guide.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)


<!-- ELLIPSIS_HIDDEN -->