### PR TITLE
fix(cohere): use Cohere V2 API to support latest models

### DIFF
--- a/docs/examples/document_segmentation.md
+++ b/docs/examples/document_segmentation.md
@@ -5,7 +5,7 @@ description: Learn effective document segmentation techniques using Cohere's LLM
 
 # Document Segmentation
 
-In this guide, we demonstrate how to do document segmentation using structured output from an LLM. We'll be using [command-a-reasoning-08-2025](https://docs.cohere.com/docs/command-a-reasoning) - one of Cohere's latest LLMs with 256k context length and testing the approach on an article explaining the Transformer architecture. Same approach to document segmentation can be applied to any other domain where we need to break down a complex long document into smaller chunks.
+In this guide, we demonstrate how to do document segmentation using structured output from an LLM. We'll be using [command-a](https://docs.cohere.com/docs/command-a) - one of Cohere's latest LLMs with 256k context length and testing the approach on an article explaining the Transformer architecture. Same approach to document segmentation can be applied to any other domain where we need to break down a complex long document into smaller chunks.
 
 !!! tips "Motivation"
 Sometimes we need a way to split the document into meaningful parts that center around a single key concept/idea. Simple length-based / rule-based text-splitters are not reliable enough. Consider the cases where documents contain code snippets or math equations - we don't want to split those on `'\n\n'` or have to write extensive rules for different types of documents. It turns out that LLMs with sufficiently long context length are well suited for this task.
@@ -77,7 +77,7 @@ import cohere
 
 # Apply the patch to the cohere client
 # enables response_model keyword
-client = instructor.from_cohere(cohere.Client())
+client = instructor.from_cohere(cohere.ClientV2())
 
 
 system_prompt = f"""\
@@ -89,7 +89,7 @@ Each line of the document is marked with its line number in square brackets (e.g
 
 def get_structured_document(document_with_line_numbers) -> StructuredDocument:
     return client.chat.completions.create(
-        model="command-a-reasoning-08-2025",
+        model="command-a-03-2025",
         response_model=StructuredDocument,
         messages=[
             {
@@ -148,7 +148,7 @@ def doc_with_lines(document):
     return document_with_line_numbers, line2text
 
 
-client = instructor.from_cohere(cohere.Client())
+client = instructor.from_cohere(cohere.ClientV2())
 
 
 system_prompt = f"""\
