### PR TITLE
Fix compatibility with custom dicts for multimodal message content

### DIFF
--- a/instructor/multimodal.py
+++ b/instructor/multimodal.py
@@ -75,19 +75,21 @@ class Image(BaseModel):
 
 
 def convert_contents(
-    contents: Union[list[Union[str, Image]], str, Image],  # noqa: UP007
+    contents: list[str | dict[str, Any] | Image] | str | dict[str, Any] | Image,  # noqa: UP007
     mode: Mode,
 ) -> Union[str, list[dict[str, Any]]]:  # noqa: UP007
     """Convert content items to the appropriate format based on the specified mode."""
     if isinstance(contents, str):
         return contents
-    if isinstance(contents, Image):
+    if isinstance(contents, Image) or isinstance(contents, dict):
         contents = [contents]
 
     converted_contents: list[dict[str, Union[str, Image]]] = []  # noqa: UP007
     for content in contents:
         if isinstance(content, str):
             converted_contents.append({"type": "text", "text": content})
+        elif isinstance(content, dict):
+            converted_contents.append(content)
         elif isinstance(content, Image):
             if mode in {Mode.ANTHROPIC_JSON, Mode.ANTHROPIC_TOOLS}:
                 converted_contents.append(content.to_anthropic())
@@ -101,7 +103,12 @@ def convert_contents(
 
 
 def convert_messages(
-    messages: list[dict[str, Union[str, list[Union[str, Image]]]]],  # noqa: UP007
+    messages: list[
+        dict[
+            str,
+            list[str | dict[str, Any] | Image] | str | dict[str, Any] | Image,
+        ]
+    ],  # noqa: UP007
     mode: Mode,
 ) -> list[dict[str, Any]]:
     """Convert messages to the appropriate format based on the specified mode."""

--- a/instructor/multimodal.py
+++ b/instructor/multimodal.py
@@ -75,7 +75,9 @@ class Image(BaseModel):
 
 
 def convert_contents(
-    contents: list[str | dict[str, Any] | Image] | str | dict[str, Any] | Image,  # noqa: UP007
+    contents: Union[  # noqa: UP007
+        list[Union[str, dict[str, Any], Image]], str, dict[str, Any], Image  # noqa: UP007
+    ],
     mode: Mode,
 ) -> Union[str, list[dict[str, Any]]]:  # noqa: UP007
     """Convert content items to the appropriate format based on the specified mode."""
@@ -106,7 +108,7 @@ def convert_messages(
     messages: list[
         dict[
             str,
-            list[str | dict[str, Any] | Image] | str | dict[str, Any] | Image,
+            Union[list[Union[str, dict[str, Any], Image]], str, dict[str, Any], Image],  # noqa: UP007
         ]
     ],  # noqa: UP007
     mode: Mode,

--- a/tests/test_multimodal.py
+++ b/tests/test_multimodal.py
@@ -180,3 +180,13 @@ def test_convert_contents_anthropic_mode():
     assert converted[1]["type"] == "image"
     assert converted[1]["source"]["type"] == "base64"
     assert converted[1]["source"]["media_type"] == "image/png"
+
+
+def test_convert_contents_custom_dict():
+    contents = {
+        "type": "image_url",
+        "image_url": {"url": f"data:image/png;base64,base64_img"},
+    }
+    converted = list(convert_contents(contents, Mode.TOOLS))
+    assert len(converted) == 1
+    assert converted == [contents]


### PR DESCRIPTION
This should fix #1052 by detecting and preserving custom `dict` contents in the `messages`. After this fix the manuals describing this behavior are valid again, such as: https://python.useinstructor.com/examples/extracting_receipts/?h=image+url#extracting-receipt-data-from-images
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes compatibility with custom `dict` objects in multimodal message content by updating `convert_contents` and `convert_messages` in `multimodal.py`.
> 
>   - **Behavior**:
>     - `convert_contents` in `multimodal.py` now supports `dict` types, preserving custom `dict` contents.
>     - `convert_messages` in `multimodal.py` updated to handle `dict` types in message content.
>   - **Tests**:
>     - Added `test_convert_contents_custom_dict` in `test_multimodal.py` to verify handling of custom `dict` contents.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=jxnl%2Finstructor&utm_source=github&utm_medium=referral)<sup> for a3f2186f0154993b82e6289d85493606e46cf859. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->