### PR TITLE
Revert "refactor: simplify safety settings configuration for Gemini API"

### DIFF
--- a/instructor/utils.py
+++ b/instructor/utils.py
@@ -774,7 +774,7 @@ def update_genai_kwargs(
     """
     Update keyword arguments for google.genai package from OpenAI format.
     """
-    from google.genai.types import HarmCategory
+    from google.genai.types import HarmCategory, HarmBlockThreshold
 
     new_kwargs = kwargs.copy()
 
@@ -798,16 +798,18 @@ def update_genai_kwargs(
                 base_config[gemini_key] = val
 
     safety_settings = new_kwargs.pop("safety_settings", {})
+    base_config["safety_settings"] = []
 
-    if safety_settings:
-        base_config["safety_settings"] = [
+    for category in HarmCategory:
+        if category == HarmCategory.HARM_CATEGORY_UNSPECIFIED:
+            continue
+        threshold = safety_settings.get(category, HarmBlockThreshold.OFF)
+        base_config["safety_settings"].append(
             {
                 "category": category,
                 "threshold": threshold,
             }
-            for category, threshold in safety_settings.items()
-            if category != HarmCategory.HARM_CATEGORY_UNSPECIFIED
-        ]
+        )
 
     return base_config
 


### PR DESCRIPTION
Reverts 567-labs/instructor#1659
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Reverts safety settings configuration logic in `update_genai_kwargs()` in `instructor/utils.py` to previous state, affecting harm category handling.
> 
>   - **Revert Changes**:
>     - Reverts logic in `update_genai_kwargs()` in `instructor/utils.py` to previous state.
>     - Iterates over `HarmCategory` and appends to `base_config['safety_settings']` instead of using list comprehension.
>     - Handles unspecified harm categories and default thresholds differently.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=567-labs%2Finstructor&utm_source=github&utm_medium=referral)<sup> for 31316c43f772059e0a6b00f80a3a86ba3d67975a. You can [customize](https://app.ellipsis.dev/567-labs/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->