### PR TITLE
Fixed typo in the installation command

### DIFF
--- a/docs/blog/posts/announcing-gemini-tool-calling-support.md
+++ b/docs/blog/posts/announcing-gemini-tool-calling-support.md
@@ -20,7 +20,7 @@ To get started, install the latest version of `instructor`. Depending on whether
 === "Gemini"
 
     ```bash
-    pip install "instructor[gemini]"
+    pip install "instructor[google-generativeai]"
     ```
 
 === "VertexAI"


### PR DESCRIPTION
It should be `pip install [google-generativeai]` instead of `pip install [gemini]`
<!-- ELLIPSIS_HIDDEN -->

----

| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit d47f1d86ab7d5b0adb235b433e2c8423bd866fe2  | 
|--------|--------|

### Summary:
Fixed installation command typo in `docs/blog/posts/announcing-gemini-tool-calling-support.md` to ensure correct package installation for Gemini SDK.

**Key points**:
- Corrected installation command in `docs/blog/posts/announcing-gemini-tool-calling-support.md`.
- Changed `pip install "instructor[gemini]"` to `pip install "instructor[google-generativeai]"`.
- Ensures correct package installation for Gemini SDK support.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)


<!-- ELLIPSIS_HIDDEN -->