### PR TITLE
fix: handle whitespace in json streams

### DIFF
--- a/instructor/dsl/partial.py
+++ b/instructor/dsl/partial.py
@@ -129,7 +129,7 @@ class PartialBase(Generic[T_Model]):
         partial_model = cls.get_partial_model()
         for chunk in json_chunks:
             potential_object += chunk
-            obj = from_json((potential_object or "{}").encode(), partial_mode="on")
+            obj = from_json((potential_object.strip() or "{}").encode(), partial_mode="on")
             obj = partial_model.model_validate(obj, strict=None, **kwargs)
             yield obj
 
@@ -141,7 +141,7 @@ class PartialBase(Generic[T_Model]):
         partial_model = cls.get_partial_model()
         async for chunk in json_chunks:
             potential_object += chunk
-            obj = from_json((potential_object or "{}").encode(), partial_mode="on")
+            obj = from_json((potential_object.strip() or "{}").encode(), partial_mode="on")
             obj = partial_model.model_validate(obj, strict=None, **kwargs)
             yield obj
 

--- a/tests/dsl/test_partial.py
+++ b/tests/dsl/test_partial.py
@@ -71,7 +71,8 @@ def test_partial():
         "type": "object",
     }, "Partial model JSON schema has changed"
 
-    for model in partial.model_from_chunks(['{"b": {"b": 1}}']):
+    # Handle any leading whitespace from the model
+    for model in partial.model_from_chunks(['\n', '\t', ' ', '{"b": {"b": 1}}']):
         assert model.model_dump() == {"a": None, "b": {"b": 1}}
 
 


### PR DESCRIPTION
Previously if an LLM generated content intended to be JSON with preceding whitespace, jiter would fail in to_json with a ValueError. This is easily remedied by stripping whitespace before comparing with the default json '{}'

Closes: #994 

<!-- ELLIPSIS_HIDDEN -->

----

| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit 506ae56313d8b0ad3c6c805da77b50ccab925972  | 
|--------|--------|

fix: handle leading whitespace in JSON streams

### Summary:
Fixes JSON stream handling by stripping leading whitespace in `model_from_chunks()` and `model_from_chunks_async()` in `partial.py`.

**Key points**:
- **Behavior**:
  - Fixes `ValueError` in `model_from_chunks()` and `model_from_chunks_async()` in `partial.py` by stripping leading whitespace from JSON chunks.
- **Tests**:
  - Updates `test_partial()` in `test_partial.py` to include JSON chunks with leading whitespace.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)


<!-- ELLIPSIS_HIDDEN -->