@@ -172,7 +172,7 @@ class StructuredDocument(BaseModel):
 
 def get_structured_document(document_with_line_numbers) -> StructuredDocument:
     return client.chat.completions.create(
-        model="command-a-reasoning-08-2025",
+        model="command-a-03-2025",
         response_model=StructuredDocument,
         messages=[
             {

--- a/docs/integrations/cohere.md
+++ b/docs/integrations/cohere.md
@@ -35,7 +35,7 @@ import instructor
 
 # Patching the Cohere client with the instructor for enhanced capabilities
 client = instructor.from_provider(
-    "cohere/command-a-reasoning-08-2025",
+    "cohere/command-a-03-2025",
     max_tokens=1000,
 )
 
@@ -94,7 +94,7 @@ print(group.model_dump_json(indent=2))
 import instructor
 
 async_client = instructor.from_provider(
-    "cohere/command-a-reasoning-08-2025",
+    "cohere/command-a-03-2025",
     async_client=True,
     max_tokens=1000,
 )

--- a/docs/learning/getting_started/client_setup.md
+++ b/docs/learning/getting_started/client_setup.md
@@ -63,7 +63,7 @@ For Cohere's models:
 import instructor
 import cohere
 
-cohere_client = cohere.Client("YOUR_API_KEY")
+cohere_client = cohere.ClientV2("YOUR_API_KEY")
 client = instructor.from_cohere(cohere_client)
 ```
 

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -154,7 +154,7 @@ Available Modes:
 import instructor
 import cohere
 
-client = instructor.from_cohere(cohere.Client())
+client = instructor.from_cohere(cohere.ClientV2())
 ```
 
 Available Modes:

--- a/examples/caching/run.py
+++ b/examples/caching/run.py
@@ -449,9 +449,9 @@ def calculate_cost_savings(baseline_stats: dict, cached_stats: dict) -> dict[str
         "cost_savings_percent": savings_percent,
         "time_saved": time_saved,
         "time_savings_percent": time_savings_percent,
-        "speed_improvement": baseline_time / cached_time
-        if cached_time > 0
-        else float("inf"),
+        "speed_improvement": (
+            baseline_time / cached_time if cached_time > 0 else float("inf")
+        ),
     }
 
 

--- a/examples/cohere/cohere.py
+++ b/examples/cohere/cohere.py
@@ -5,9 +5,9 @@ from pydantic import BaseModel, Field
 
 # Patching the Cohere client with the instructor for enhanced capabilities
 client = instructor.from_cohere(
-    cohere.Client(),
+    cohere.ClientV2(),
     max_tokens=1000,
-    model="command-a-reasoning-08-2025",
+    model="command-a-03-2025",
 )
 
 

--- a/instructor/auto_client.py
+++ b/instructor/auto_client.py
@@ -407,11 +407,11 @@ def from_provider(
             from instructor import from_cohere
 
             client = (
-                cohere.AsyncClient(api_key=api_key)
+                cohere.AsyncClientV2(api_key=api_key)
                 if async_client
-                else cohere.Client(api_key=api_key)
+                else cohere.ClientV2(api_key=api_key)
             )
-            result = from_cohere(client, **kwargs)
+            result = from_cohere(client, model=model_name, **kwargs)
             logger.info(
                 "Client initialized",
                 extra={**provider_info, "status": "success"},
@@ -809,7 +809,10 @@ def from_provider(
                 "llama4",
                 "mistral-nemo",
                 "firefunction-v2",
-                "command-a-reasoning-08-2025",
+                "command-a",
+                "command-r",
+                "command-r-plus",
+                "command-r7b",
                 "qwen2.5",
                 "qwen2.5-coder",
                 "qwen3",

--- a/instructor/core/retry.py
+++ b/instructor/core/retry.py
@@ -6,7 +6,12 @@ import logging
 from json import JSONDecodeError
 from typing import Any, Callable, TypeVar
 
-from .exceptions import InstructorRetryException, AsyncValidationError, FailedAttempt, ValidationError as InstructorValidationError
+from .exceptions import (
+    InstructorRetryException,
+    AsyncValidationError,
+    FailedAttempt,
+    ValidationError as InstructorValidationError,
+)
 from .hooks import Hooks
 from ..mode import Mode
 from ..processing.response import (
@@ -199,7 +204,11 @@ def retry_sync(
                         mode=mode,
                         stream=stream,
                     )
-                except (ValidationError, JSONDecodeError, InstructorValidationError) as e:
+                except (
+                    ValidationError,
+                    JSONDecodeError,
+                    InstructorValidationError,
+                ) as e:
                     logger.debug(f"Parse error: {e}")
                     hooks.emit_parse_error(e)
 

--- a/instructor/models.py
+++ b/instructor/models.py
@@ -27,11 +27,11 @@ KnownModelName = TypeAliasType(
         "cohere/command-r7b-12-2024",
         "cohere/command-a-translate-08-2025",
         "cohere/command-a-reasoning-08-2025",
-        "cohere/command-r",
-        "cohere/command-r-03-2024",
+        "cohere/command-r",  # deprecated 2025-09-15
+        "cohere/command-r-03-2024",  # deprecated 2025-09-15
         "cohere/command-r-08-2024",
-        "cohere/command-r-plus",
-        "cohere/command-r-plus-04-2024",
+        "cohere/command-r-plus",  # deprecated 2025-09-15
+        "cohere/command-r-plus-04-2024",  # deprecated 2025-09-15
         "cohere/command-r-plus-08-2024",
         "cohere/command-r7b-12-2024",
         # OpenAI Models

--- a/instructor/processing/multimodal.py
+++ b/instructor/processing/multimodal.py
@@ -682,18 +682,22 @@ class PDF(BaseModel):
             if mode in {Mode.RESPONSES_TOOLS, Mode.RESPONSES_TOOLS_WITH_INBUILT_TOOLS}:
                 return {
                     "type": input_file_type,
-                    "filename": self.source
-                    if isinstance(self.source, str)
-                    else str(self.source),
+                    "filename": (
+                        self.source
+                        if isinstance(self.source, str)
+                        else str(self.source)
+                    ),
                     "file_data": f"data:{self.media_type};base64,{data}",
                 }
             else:
                 return {
                     "type": input_file_type,
                     "file": {
-                        "filename": self.source
-                        if isinstance(self.source, str)
-                        else str(self.source),
+                        "filename": (
+                            self.source
+                            if isinstance(self.source, str)
+                            else str(self.source)
+                        ),
                         "file_data": f"data:{self.media_type};base64,{data}",
                     },
                 }

--- a/instructor/processing/response.py
+++ b/instructor/processing/response.py
@@ -357,7 +357,6 @@ def process_response(
         return model.content
 
     model._raw_response = response
-
     return model
 
 

--- a/instructor/providers/cohere/utils.py
+++ b/instructor/providers/cohere/utils.py
@@ -18,55 +18,119 @@ def reask_cohere_tools(
 ):
     """
     Handle reask for Cohere tools and JSON schema modes.
+    Supports both V1 and V2 formats.
 
-    Kwargs modifications:
+    V1 kwargs modifications:
     - Adds/Modifies: "chat_history" (appends prior message)
     - Modifies: "message" (user prompt describing validation errors)
+
+    V2 kwargs modifications:
+    - Modifies: "messages" (appends error correction message)
     """
-    # Get message outside the function
-    message = kwargs.get("message", "")
-
-    # Fetch or initialize chat_history in one operation
-    if "chat_history" in kwargs:
-        # Only modify chat_history if it exists
-        kwargs["chat_history"].append({"role": "user", "message": message})
+    # Detect V1 vs V2 response structure and extract text
+    if hasattr(response, "text"):
+        client_version = "v1"
+        response_text = response.text
+    elif hasattr(response, "message") and hasattr(response.message, "content"):
+        client_version = "v2"
+        content_items = response.message.content
+        response_text = ""
+        if content_items:
+            # Find the text content item (skip thinking/other types)
+            for item in content_items:
+                if (
+                    hasattr(item, "type")
+                    and item.type == "text"
+                    and hasattr(item, "text")
+                ):
+                    response_text = item.text
+                    break
+        if not response_text:
+            response_text = str(response)
     else:
-        # Create a new chat_history if it doesn't exist
-        kwargs["chat_history"] = [{"role": "user", "message": message}]
+        # Fallback to string representation
+        response_text = str(response)
 
-    # Set the message directly without string concatenation with f-strings
-    kwargs["message"] = (
+    # Create the correction message
+    correction_msg = (
         "Correct the following JSON response, based on the errors given below:\n\n"
-        f"JSON:\n{response.text}\n\nExceptions:\n{exception}"
+        f"JSON:\n{response_text}\n\nExceptions:\n{exception}"
     )
+
+    if client_version == "v2":
+        # V2 format: append to messages list
+        kwargs["messages"].append({"role": "user", "content": correction_msg})
+    elif client_version == "v1":
+        # V1 format: use chat_history and message
+        message = kwargs.get("message", "")
+
+        # Fetch or initialize chat_history in one operation
+        if "chat_history" in kwargs:
+            kwargs["chat_history"].append({"role": "user", "message": message})
+        else:
+            kwargs["chat_history"] = [{"role": "user", "message": message}]
+
+        kwargs["message"] = correction_msg
+    else:
+        # Unknown version - raise error for future compatibility
+        raise ValueError(
+            f"Unsupported Cohere client version: {client_version}. "
+            f"Expected 'v1' or 'v2'."
+        )
+
     return kwargs
 
 
 def handle_cohere_modes(new_kwargs: dict[str, Any]) -> tuple[None, dict[str, Any]]:
     """
     Convert OpenAI-style messages to Cohere format.
+    Handles both V1 and V2 client formats.
 
-    Kwargs modifications:
+    V1 format:
     - Removes: "messages"
     - Adds: "message" (last user message)
     - Adds: "chat_history" (prior messages)
+
+    V2 format:
+    - Keeps: "messages" (compatible with OpenAI format)
+
+    Both versions:
     - Renames: "model_name" -> "model"
     - Removes: "strict"
+    - Removes: "_cohere_client_version" (internal marker)
     """
-    messages = new_kwargs.pop("messages", [])
-    chat_history = []
-    for message in messages[:-1]:
-        chat_history.append(  # type: ignore
-            {
-                "role": message["role"],
-                "message": message["content"],
-            }
+    new_kwargs = new_kwargs.copy()
+    client_version = new_kwargs.pop("_cohere_client_version")
+
+    if client_version == "v2":
+        # V2 uses OpenAI-style messages directly - no conversion needed
+        # Just clean up incompatible fields
+        if "model_name" in new_kwargs and "model" not in new_kwargs:
+            new_kwargs["model"] = new_kwargs.pop("model_name")
+        new_kwargs.pop("strict", None)
+    elif client_version == "v1":
+        # V1 needs conversion from OpenAI format to Cohere V1 format
+        messages = new_kwargs.pop("messages", [])
+        chat_history = []
+        for message in messages[:-1]:
+            chat_history.append(  # type: ignore
+                {
+                    "role": message["role"],
+                    "message": message["content"],
+                }
+            )
+        new_kwargs["message"] = messages[-1]["content"]
+        new_kwargs["chat_history"] = chat_history
+        if "model_name" in new_kwargs and "model" not in new_kwargs:
+            new_kwargs["model"] = new_kwargs.pop("model_name")
+        new_kwargs.pop("strict", None)
+    else:
+        # Unknown version - raise error for future compatibility
+        raise ValueError(
+            f"Unsupported Cohere client version: {client_version}. "
+            f"Expected 'v1' or 'v2'."
         )
-    new_kwargs["message"] = messages[-1]["content"]
-    new_kwargs["chat_history"] = chat_history
-    if "model_name" in new_kwargs and "model" not in new_kwargs:
-        new_kwargs["model"] = new_kwargs.pop("model_name")
-    new_kwargs.pop("strict", None)
+
     return None, new_kwargs
 
 
@@ -112,19 +176,19 @@ def handle_cohere_tools(
     Handle Cohere tools mode.
 
     When response_model is None:
-        - Converts messages from OpenAI format to Cohere format (message + chat_history)
+        - Converts messages from OpenAI format to Cohere format (message + chat_history for V1, messages for V2)
         - No tools or schema instructions are added
         - Allows for unstructured responses from Cohere
 
     When response_model is provided:
         - Converts messages from OpenAI format to Cohere format
-        - Prepends extraction instructions to the chat history
+        - Prepends extraction instructions to the chat history (V1) or messages (V2)
         - Includes the model's JSON schema in the instructions
         - The model is instructed to extract a valid object matching the schema
 
     Kwargs modifications:
     - All modifications from handle_cohere_modes (message format conversion)
-    - Modifies: "chat_history" (prepends extraction instruction) - only when response_model provided
+    - Modifies: "chat_history" (V1) or "messages" (V2) to prepend extraction instruction - only when response_model provided
     """
     if response_model is None:
         # Just handle message conversion
@@ -142,9 +206,17 @@ schema = {response_model.__name__}.model_json_schema()
 
 The output must be a valid JSON object that `{response_model.__name__}.model_validate_json()` can successfully parse.
 """
-    new_kwargs["chat_history"] = [
-        {"role": "user", "message": instruction}
-    ] + new_kwargs["chat_history"]
+    # Check client version explicitly (marker already removed by handle_cohere_modes)
+    # Use presence of messages vs chat_history as indicator since marker is already consumed
+    if "messages" in new_kwargs:
+        # V2 format: prepend to messages
+        new_kwargs["messages"].insert(0, {"role": "user", "content": instruction})
+    else:
+        # V1 format: prepend to chat_history
+        new_kwargs["chat_history"] = [
+            {"role": "user", "message": instruction}
+        ] + new_kwargs["chat_history"]
+
     return response_model, new_kwargs
 
 

--- a/instructor/templating.py
+++ b/instructor/templating.py
@@ -21,9 +21,11 @@ def process_message(
         return types.Content(
             role=message.role,
             parts=[
-                types.Part.from_text(text=apply_template(part.text, context))
-                if hasattr(part, "text")
-                else part
+                (
+                    types.Part.from_text(text=apply_template(part.text, context))
+                    if hasattr(part, "text")
+                    else part
+                )
                 for part in message.parts
             ],
         )

--- a/tests/llm/test_cohere/conftest.py
+++ b/tests/llm/test_cohere/conftest.py
@@ -9,16 +9,26 @@ if not os.getenv("COHERE_API_KEY"):
     )
 
 try:
-    from cohere import Client, AsyncClient
+    from cohere import Client, ClientV2, AsyncClient, AsyncClientV2
 except ImportError:  # pragma: no cover - optional dependency
     pytest.skip("cohere package is not installed", allow_module_level=True)
 
 
 @pytest.fixture(scope="session")
-def client():
+def client_v1():
     yield Client()
 
 
 @pytest.fixture(scope="session")
-def aclient():
+def client_v2():
+    yield ClientV2()
+
+
+@pytest.fixture(scope="session")
+def aclient_v1():
     yield AsyncClient()
+
+
+@pytest.fixture(scope="session")
+def aclient_v2():
+    yield AsyncClientV2()

--- a/tests/llm/test_cohere/test_json_schema.py
+++ b/tests/llm/test_cohere/test_json_schema.py
@@ -13,11 +13,12 @@ class User(BaseModel):
 
 
 @pytest.mark.parametrize("mode", modes)
-def test_parse_user_sync(client, mode):
-    client = instructor.from_cohere(client, mode=mode)
+def test_parse_user_sync(client_v2, mode):
+    client = instructor.from_cohere(client_v2, mode=mode)
 
     resp = client.chat.completions.create(
         response_model=User,
+        model="command-a-03-2025",
         messages=[
             {
                 "role": "user",
@@ -31,8 +32,8 @@ def test_parse_user_sync(client, mode):
 
 
 @pytest.mark.parametrize("mode", modes)
-def test_parse_user_sync_jinja(client, mode):
-    client = instructor.from_cohere(client, mode=mode)
+def test_parse_user_sync_jinja(client_v1, mode):
+    client = instructor.from_cohere(client_v1, mode=mode, model="command-a-03-2025")
 
     resp = client.chat.completions.create(
         response_model=User,
@@ -64,11 +65,12 @@ class ValidatedUser(BaseModel):
 
 
 @pytest.mark.parametrize("mode", modes)
-def test_parse_validated_user_sync(client, mode):
-    client = instructor.from_cohere(client, mode=mode)
+def test_parse_validated_user_sync(client_v1, mode):
+    client = instructor.from_cohere(client_v1, mode=mode)
 
     resp = client.chat.completions.create(
         response_model=ValidatedUser,
+        model="command-a-03-2025",
         messages=[
             {
                 "role": "user",
@@ -83,12 +85,12 @@ def test_parse_validated_user_sync(client, mode):
 
 @pytest.mark.parametrize("mode", modes)
 @pytest.mark.asyncio
-async def test_parse_user_async(aclient, mode):
-    client = instructor.from_cohere(aclient, mode=mode)
+async def test_parse_user_async(aclient_v2, mode):
+    client = instructor.from_cohere(aclient_v2, mode=mode)
 
     resp = await client.chat.completions.create(
         response_model=ValidatedUser,
-        model="command-a-reasoning-08-2025",
+        model="command-a-03-2025",
         messages=[
             {
                 "role": "user",
@@ -104,12 +106,12 @@ async def test_parse_user_async(aclient, mode):
 
 @pytest.mark.parametrize("mode", modes)
 @pytest.mark.asyncio
-async def test_parse_user_async_jinja(aclient, mode):
-    client = instructor.from_cohere(aclient, mode=mode)
+async def test_parse_user_async_jinja(aclient_v2, mode):
+    client = instructor.from_cohere(aclient_v2, mode=mode)
 
     resp = await client.chat.completions.create(
         response_model=ValidatedUser,
-        model="command-a-reasoning-08-2025",
+        model="command-a-03-2025",
         messages=[
             {
                 "role": "user",

--- a/tests/llm/test_cohere/test_none_response.py
+++ b/tests/llm/test_cohere/test_none_response.py
@@ -10,9 +10,9 @@ modes = [
 
 
 @pytest.mark.parametrize("mode", modes)
-def test_none_response_model(client, mode):
+def test_none_response_model(mode):
     client = instructor.from_provider(
-        "cohere/command-r",
+        "cohere/command-a-03-2025",
         max_tokens=1000,
         mode=mode,
     )
@@ -23,14 +23,14 @@ def test_none_response_model(client, mode):
         temperature=0,
     )
 
-    assert response.text
+    assert response.message
 
 
 @pytest.mark.asyncio()
 @pytest.mark.parametrize("mode", modes)
 async def test_none_response_model_async(mode):
     client = instructor.from_provider(
-        "cohere/command-r",
+        "cohere/command-a-03-2025",
         max_tokens=1000,
         async_client=True,
         mode=mode,
@@ -42,4 +42,4 @@ async def test_none_response_model_async(mode):
         temperature=0,
     )
 
-    assert response.text
+    assert response.message

--- a/tests/llm/test_cohere/test_retries.py
+++ b/tests/llm/test_cohere/test_retries.py
@@ -13,11 +13,11 @@ class User(BaseModel):
         raise ValueError("Name must be Bob")
 
 
-def test_user_creation_retry(client):
+def test_user_creation_retry(client_v1):
     try:
-        client = from_cohere(client)
+        client = from_cohere(client_v1)
         res = client.chat.completions.create(
-            model="command-r",
+            model="command-a-03-2025",
             messages=[{"role": "user", "content": "What is the capital of the moon?"}],
             response_model=User,
         )
@@ -27,11 +27,11 @@ def test_user_creation_retry(client):
 
 
 @pytest.mark.asyncio()
-async def test_user_async_creation_retry(aclient):
-    client = from_cohere(aclient)
+async def test_user_async_creation_retry(aclient_v1):
+    client = from_cohere(aclient_v1)
     try:
         res = await client.chat.completions.create(
-            model="command-r",
+            model="command-a-03-2025",
             messages=[{"role": "user", "content": "What is the capital of the moon?"}],
             response_model=User,
         )

--- a/tests/llm/test_new_client.py
+++ b/tests/llm/test_new_client.py
@@ -263,11 +263,11 @@ async def test_async_client_anthropic_bedrock_response():
 
 @pytest.mark.skip(reason="Skipping if Cohere API is not available")
 def test_client_cohere_response():
-    client = cohere.Client()
+    client = cohere.ClientV2()
     instructor_client = instructor.from_cohere(
         client,
         max_tokens=1000,
-        model="command-a-reasoning-08-2025",
+        model="command-a-03-2025",
     )
 
     user = instructor_client.messages.create(
@@ -281,11 +281,11 @@ def test_client_cohere_response():
 
 @pytest.mark.skip(reason="Skipping if Cohere API is not available")
 def test_client_cohere_response_with_nested_classes():
-    client = cohere.Client()
+    client = cohere.ClientV2()
     instructor_client = instructor.from_cohere(
         client,
         max_tokens=1000,
-        model="command-a-reasoning-08-2025",
+        model="command-a-03-2025",
     )
 
     class Person(BaseModel):
@@ -318,11 +318,11 @@ def test_client_cohere_response_with_nested_classes():
 @pytest.mark.skip(reason="Skipping if Cohere API is not available")
 @pytest.mark.asyncio
 async def test_client_cohere_async():
-    client = cohere.AsyncClient()
+    client = cohere.AsyncClientV2()
     instructor_client = instructor.from_cohere(
         client,
         max_tokens=1000,
-        model="command-a-reasoning-08-2025",
+        model="command-a-03-2025",
     )
 
     class Person(BaseModel):

--- a/tests/llm/test_openai/test_multitask.py
+++ b/tests/llm/test_openai/test_multitask.py
@@ -69,9 +69,11 @@ async def test_multi_user_tools_mode_async(model, mode, aclient):
 
     client = instructor.patch(
         aclient,
-        create=partial(async_map_chat_completion_to_response, client=aclient)
-        if mode in {Mode.RESPONSES_TOOLS, Mode.RESPONSES_TOOLS_WITH_INBUILT_TOOLS}
-        else aclient.chat.completions.create,
+        create=(
+            partial(async_map_chat_completion_to_response, client=aclient)
+            if mode in {Mode.RESPONSES_TOOLS, Mode.RESPONSES_TOOLS_WITH_INBUILT_TOOLS}
+            else aclient.chat.completions.create
+        ),
         mode=mode,
     )
 

--- a/tests/test_auto_client.py
+++ b/tests/test_auto_client.py
@@ -23,7 +23,7 @@ PROVIDERS = [
     "openai/gpt-4o-mini",
     "azure_openai/gpt-4o-mini",
     "mistral/ministral-8b-latest",
-    "cohere/command-a-reasoning-08-2025",
+    "cohere/command-a-03-2025",
     "perplexity/sonar-pro",
     "groq/llama-3.1-8b-instant",
     "writer/palmyra-x5",
@@ -39,7 +39,7 @@ def should_skip_provider(provider_string: str) -> bool:
 
     if os.getenv("INSTRUCTOR_ENV") == "CI":
         return provider_string not in [
-            "cohere/command-a-reasoning-08-2025",
+            "cohere/command-a-03-2025",
             "google/gemini-2.0-flash",
             "openai/gpt-4o-mini",
         ]

--- a/tests/test_process_response.py
+++ b/tests/test_process_response.py
@@ -123,9 +123,7 @@ def test_empty_and_missing_content() -> None:
 def test_bedrock_invalid_content_format() -> None:
     """Invalid content types should raise NotImplementedError."""
     call_kwargs = {
-        "messages": [
-            {"role": "user", "content": 12345}  # Invalid content type
-        ]
+        "messages": [{"role": "user", "content": 12345}]  # Invalid content type
     }
     try:
         _prepare_bedrock_converse_kwargs_internal(call_kwargs)


### PR DESCRIPTION
- support V1 and V2 Cohere SDK clients (default to V2)
- pass model explicitly in calls (fixing existing issue)
- update tests and examples to use V2
- fix ollama cohere models which support tool calling
- add comments for more models
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Update Cohere integration to support V1 and V2 API clients, defaulting to V2, with updated tests and examples.
> 
>   - **Behavior**:
>     - Support for both V1 and V2 Cohere SDK clients in `instructor/providers/cohere/client.py`, defaulting to V2.
>     - Explicit model specification in API calls to fix existing issues.
>     - Updated response handling to accommodate V2 API structure in `instructor/processing/function_calls.py` and `instructor/providers/cohere/utils.py`.
>   - **Testing**:
>     - Updated tests in `tests/llm/test_cohere/test_json_schema.py` and `tests/llm/test_cohere/test_none_response.py` to use V2 API.
>     - Added fixtures for V1 and V2 clients in `tests/llm/test_cohere/conftest.py`.
>   - **Documentation**:
>     - Updated examples in `docs/examples/document_segmentation.md` and `docs/integrations/cohere.md` to use V2 API.
>   - **Misc**:
>     - Minor code formatting changes in `examples/caching/run.py` and `instructor/processing/multimodal.py`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=567-labs%2Finstructor&utm_source=github&utm_medium=referral)<sup> for cee3a6dce8b33192acbe638ab79509bb7dada23b. You can [customize](https://app.ellipsis.dev/567-labs/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->