### PR TITLE
Fixing blog typo for post "Should I Be Using Structured Outputs?"

### DIFF
--- a/docs/blog/posts/introducing-structured-outputs.md
+++ b/docs/blog/posts/introducing-structured-outputs.md
@@ -240,7 +240,7 @@ During the meeting, we agreed on several key points. The conference will be held
 
 The budget for the event is set at $50,000, covering venue costs, speaker fees, and promotional activities. Each participant is expected to contribute an article to the conference blog by February 20th.
 
-A follow-up meetingis scheduled for January 25th at 3 PM GMT to finalize the agenda and confirm the list of speakers.
+A follow-up meeting is scheduled for January 25th at 3 PM GMT to finalize the agenda and confirm the list of speakers.
 """
 
 

--- a/docs/blog/posts/introducing-structured-outputs.md
+++ b/docs/blog/posts/introducing-structured-outputs.md
@@ -179,7 +179,7 @@ print(resp)
 #> name='JASON' age=25
 ```
 
-This built-in retry logic allows for targetted correction to the generated response, ensuring that outputs are not only consistent with your schema but also corect for your use-case. This is invaluable in building reliable LLM systems.
+This built-in retry logic allows for targetted correction to the generated response, ensuring that outputs are not only consistent with your schema but also correct for your use-case. This is invaluable in building reliable LLM systems.
 
 ### Real-time Streaming Validation
 


### PR DESCRIPTION
The word "correct" has a typo where it only has one "r". This is a quick change from corect->correct.
Added a missing space in an example prompt that my IDE picked up on (meetingis->meeting is).
<!-- ELLIPSIS_HIDDEN -->

----

| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit 59c3f7a9d02ae23be81828500e274528423251ba  | 
|--------|--------|

fix: correct typo in blog post "Should I Be Using Structured Outputs?"

### Summary:
Fix typo in `introducing-structured-outputs.md`, changing "corect" to "correct".

**Key points**:
- Fix typo in `introducing-structured-outputs.md`, changing "corect" to "correct".


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)


<!-- ELLIPSIS_HIDDEN -->