### PR TITLE
fix: Bedrock OpenAI models response parsing (reasoning before text)

### DIFF
--- a/instructor/processing/function_calls.py
+++ b/instructor/processing/function_calls.py
@@ -402,8 +402,12 @@ class OpenAISchema(BaseModel):
         strict: Optional[bool] = None,
     ) -> BaseModel:
         if isinstance(completion, dict):
-            text = completion.get("output").get("message").get("content")[0].get("text")
-
+            # OpenAI will send the first content to be 'reasoningText', and then 'text'
+            content = completion["output"]["message"]["content"]
+            text_content = next((c for c in content if "text" in c), None)
+            if not text_content:
+                raise ValueError("Unexpected format. No text content found.")
+            text = text_content["text"]
             match = re.search(r"```?json(.*?)```?", text, re.DOTALL)
             if match:
                 text = match.group(1).strip()


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Fixes Bedrock OpenAI model response parsing to handle reasoning text before actual text content and adds tests for validation.
> 
>   - **Behavior**:
>     - Fixes `parse_bedrock_json` in `function_calls.py` to handle cases where `reasoningText` precedes `text` in Bedrock OpenAI model responses.
>     - Raises `ValueError` if no text content is found.
>   - **Tests**:
>     - Adds `TestBedrockJSONParsing` in `test_json_extraction.py` to cover scenarios with reasoning text, code blocks, and multiple text contents.
>     - Ensures correct text extraction and error handling for missing text content.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=567-labs%2Finstructor&utm_source=github&utm_medium=referral)<sup> for aea9365676586a96e3deaa0df3e46d155bad03be. You can [customize](https://app.ellipsis.dev/567-labs/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->