### PR TITLE
Fixed up failing test cases for partial parsing

### DIFF
--- a/tests/dsl/test_partial.py
+++ b/tests/dsl/test_partial.py
@@ -71,10 +71,31 @@ def test_partial():
         "type": "object",
     }, "Partial model JSON schema has changed"
 
-    # Handle any leading whitespace from the model
-    for model in partial.model_from_chunks(['\n', '\t', ' ', '{"b": {"b": 1}}']):
-        assert model.model_dump() == {"a": None, "b": {"b": 1}}
+    
 
+def test_partial_with_whitespace():
+    partial = Partial[SamplePartial]
+    final_model = None
+    # Handle any leading whitespace from the model
+    for model in partial.model_from_chunks(["\n", "\t", " ", '{"b": {"b": 1}}']):
+        final_model = model
+
+    assert final_model.model_dump() == {"a": None, "b": {"b": 1}}
+
+@pytest.mark.asyncio
+async def test_async_partial_with_whitespace():
+    partial = Partial[SamplePartial]
+    final_model = None
+    # Handle any leading whitespace from the model
+    async def async_generator():
+        for chunk in ["\n", "\t", " ", '{"b": {"b": 1}}']:
+            yield chunk
+
+    async for model in partial.model_from_chunks_async(async_generator()):
+        final_model = model
+
+    assert final_model.model_dump() == {"a": None, "b": {"b": 1}}
+    
 
 def test_summary_extraction():
     class Summary(BaseModel):


### PR DESCRIPTION
Currently our tests for partials are failing because the tests haven't been updated correctly. Our assertions always fail because we get the following error

```
FAILED tests/dsl/test_partial.py::test_partial - AssertionError: assert {'a': None, 'b': {}} == {'a': None, 'b': {'b': 1}}
  Omitting 1 identical items, use -vv to show
  Differing items:
  {'b': {}} != {'b': {'b': 1}}
  Full diff:
  - {'a': None, 'b': {'b': 1}}
  ?                   ------
  + {'a': None, 'b': {}}
```

This is because as we process the model in chunks, the final object isn't obtained until the final iteration. Added a test for the async processor too and updated both tests to pass
<!-- ELLIPSIS_HIDDEN -->

----

| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit 964f79a0355f53319523d8af59f76137b9aed729  | 
|--------|--------|

fix: update partial parsing tests for correct chunk processing

### Summary:
Fixes and updates partial parsing tests to correctly handle model processing in chunks, including whitespace, and adds async test.

**Key points**:
- **Tests**:
  - Fix `test_partial` in `test_partial.py` to correctly assert final model after processing all chunks.
  - Add `test_partial_with_whitespace` to handle leading whitespace in model chunks.
  - Add `test_async_partial_with_whitespace` to verify async processing of model chunks with whitespace.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)


<!-- ELLIPSIS_HIDDEN -->