### PR TITLE
fix(auto_client): add support for litellm provider in from_provider

### DIFF
--- a/instructor/auto_client.py
+++ b/instructor/auto_client.py
@@ -31,6 +31,7 @@ supported_providers = [
     "fireworks",
     "ollama",
     "xai",
+    "litellm",
 ]
 
 
@@ -840,6 +841,39 @@ def from_provider(
             raise ConfigurationError(
                 "The xai-sdk package is required to use the xAI provider. "
                 "Install it with `pip install xai-sdk`."
+            ) from None
+        except Exception as e:
+            logger.error(
+                "Error initializing %s client: %s",
+                provider,
+                e,
+                exc_info=True,
+                extra={**provider_info, "status": "error"},
+            )
+            raise
+
+    elif provider == "litellm":
+        try:
+            from litellm import completion, acompletion
+            from instructor import from_litellm
+
+            completion_func = acompletion if async_client else completion
+            result = from_litellm(
+                completion_func,
+                mode=mode if mode else instructor.Mode.TOOLS,
+                **kwargs,
+            )
+            logger.info(
+                "Client initialized",
+                extra={**provider_info, "status": "success"},
+            )
+            return result
+        except ImportError:
+            from instructor.exceptions import ConfigurationError
+
+            raise ConfigurationError(
+                "The litellm package is required to use the LiteLLM provider. "
+                "Install it with `pip install litellm`."
             ) from None
         except Exception as e:
             logger.error(


### PR DESCRIPTION
Fixes ##1710

Adds missing LiteLLM support to the `from_provider()` function in auto_client.py. The documentation shows examples using `instructor.from_provider("litellm/gpt-3.5-turbo")` but this was throwing a ConfigurationError.

**Changes:**
- Added "litellm" to supported_providers list
- Added litellm provider handler that integrates with existing `from_litellm()` function
- Supports both sync and async clients
- Includes proper error handling for missing litellm package

**Testing:**
- Verified both sync and async client creation work
- Confirmed existing litellm tests remain compatible
- Follows same patterns as other provider implementations

Generated with [Claude Code](https://claude.ai/code)
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds LiteLLM provider support to `from_provider()` in `auto_client.py`, including sync/async client handling and error management.
> 
>   - **Behavior**:
>     - Adds "litellm" to `supported_providers` in `auto_client.py`.
>     - Implements LiteLLM provider handler in `from_provider()` to integrate with `from_litellm()`.
>     - Supports both sync and async clients.
>     - Includes error handling for missing `litellm` package.
>   - **Testing**:
>     - Verified sync and async client creation.
>     - Confirmed compatibility with existing LiteLLM tests.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=567-labs%2Finstructor&utm_source=github&utm_medium=referral)<sup> for 3b70ca5fc3568659873e83df9c33301c875c01ab. You can [customize](https://app.ellipsis.dev/567-labs/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->