### PR TITLE
Handle Anthropic tool_use retries on ValidationError

### DIFF
--- a/instructor/providers/anthropic/utils.py
+++ b/instructor/providers/anthropic/utils.py
@@ -158,7 +158,7 @@ def reask_anthropic_tools(
         assistant_content.append(content.model_dump())  # type: ignore
         if (
             content.type == "tool_use"
-            and isinstance(exception, ValidationError | InstructorValidationError)
+            and isinstance(exception, (ValidationError, InstructorValidationError))
             and content.name == exception.title
         ):
             tool_use_id = content.id


### PR DESCRIPTION
Auto-retry when is not working when using Anthropic Claude tool use because of this error:
```
Error code: 400 - {'type': 'error', 'error': {'type': 'invalid_request_error', 'message': 'messages.2: `tool_use` ids were found without `tool_result` blocks immediately after: toolu_01KELz18M6qYvnwPEYi9wZKx. Each `tool_use` block must have a corresponding `tool_result` block in the next message.'}, 'request_id': 'req_011CT5ysHdXtzNDMm2WwNgKc'}
```
This is when first attempt resulted in `ValidationError`, eg,:
```
<generation number="1">
<exception>
    1 validation error
...
```

**To Reproduce**
Something like the below when the client is instantiated with `mode=instructor.Mode.ANTHROPIC_TOOLS` or the equivalent:

```
client.messages.create(
    model=model_id,
    messages=instruct_msgs,
    system=system_prompt,
    response_model=response_model,
)
```

**Expected behavior and fix**
That retried requests will contain the tool call result and successful generate responses (whether valid or not)

***Root cause***
In instructor/core/retry.py line 599, the `handle_reask_kwargs()` function calls:
```
exception = InstructorError.from_exception(exception, failed_attempts=failed_attempts)
```

This converts pydantic `ValidationError` exceptions to instructor `ValidationError` exceptions, so by the time the exception reaches `reask_anthropic_tools()`, it's an instructor `ValidationError`, not a pydantic one.

***Fix Applied***

File: `instructor/providers/anthropic/utils.py`
Change:
```
        if (
            content.type == "tool_use"
            and isinstance(exception, ValidationError)
            and content.name == exception.title
        ):
```
to
```
        if (
            content.type == "tool_use"
            and isinstance(exception, ValidationError | InstructorValidationError)   # should really just be InstructorValidationError, but being safe
            and content.name == exception.title
        ):
```

Seems only the `providers/anthropic/utils.py` has the problematic pattern as it is the only provider that:
- uses isinstance(exception, ValidationError) checks
- accesses the exception.title attribute
- imports ValidationError from pydantic

So OpenAI, Mistral, Gemini, Cohere, Cerebras, Fireworks, Writer, XAI, Bedrock, Perplexity, VertexAI  seem unaffected.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes auto-retry issue in `reask_anthropic_tools()` by handling both `ValidationError` and `InstructorValidationError` for Anthropic provider.
> 
>   - **Behavior**:
>     - Fixes auto-retry issue in `reask_anthropic_tools()` in `utils.py` by handling both `ValidationError` and `InstructorValidationError`.
>     - Ensures tool call results are included in retried requests for Anthropic Claude tool.
>   - **Exceptions**:
>     - Imports `InstructorValidationError` from `core.exceptions` in `utils.py`.
>     - Updates `isinstance` check to include `InstructorValidationError` in `reask_anthropic_tools()`.
>   - **Scope**:
>     - Only affects Anthropic provider; other providers like OpenAI, Mistral, etc., are unaffected.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=567-labs%2Finstructor&utm_source=github&utm_medium=referral)<sup> for b113c931049b46be3948775b23d5797a5ed3f61e. You can [customize](https://app.ellipsis.dev/567-labs/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->