### PR TITLE
fix: replace deprecated gpt-3.5-turbo-0613 with gpt-4o-mini

### DIFF
--- a/docs/blog/posts/logfire.md
+++ b/docs/blog/posts/logfire.md
@@ -98,7 +98,7 @@ Logfire can help us to log this entire function, and what's happening inside it,
 def classify(data: str) -> SinglePrediction:
     """Perform single-label classification on the input text."""
     return client.chat.completions.create(
-        model="gpt-3.5-turbo-0613",
+        model="gpt-4o-mini",
         response_model=SinglePrediction,
         messages=[
             {

--- a/docs/examples/exact_citations.md
+++ b/docs/examples/exact_citations.md
@@ -155,7 +155,7 @@ class QuestionAnswer(BaseModel):
 # <%hide%>
 def ask_ai(question: str, context: str) -> QuestionAnswer:
     return client.chat.completions.create(
-        model="gpt-3.5-turbo-0613",
+        model="gpt-4o-mini",
         temperature=0,
         response_model=QuestionAnswer,
         messages=[

--- a/examples/auto-ticketer/run.py
+++ b/examples/auto-ticketer/run.py
@@ -51,7 +51,7 @@ class ActionItems(BaseModel):
 
 def generate(data: str):
     return client.chat.completions.create(
-        model="gpt-3.5-turbo-0613",
+        model="gpt-4o-mini",
         response_model=ActionItems,
         messages=[
             {

--- a/examples/citation_with_extraction/citation_fuzzy_match.py
+++ b/examples/citation_with_extraction/citation_fuzzy_match.py
@@ -82,7 +82,7 @@ class QuestionAnswer(instructor.OpenAISchema):
 
 def ask_ai(question: str, context: str) -> QuestionAnswer:
     return client.chat.completions.create(
-        model="gpt-3.5-turbo-0613",
+        model="gpt-4o-mini",
         temperature=0,
         response_model=QuestionAnswer,
         messages=[

--- a/examples/citation_with_extraction/main.py
+++ b/examples/citation_with_extraction/main.py
@@ -82,7 +82,7 @@ class Question(BaseModel):
 # Function to extract entities from input text using GPT-3.5
 def stream_extract(question: Question) -> Iterable[Fact]:
     completion = client.chat.completions.create(
-        model="gpt-3.5-turbo-0613",
+        model="gpt-4o-mini",
         temperature=0,
         stream=True,
         functions=[QuestionAnswer.openai_schema],

--- a/examples/classification/multi_prediction.py
+++ b/examples/classification/multi_prediction.py
@@ -22,7 +22,7 @@ class MultiClassPrediction(BaseModel):
 # Modify the classify function
 def multi_classify(data: str) -> MultiClassPrediction:
     return client.chat.completions.create(
-        model="gpt-3.5-turbo-0613",
+        model="gpt-4o-mini",
         response_model=MultiClassPrediction,
         messages=[
             {

--- a/examples/classification/simple_prediction.py
+++ b/examples/classification/simple_prediction.py
@@ -22,7 +22,7 @@ class SinglePrediction(BaseModel):
 
 def classify(data: str) -> SinglePrediction:
     return client.chat.completions.create(
-        model="gpt-3.5-turbo-0613",
+        model="gpt-4o-mini",
         response_model=SinglePrediction,
         messages=[
             {

--- a/examples/gpt-engineer/generate.py
+++ b/examples/gpt-engineer/generate.py
@@ -32,7 +32,7 @@ class Program(OpenAISchema):
 
 def develop(data: str) -> Program:
     completion = client.chat.completions.create(
-        model="gpt-3.5-turbo-0613",
+        model="gpt-4o-mini",
         temperature=0.1,
         functions=[Program.openai_schema],
         function_call={"name": Program.openai_schema["name"]},

--- a/examples/logfire/classify.py
+++ b/examples/logfire/classify.py
@@ -30,7 +30,7 @@ client = instructor.from_openai(openai_client)
 def classify(data: str) -> SinglePrediction:
     """Perform single-label classification on the input text."""
     return client.chat.completions.create(
-        model="gpt-3.5-turbo-0613",
+        model="gpt-4o-mini",
         response_model=SinglePrediction,
         messages=[
             {

--- a/examples/query_planner_execution/query_planner_execution.py
+++ b/examples/query_planner_execution/query_planner_execution.py
@@ -111,7 +111,7 @@ QueryPlan.model_rebuild()
 
 def query_planner(question: str, plan=False) -> QueryPlan:
     PLANNING_MODEL = "gpt-4"
-    ANSWERING_MODEL = "gpt-3.5-turbo-0613"
+    ANSWERING_MODEL = "gpt-4o-mini"
 
     messages = [
         {

--- a/examples/recursive_filepaths/parse_recursive_paths.py
+++ b/examples/recursive_filepaths/parse_recursive_paths.py
@@ -90,7 +90,7 @@ def parse_tree_to_filesystem(data: str) -> DirectoryTree:
     """
 
     completion = client.chat.completions.create(
-        model="gpt-3.5-turbo-0613",
+        model="gpt-4o-mini",
         response_model=DirectoryTree,
         messages=[
             {

--- a/examples/safer_sql_example/safe_sql.py
+++ b/examples/safer_sql_example/safe_sql.py
@@ -58,7 +58,7 @@ class SQL(BaseModel):
 
 def create_query(data: str) -> SQL:
     completion = client.chat.completions.create(
-        model="gpt-3.5-turbo-0613",
+        model="gpt-4o-mini",
         temperature=0,
         functions=[SQL.openai_schema],
         function_call={"name": SQL.openai_schema["name"]},

--- a/examples/simple-extraction/maybe_user.py
+++ b/examples/simple-extraction/maybe_user.py
@@ -18,7 +18,7 @@ MaybeUser = instructor.Maybe(UserDetail)
 
 def get_user_detail(string) -> MaybeUser:  # type: ignore
     return client.chat.completions.create(
-        model="gpt-3.5-turbo-0613",
+        model="gpt-4o-mini",
         response_model=MaybeUser,
         messages=[
             {

--- a/examples/simple-extraction/user.py
+++ b/examples/simple-extraction/user.py
@@ -15,7 +15,7 @@ class UserDetail(BaseModel):
 
 def get_user_detail(string) -> UserDetail:
     return client.chat.completions.create(
-        model="gpt-3.5-turbo-0613",
+        model="gpt-4o-mini",
         response_model=UserDetail,
         messages=[
             {

--- a/instructor/validation/llm_validators.py
+++ b/instructor/validation/llm_validators.py
@@ -42,7 +42,7 @@ def llm_validator(
 
     Parameters:
         statement (str): The statement to validate
-        model (str): The LLM to use for validation (default: "gpt-3.5-turbo-0613")
+        model (str): The LLM to use for validation (default: "gpt-4o-mini")
         temperature (float): The temperature to use for the LLM (default: 0)
         client (OpenAI): The OpenAI client to use (default: None)
     """


### PR DESCRIPTION
Replace all instances of the deprecated model gpt-3.5-turbo-0613 with gpt-4o-mini in executable code across examples and library code.

Changes:
- Updated 13 example files with model references
- Updated documentation examples
- Updated llm_validators.py docstring
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Replaces deprecated `gpt-3.5-turbo-0613` with `gpt-4o-mini` across code and documentation.
> 
>   - **Behavior**:
>     - Replaces `gpt-3.5-turbo-0613` with `gpt-4o-mini` in 13 example files, including `run.py`, `citation_fuzzy_match.py`, and `multi_prediction.py`.
>     - Updates model references in `llm_validators.py` docstring.
>   - **Documentation**:
>     - Updates model references in documentation examples, including `logfire.md` and `exact_citations.md`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=567-labs%2Finstructor&utm_source=github&utm_medium=referral)<sup> for 7ad1cd9764c345e5190384af1547729b38eafe42. You can [customize](https://app.ellipsis.dev/567-labs/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->