### PR TITLE
fix: resolve pyright TypedDict key access error in dump_message

### DIFF
--- a/instructor/utils.py
+++ b/instructor/utils.py
@@ -467,10 +467,15 @@ def dump_message(message: ChatCompletionMessage) -> ChatCompletionMessageParam:
         if not isinstance(ret["content"], str):
             response_message: str = ""
             for content_message in ret["content"]:
-                if "text" in content_message:
-                    response_message += content_message["text"]
-                elif "refusal" in content_message:
-                    response_message += content_message["refusal"]
+                if isinstance(content_message, dict):
+                    # Use get() to safely access values
+                    message_type = content_message.get("type")
+                    if message_type == "text":
+                        text_content = content_message.get("text", "")
+                        response_message += text_content
+                    elif message_type == "refusal":
+                        refusal_content = content_message.get("refusal", "")
+                        response_message += refusal_content
             ret["content"] = response_message
         ret["content"] += json.dumps(message.model_dump()["function_call"])
     return ret


### PR DESCRIPTION
## Summary
- Fixed pyright error when accessing 'text' key in ChatCompletionContentPartRefusalParam
- Updated the code to use `get()` method instead of direct dictionary access to handle different content part types safely

## Details
The `dump_message` function was causing a pyright error because it was directly accessing the 'text' key on content parts that could be either text or refusal types. The ChatCompletionContentPartRefusalParam TypedDict only has 'refusal' and 'type' keys, not 'text'.

The fix checks the message type first and then uses the appropriate key to extract the content, preventing the TypedDict key access error.

## Test plan
- [x] Run `uv run pyright` and verify the error at line 471 is resolved
- [x] Existing tests should continue to pass as this is a type-safety fix only

🤖 Generated with [Claude Code](https://claude.ai/code)
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes pyright TypedDict key access error in `dump_message()` by using `get()` for safe dictionary access.
> 
>   - **Behavior**:
>     - Fixes pyright error in `dump_message()` by using `get()` for safe dictionary access.
>     - Handles `text` and `refusal` content types in `ChatCompletionContentPartRefusalParam`.
>   - **Testing**:
>     - Verified error resolution by running `uv run pyright`.
>     - Ensured existing tests pass as this is a type-safety fix only.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=567-labs%2Finstructor&utm_source=github&utm_medium=referral)<sup> for 62c34edc55735f07ec4f9e6d2271381c164f4b95. You can [customize](https://app.ellipsis.dev/567-labs/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->