### PR TITLE
Add consistent docstrings to utils modules

### DIFF
--- a/instructor/utils/bedrock.py
+++ b/instructor/utils/bedrock.py
@@ -18,6 +18,12 @@ def reask_bedrock_json(
     response: Any,
     exception: Exception,
 ):
+    """
+    Handle reask for Bedrock JSON mode when validation fails.
+
+    Kwargs modifications:
+    - Adds: "messages" (user message requesting JSON correction)
+    """
     kwargs = kwargs.copy()
     reask_msgs = [response["output"]["message"]]
     reask_msgs.append(
@@ -37,9 +43,14 @@ def reask_bedrock_json(
 def _prepare_bedrock_converse_kwargs_internal(
     call_kwargs: dict[str, Any],
 ) -> dict[str, Any]:
-    """Minimal processing to support `converse` parameters for the Bedrock client
+    """
+    Prepare kwargs for the Bedrock Converse API.
 
-    See: https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/bedrock-runtime/client/converse.html
+    Kwargs modifications:
+    - Moves: system list to messages as a system role
+    - Renames: "model" -> "modelId"
+    - Collects: temperature, max_tokens, top_p, stop into inferenceConfig
+    - Converts: messages content to Bedrock format
     """
     # Handle Bedrock-native system parameter format: system=[{'text': '...'}]
     # Convert to OpenAI format by adding to messages as system role
@@ -176,6 +187,14 @@ def _prepare_bedrock_converse_kwargs_internal(
 def handle_bedrock_json(
     response_model: type[Any], new_kwargs: dict[str, Any]
 ) -> tuple[type[Any], dict[str, Any]]:
+    """
+    Handle Bedrock JSON mode.
+
+    Kwargs modifications:
+    - Adds: "response_format" with json_schema
+    - Adds/Modifies: "system" (prepends JSON instructions)
+    - Applies: _prepare_bedrock_converse_kwargs_internal transformations
+    """
     new_kwargs = _prepare_bedrock_converse_kwargs_internal(new_kwargs)
     json_message = dedent(
         f"""
@@ -207,6 +226,12 @@ def handle_bedrock_json(
 def handle_bedrock_tools(
     response_model: type[Any], new_kwargs: dict[str, Any]
 ) -> tuple[type[Any], dict[str, Any]]:
+    """
+    Handle Bedrock tools mode.
+
+    Kwargs modifications:
+    - Applies: _prepare_bedrock_converse_kwargs_internal transformations
+    """
     new_kwargs = _prepare_bedrock_converse_kwargs_internal(new_kwargs)
     return response_model, new_kwargs
 

--- a/instructor/utils/cerebras.py
+++ b/instructor/utils/cerebras.py
@@ -18,6 +18,12 @@ def reask_cerebras_tools(
     response: Any,
     exception: Exception,
 ):
+    """
+    Handle reask for Cerebras tools mode when validation fails.
+
+    Kwargs modifications:
+    - Adds: "messages" (tool response messages indicating validation errors)
+    """
     kwargs = kwargs.copy()
     reask_msgs = [dump_message(response.choices[0].message)]
     for tool_call in response.choices[0].message.tool_calls:
@@ -38,6 +44,14 @@ def reask_cerebras_tools(
 def handle_cerebras_tools(
     response_model: type[Any], new_kwargs: dict[str, Any]
 ) -> tuple[type[Any], dict[str, Any]]:
+    """
+    Handle Cerebras tools mode.
+
+    Kwargs modifications:
+    - Adds: "tools" (list with function schema)
+    - Adds: "tool_choice" (forced function call)
+    - Validates: stream=False
+    """
     if new_kwargs.get("stream", False):
         raise ValueError("Stream is not supported for Cerebras Tool Calling")
     new_kwargs["tools"] = [
@@ -56,6 +70,12 @@ def handle_cerebras_tools(
 def handle_cerebras_json(
     response_model: type[Any], new_kwargs: dict[str, Any]
 ) -> tuple[type[Any], dict[str, Any]]:
+    """
+    Handle Cerebras JSON mode.
+
+    Kwargs modifications:
+    - Adds: "messages" (system instruction with JSON schema)
+    """
     instruction = f"""
 You are a helpful assistant that excels at following instructions.Your task is to understand the content and provide the parsed objects in json that match the following json_schema:\n
 

--- a/instructor/utils/fireworks.py
+++ b/instructor/utils/fireworks.py
@@ -14,6 +14,12 @@ from instructor.utils.core import dump_message
 
 
 def reask_fireworks_tools(kwargs: dict[str, Any], response: Any, exception: Exception):
+    """
+    Handle reask for Fireworks tools mode when validation fails.
+
+    Kwargs modifications:
+    - Adds: "messages" (tool response messages indicating validation errors)
+    """
     kwargs = kwargs.copy()
     reask_msgs = [dump_message(response.choices[0].message)]
     for tool_call in response.choices[0].message.tool_calls:
@@ -36,6 +42,12 @@ def reask_fireworks_json(
     response: Any,
     exception: Exception,
 ):
+    """
+    Handle reask for Fireworks JSON mode when validation fails.
+
+    Kwargs modifications:
+    - Adds: "messages" (user message requesting JSON correction)
+    """
     kwargs = kwargs.copy()
     reask_msgs = [dump_message(response.choices[0].message)]
     reask_msgs.append(
@@ -51,6 +63,14 @@ def reask_fireworks_json(
 def handle_fireworks_tools(
     response_model: type[Any], new_kwargs: dict[str, Any]
 ) -> tuple[type[Any], dict[str, Any]]:
+    """
+    Handle Fireworks tools mode.
+
+    Kwargs modifications:
+    - Adds: "tools" (list with function schema)
+    - Adds: "tool_choice" (forced function call)
+    - Sets default: stream=False
+    """
     if "stream" not in new_kwargs:
         new_kwargs["stream"] = False
     new_kwargs["tools"] = [
@@ -69,6 +89,13 @@ def handle_fireworks_tools(
 def handle_fireworks_json(
     response_model: type[Any], new_kwargs: dict[str, Any]
 ) -> tuple[type[Any], dict[str, Any]]:
+    """
+    Handle Fireworks JSON mode.
+
+    Kwargs modifications:
+    - Adds: "response_format" with json_schema
+    - Sets default: stream=False
+    """
     if "stream" not in new_kwargs:
         new_kwargs["stream"] = False
 

--- a/instructor/utils/mistral.py
+++ b/instructor/utils/mistral.py
@@ -18,6 +18,12 @@ def reask_mistral_structured_outputs(
     response: Any,
     exception: Exception,
 ):
+    """
+    Handle reask for Mistral structured outputs mode when validation fails.
+
+    Kwargs modifications:
+    - Adds: "messages" (assistant content and user correction request)
+    """
     kwargs = kwargs.copy()
     reask_msgs = [
         {
@@ -42,6 +48,12 @@ def reask_mistral_tools(
     response: Any,
     exception: Exception,
 ):
+    """
+    Handle reask for Mistral tools mode when validation fails.
+
+    Kwargs modifications:
+    - Adds: "messages" (tool response messages indicating validation errors)
+    """
     kwargs = kwargs.copy()
     reask_msgs = [dump_message(response.choices[0].message)]
     for tool_call in response.choices[0].message.tool_calls:
@@ -62,6 +74,13 @@ def reask_mistral_tools(
 def handle_mistral_tools(
     response_model: type[Any], new_kwargs: dict[str, Any]
 ) -> tuple[type[Any], dict[str, Any]]:
+    """
+    Handle Mistral tools mode.
+
+    Kwargs modifications:
+    - Adds: "tools" (list with function schema)
+    - Adds: "tool_choice" set to "any"
+    """
     new_kwargs["tools"] = [
         {
             "type": "function",
@@ -75,6 +94,13 @@ def handle_mistral_tools(
 def handle_mistral_structured_outputs(
     response_model: type[Any], new_kwargs: dict[str, Any]
 ) -> tuple[type[Any], dict[str, Any]]:
+    """
+    Handle Mistral structured outputs mode.
+
+    Kwargs modifications:
+    - Adds: "response_format" derived from the response model
+    - Removes: "tools" and "response_model" from kwargs
+    """
     from mistralai.extra import response_format_from_pydantic_model
 
     new_kwargs["response_format"] = response_format_from_pydantic_model(response_model)

--- a/instructor/utils/perplexity.py
+++ b/instructor/utils/perplexity.py
@@ -17,7 +17,12 @@ def reask_perplexity_json(
     response: Any,
     exception: Exception,
 ):
-    """Handle reasking for Perplexity JSON mode."""
+    """
+    Handle reask for Perplexity JSON mode when validation fails.
+
+    Kwargs modifications:
+    - Adds: "messages" (user message requesting JSON correction)
+    """
     kwargs = kwargs.copy()
     reask_msgs = [dump_message(response.choices[0].message)]
     reask_msgs.append(
@@ -33,6 +38,12 @@ def reask_perplexity_json(
 def handle_perplexity_json(
     response_model: type[Any], new_kwargs: dict[str, Any]
 ) -> tuple[type[Any], dict[str, Any]]:
+    """
+    Handle Perplexity JSON mode.
+
+    Kwargs modifications:
+    - Adds: "response_format" with json_schema
+    """
     new_kwargs["response_format"] = {
         "type": "json_schema",
         "json_schema": {"schema": response_model.model_json_schema()},

--- a/instructor/utils/writer.py
+++ b/instructor/utils/writer.py
@@ -18,6 +18,12 @@ def reask_writer_tools(
     response: Any,
     exception: Exception,
 ):
+    """
+    Handle reask for Writer tools mode when validation fails.
+
+    Kwargs modifications:
+    - Adds: "messages" (user instructions to correct tool call)
+    """
     kwargs = kwargs.copy()
     reask_msgs = [dump_message(response.choices[0].message)]
     reask_msgs.append(
@@ -41,6 +47,12 @@ def reask_writer_json(
     response: Any,
     exception: Exception,
 ):
+    """
+    Handle reask for Writer JSON mode when validation fails.
+
+    Kwargs modifications:
+    - Adds: "messages" (user message requesting JSON correction)
+    """
     kwargs = kwargs.copy()
     reask_msgs = [dump_message(response.choices[0].message)]
     reask_msgs.append(
@@ -57,6 +69,13 @@ def reask_writer_json(
 def handle_writer_tools(
     response_model: type[Any], new_kwargs: dict[str, Any]
 ) -> tuple[type[Any], dict[str, Any]]:
+    """
+    Handle Writer tools mode.
+
+    Kwargs modifications:
+    - Adds: "tools" (list with function schema)
+    - Sets: "tool_choice" to "auto"
+    """
     new_kwargs["tools"] = [
         {
             "type": "function",
@@ -70,6 +89,12 @@ def handle_writer_tools(
 def handle_writer_json(
     response_model: type[Any], new_kwargs: dict[str, Any]
 ) -> tuple[type[Any], dict[str, Any]]:
+    """
+    Handle Writer JSON mode.
+
+    Kwargs modifications:
+    - Adds: "response_format" with json_schema
+    """
     new_kwargs["response_format"] = {
         "type": "json_schema",
         "json_schema": {"schema": response_model.model_json_schema()},


### PR DESCRIPTION
## Summary
- document reask and handler functions in utils modules
- keep docstring style consistent across providers
- run formatter

## Testing
- `uv run ruff format instructor/utils/*.py`
- `uv run pytest tests/ -k "not llm and not openai"` *(fails: openai.OpenAIError)*

------
https://chatgpt.com/codex/tasks/task_e_687ab810fedc8326b0aee00f7e30a0bd
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add consistent docstrings to utility modules for various providers and run a code formatter for style consistency.
> 
>   - **Docstrings**:
>     - Add consistent docstrings to functions in `anthropic.py`, `bedrock.py`, `cerebras.py`, `cohere.py`, `fireworks.py`, `google.py`, `mistral.py`, `perplexity.py`, and `writer.py`.
>     - Ensure docstring style consistency across all provider modules.
>   - **Formatting**:
>     - Run code formatter on `instructor/utils/*.py` to maintain code style consistency.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=567-labs%2Finstructor&utm_source=github&utm_medium=referral)<sup> for 0e73cf7e2ff68a1dc275cce7be4fbc0effbce68f. You can [customize](https://app.ellipsis.dev/567-labs/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->