### PR TITLE
fix(docs): correct broken tutorials navigation link

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -142,7 +142,7 @@ nav:
     - Help with Instructor: 'help.md'
     - Contributing: 'contributing.md'
     - Newsletter: 'newsletter.md'
-    - Tutorials: 'tutorials.md'
+    - Tutorials: 'tutorials/index.md'
   - Learning:
     - Installation: 'learning/getting_started/installation.md'
     - Overview: 'learning/index.md'


### PR DESCRIPTION
Fixes broken link to tutorials in mkdocs.yml.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes broken Tutorials link in `mkdocs.yml` by updating path to `'tutorials/index.md'`.
> 
>   - **Navigation Fix**:
>     - Corrects broken link in `mkdocs.yml` for Tutorials section from `'tutorials.md'` to `'tutorials/index.md'`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=567-labs%2Finstructor&utm_source=github&utm_medium=referral)<sup> for 71798d8c0c96307ce40af68e672030e73d9af9fe. You can [customize](https://app.ellipsis.dev/567-labs/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->