### PR TITLE
fix: Add parse_from_string method to BatchJob

### DIFF
--- a/instructor/batch.py
+++ b/instructor/batch.py
@@ -80,6 +80,30 @@ class BatchJob:
             return res, error_objs
 
     @classmethod
+    def parse_from_string(
+        cls, content: str, response_model: type[T]
+    ) -> tuple[list[T], list[dict[Any, Any]]]:
+        res: list[T] = []
+        error_objs: list[dict[Any, Any]] = []
+        lines = content.splitlines()
+        for line in lines:
+            data = json.loads(line)
+            try:
+                res.append(
+                    response_model(
+                        **json.loads(
+                            data["response"]["body"]["choices"][0]["message"][
+                                "tool_calls"
+                            ][0]["function"]["arguments"]
+                        )
+                    )
+                )
+            except Exception:
+                error_objs.append(data)
+
+        return res, error_objs
+
+    @classmethod
     def create_from_messages(
         cls,
         messages_batch: Union[


### PR DESCRIPTION
BatchJob.parse_from_string() accomplishes the same function as parse_from_file() but takes the batch job result in-memory and uses that instead of having to have the intermediary step of writing the results to disk and reading them again.

This implements the feature request in #1031 .
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds `parse_from_string()` to `BatchJob` for parsing batch job results from a string.
> 
>   - **New Method**:
>     - Adds `parse_from_string()` to `BatchJob` class in `batch.py`.
>     - Parses batch job results from a string, similar to `parse_from_file()`.
>     - Returns a tuple of parsed results and error objects.
>   - **Feature Request**:
>     - Implements feature request #1031.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=jxnl%2Finstructor&utm_source=github&utm_medium=referral)<sup> for 31d56db2cd9cd86fd495cee29982442e729e6feb. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->