### PR TITLE
fix(rag-and-beyond.md): Formatting

### DIFF
--- a/docs/blog/posts/rag-and-beyond.md
+++ b/docs/blog/posts/rag-and-beyond.md
@@ -226,6 +226,6 @@ This is not about fancy embedding tricks, it's just plain old information retrie
 
 ## What's Next?
 
-Here I want to show that `instructor`` isn’t just about data extraction. It’s a powerful framework for building a data model and integrating it with your LLM. Structured output is just the beginning — the untapped goldmine is skilled use of tools and APIs.
+Here I want to show that `instructor` isn’t just about data extraction. It’s a powerful framework for building a data model and integrating it with your LLM. Structured output is just the beginning — the untapped goldmine is skilled use of tools and APIs.
 
 If you enjoy the content or want to try out `instructor` please check out the [github](https://github.com/jxnl/instructor) and give us a star!


### PR DESCRIPTION
Fixed an extra backtick that was breaking some formatting:
![image](https://github.com/user-attachments/assets/07dcfbdd-3929-421b-996a-57a3f3b4bbca)

----

Now it should render as:
> Here I want to show that `instructor` isn't just about [...]

as intended.
<!-- ELLIPSIS_HIDDEN -->

----

| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit 37c349558151e26d6f87dda71561e1ec5fe50ed5  | 
|--------|--------|

fix: remove extra backtick in `rag-and-beyond.md`

### Summary:
Remove extra backtick in `rag-and-beyond.md` to fix formatting issue.

**Key points**:
- **Formatting Fix**:
  - Removed an extra backtick in `rag-and-beyond.md` to correct rendering of a sentence.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)


<!-- ELLIPSIS_HIDDEN -->