### PR TITLE
Change Gemini to use Tools by default

### DIFF
--- a/docs/blog/posts/announcing-gemini-tool-calling-support.md
+++ b/docs/blog/posts/announcing-gemini-tool-calling-support.md
@@ -1,0 +1,115 @@
+---
+draft: False
+date: 2024-09-03
+authors:
+  - ivanleomk
+---
+
+# Structured Outputs for Gemini now supported
+
+We're excited to announce that `instructor` now supports structured outputs using tool calling for both the Gemini SDK and the VertexAI SDK.
+
+A special shoutout to [Sonal](https://x.com/sonalsaldanha) for his contributions to the Gemini Tool Calling support.
+
+Let's walk through a simple example of how to use these new features
+
+## Installation
+
+To get started, install the latest version of `instructor`. Depending on whether you're using Gemini or VertexAI, you should install the following:
+
+=== "Gemini"
+
+    ```bash
+    pip install "instructor[gemini]"
+    ```
+
+=== "VertexAI"
+
+    ```bash
+    pip install "instructor[vertexai]"
+    ```
+
+This ensures that you have the necessary dependencies to use the Gemini or VertexAI SDKs with instructor.
+
+We recommend using the Gemini SDK over the VertexAI SDK for two main reasons.
+
+1. Compared to the VertexAI SDK, the Gemini SDK comes with a free daily quota of 1.5 billion tokens to use for developers.
+2. The Gemini SDK is significantly easier to setup, all you need is a `GOOGLE_API_KEY` that you can generate in your GCP console. THe VertexAI SDK on the other hand requires a credentials.json file or an OAuth integration to use.
+
+## Getting Started
+
+With our provider agnostic API, you can use the same interface to interact with both SDKs, the only thing that changes here is how we initialise the client itself.
+
+Before running the following code, you'll need to make sure that you have your Gemini API Key set in your shell under the alias `GOOGLE_API_KEY`.
+
+```python
+import instructor
+import google.generativeai as genai
+from pydantic import BaseModel
+
+
+class User(BaseModel):
+    name: str
+    age: int
+
+
+client = instructor.from_gemini(
+    client=genai.GenerativeModel(
+        model_name="models/gemini-1.5-flash-latest", # (1)!
+    )
+)
+
+resp = client.chat.completions.create(
+    messages=[
+        {
+            "role": "user",
+            "content": "Extract Jason is 25 years old.",
+        }
+    ],
+    response_model=User,
+)
+
+print(resp)
+#> name='Jason' age=25
+```
+
+1. Current Gemini models that support tool calling are `gemini-1.5-flash-latest` and `gemini-1.5-pro-latest`.
+
+We can achieve a similar thing with the VertexAI SDK. For this to work, you'll need to authenticate to VertexAI.
+
+There are some instructions [here](https://cloud.google.com/vertex-ai/docs/authentication) but the easiest way I found was to simply download the GCloud cli and run `gcloud auth application-default login`.
+
+```python
+import instructor
+import vertexai  # type: ignore
+from vertexai.generative_models import GenerativeModel  # type: ignore
+from pydantic import BaseModel
+
+vertexai.init()
+
+
+class User(BaseModel):
+    name: str
+    age: int
+
+
+client = instructor.from_vertexai(
+    client=GenerativeModel("gemini-1.5-pro-preview-0409"), # (1)!
+)
+
+
+resp = client.chat.completions.create(
+    messages=[
+        {
+            "role": "user",
+            "content": "Extract Jason is 25 years old.",
+        }
+    ],
+    response_model=User,
+)
+
+print(resp)
+#> name='Jason' age=25
+```
+
+1. Current Gemini models that support tool calling are `gemini-1.5-flash-latest` and `gemini-1.5-pro-latest`.

--- a/instructor/client_gemini.py
+++ b/instructor/client_gemini.py
@@ -11,7 +11,7 @@ import instructor
 @overload
 def from_gemini(
     client: genai.GenerativeModel,
-    mode: instructor.Mode = instructor.Mode.GEMINI_JSON,
+    mode: instructor.Mode = instructor.Mode.GEMINI_TOOLS,
     use_async: Literal[True] = True,
     **kwargs: Any,
 ) -> instructor.AsyncInstructor: ...
@@ -20,7 +20,7 @@ def from_gemini(
 @overload
 def from_gemini(
     client: genai.GenerativeModel,
-    mode: instructor.Mode = instructor.Mode.GEMINI_JSON,
+    mode: instructor.Mode = instructor.Mode.GEMINI_TOOLS,
     use_async: Literal[False] = False,
     **kwargs: Any,
 ) -> instructor.Instructor: ...
@@ -28,7 +28,7 @@ def from_gemini(
 
 def from_gemini(
     client: genai.GenerativeModel,
-    mode: instructor.Mode = instructor.Mode.GEMINI_JSON,
+    mode: instructor.Mode = instructor.Mode.GEMINI_TOOLS,
     use_async: bool = False,
     **kwargs: Any,
 ) -> instructor.Instructor | instructor.AsyncInstructor:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "instructor"
-version = "1.4.0"
+version = "1.4.1"
 description = "structured outputs for llm"
 authors = ["Jason Liu <jason@jxnl.co>"]
 license = "MIT"


### PR DESCRIPTION
This PR introduces a new change to the default mode used in the from_gemini client so that it uses GEMINI_TOOLS by default
<!-- ELLIPSIS_HIDDEN -->

----

| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit f14302e42e08d4645e4515ac47c492666da8f69f  | 
|--------|--------|

### Summary:
The `from_gemini` function in `instructor/client_gemini.py` now defaults to `GEMINI_TOOLS` mode instead of `GEMINI_JSON`.

**Key points**:
- Changes default mode in `from_gemini` function to `GEMINI_TOOLS`.
- Affects both synchronous and asynchronous overloads.
- Modifications made in `instructor/client_gemini.py`.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)


<!-- ELLIPSIS_HIDDEN -->