### PR TITLE
doc(openrouter): use explicit async_client=False

### DIFF
--- a/docs/integrations/openrouter.md
+++ b/docs/integrations/openrouter.md
@@ -34,6 +34,7 @@ class User(BaseModel):
 client = instructor.from_provider(
     "openrouter/google/gemini-2.0-flash-lite-001",
     base_url="https://openrouter.ai/api/v1",
+    async_client=False
 )
 
 resp = client.chat.completions.create(
@@ -113,6 +114,7 @@ class User(BaseModel):
 client = instructor.from_provider(
     "openrouter/google/gemini-2.0-flash-lite-001",
     base_url="https://openrouter.ai/api/v1",
+    async_client=False
 )
 
 # Create structured output with nested objects
@@ -161,6 +163,7 @@ class User(BaseModel):
 client = instructor.from_provider(
     "openrouter/google/gemini-2.0-flash-lite-001",
     base_url="https://openrouter.ai/api/v1",
+    async_client=False
 )
 
 # Create structured output with nested objects
@@ -209,6 +212,7 @@ class User(BaseModel):
 client = instructor.from_provider(
     "openrouter/google/gemini-2.0-flash-lite-001",
     base_url="https://openrouter.ai/api/v1",
+    async_client=False
 )
 
 # Create structured output with nested objects


### PR DESCRIPTION
I have an issue where the default `instructor.from_provider` is inferred by Pyright to be `AsyncInstructor`:



<img width="1224" height="504" alt="image" src="https://github.com/user-attachments/assets/cd1537b9-fe4f-4418-a9e1-edcbd136b478" />


the issue is fixed once I explicitly declare `async_client=False`.


<img width="1228" height="482" alt="image" src="https://github.com/user-attachments/assets/213dea58-7fc0-45d4-abbf-6161f6c1e45d" />

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Explicitly set `async_client=False` in `openrouter.md` to fix type inference issues in documentation examples.
> 
>   - **Documentation**:
>     - In `openrouter.md`, explicitly set `async_client=False` in four code examples to ensure correct type inference by Pyright.
>     - Affects examples in sections: Simple User Example (Sync), Nested Object Example (Sync), Structured Outputs (Sync), and JSON Mode.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=567-labs%2Finstructor&utm_source=github&utm_medium=referral)<sup> for 1305fdc375daaa63cc56311a651fd2ba883392ef. You can [customize](https://app.ellipsis.dev/567-labs/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->