### PR TITLE
Bump version and add partial support

### DIFF
--- a/instructor/dsl/partial.py
+++ b/instructor/dsl/partial.py
@@ -169,7 +169,12 @@ class PartialBase(Generic[T_Model]):
                         Mode.warn_mode_functions_deprecation()
                         if json_chunk := chunk.choices[0].delta.function_call.arguments:
                             yield json_chunk
-                    elif mode in {Mode.JSON, Mode.MD_JSON, Mode.JSON_SCHEMA}:
+                    elif mode in {
+                        Mode.JSON,
+                        Mode.MD_JSON,
+                        Mode.JSON_SCHEMA,
+                        Mode.CEREBRAS_JSON,
+                    }:
                         if json_chunk := chunk.choices[0].delta.content:
                             yield json_chunk
                     elif mode in {Mode.TOOLS, Mode.TOOLS_STRICT}:
@@ -198,7 +203,12 @@ class PartialBase(Generic[T_Model]):
                         Mode.warn_mode_functions_deprecation()
                         if json_chunk := chunk.choices[0].delta.function_call.arguments:
                             yield json_chunk
-                    elif mode in {Mode.JSON, Mode.MD_JSON, Mode.JSON_SCHEMA}:
+                    elif mode in {
+                        Mode.JSON,
+                        Mode.MD_JSON,
+                        Mode.JSON_SCHEMA,
+                        Mode.CEREBRAS_JSON,
+                    }:
                         if json_chunk := chunk.choices[0].delta.content:
                             yield json_chunk
                     elif mode in {Mode.TOOLS, Mode.TOOLS_STRICT}:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "instructor"
-version = "1.5.1"
+version = "1.5.2"
 description = "structured outputs for llm"
 authors = ["Jason Liu <jason@jxnl.co>"]
 license = "MIT"


### PR DESCRIPTION
Got partials working with Cerebras client + bump instructor version

```python
client = instructor.from_cerebras(Cerebras(), mode=instructor.Mode.CEREBRAS_JSON)


text_block = """
In our recent online meeting, participants from various backgrounds joined to discuss the upcoming tech conference. The names and contact details of the participants were as follows:

- Name: Alice Brown, Email: alice.brown@email.com, Twitter: @AliceInTech
- Name: Bob White, Email: bob.white@email.com, Twitter: @BobTheBuilder
- Name: Charlie Green, Email: charlie.green@email.com, Twitter: @CharlieCodes
- Name: Dana Black, Email: dana.black@email.com, Twitter: @DanaDev
- Name: Eva Blue, Email: eva.blue@email.com, Twitter: @EvaInnovates
- Name: Frank Red, Email: frank.red@email.com, Twitter: @FranklySpeaking
- Name: Grace Yellow, Email: grace.yellow@email.com, Twitter: @GraceGoesTech
- Name: Henry Purple, Email: henry.purple@email.com, Twitter: @HenryHacks
- Name: Ivy Orange, Email: ivy.orange@email.com, Twitter: @IvyInTech
- Name: Jack Grey, Email: jack.grey@email.com, Twitter: @JackOfAllTech
- Name: John Doe, Email: johndoe@email.com, Twitter: @TechGuru44
- Name: Jane Smith, Email: janesmith@email.com, Twitter: @DigitalDiva88
- Name: Alex Johnson, Email: alexj@email.com, Twitter: @CodeMaster2023


During the meeting, we agreed on several key points. The conference will be held on March 15th, 2024, at the Grand Tech Arena located at 4521 Innovation Drive. Dr. Emily Johnson, a renowned AI researcher, will be our keynote speaker.

The budget for the event is set at $50,000, covering venue costs, speaker fees, and promotional activities. Each participant is expected to contribute an article to the conference blog by February 20th.

A follow-up meeting is scheduled for January 25th at 3 PM GMT to finalize the agenda and confirm the list of speakers.
"""


class User(BaseModel):
    name: str
    email: str
    twitter: str


class MeetingInfo(BaseModel):
    users: list[User]
    date: str
    location: str
    budget: int
    deadline: str
    agenda: str


extraction_stream = client.chat.completions.create_partial(
    model="llama3.1-70b",
    response_model=MeetingInfo,
    messages=[
        {
            "role": "user",
            "content": f"""Get the information about the meeting and the users {text_block}. Make sure to format the output as valid JSON. Do not include any other text than the JSON, start your response with a {{ and end with a }}""",
        },
    ],
    stream=True,
)

console = Console()
for extraction in extraction_stream:
    obj = extraction.model_dump()
    console.clear()
    console.print(obj)

```
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add partial support for `Mode.CEREBRAS_JSON` in `partial.py` and bump version to 1.5.2.
> 
>   - **Behavior**:
>     - Add support for `Mode.CEREBRAS_JSON` in `extract_json` and `extract_json_async` functions in `partial.py`.
>   - **Versioning**:
>     - Bump version from `1.5.1` to `1.5.2` in `pyproject.toml`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=jxnl%2Finstructor&utm_source=github&utm_medium=referral)<sup> for 026bd76062b1e5fd3843177eb0fcfc97bc0e71df. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->