### PR TITLE
fix(gemini): exclude HARM_CATEGORY_JAILBREAK for google.genai API

### DIFF
--- a/instructor/providers/gemini/utils.py
+++ b/instructor/providers/gemini/utils.py
@@ -251,7 +251,11 @@ def update_genai_kwargs(
     supported_categories = [
         c
         for c in HarmCategory
-        if c != HarmCategory.HARM_CATEGORY_UNSPECIFIED
+        if c
+        not in (
+            HarmCategory.HARM_CATEGORY_UNSPECIFIED,
+            HarmCategory.HARM_CATEGORY_JAILBREAK,
+        )
         and not c.name.startswith("HARM_CATEGORY_IMAGE_")
     ]
 

--- a/tests/llm/test_genai/test_utils.py
+++ b/tests/llm/test_genai/test_utils.py
@@ -37,7 +37,11 @@ def test_update_genai_kwargs_safety_settings():
     supported_categories = [
         c
         for c in HarmCategory
-        if c != HarmCategory.HARM_CATEGORY_UNSPECIFIED
+        if c
+        not in (
+            HarmCategory.HARM_CATEGORY_UNSPECIFIED,
+            HarmCategory.HARM_CATEGORY_JAILBREAK,
+        )
         and not c.name.startswith("HARM_CATEGORY_IMAGE_")
     ]
 
@@ -68,7 +72,11 @@ def test_update_genai_kwargs_with_custom_safety_settings():
     supported_categories = [
         c
         for c in HarmCategory
-        if c != HarmCategory.HARM_CATEGORY_UNSPECIFIED
+        if c
+        not in (
+            HarmCategory.HARM_CATEGORY_UNSPECIFIED,
+            HarmCategory.HARM_CATEGORY_JAILBREAK,
+        )
         and not c.name.startswith("HARM_CATEGORY_IMAGE_")
     ]
 


### PR DESCRIPTION
Fixes #1862 

## Problem

The `google.genai` API (Gemini API) was attempting to include `HARM_CATEGORY_JAILBREAK` in safety settings, which caused a 400 error:

```
INVALID_ARGUMENT: Invalid value at 'safety_settings[5].category' (type.googleapis.com/google.ai.generativelanguage.v1beta.HarmCategory), "HARM_CATEGORY_JAILBREAK"
```

## Root Cause
`HARM_CATEGORY_JAILBREAK` is only supported in Vertex AI, not in the Gemini API:
- **Gemini API** ([docs](https://ai.google.dev/api/generate-content#v1beta.HarmCategory)): Does not include `HARM_CATEGORY_JAILBREAK`
- **Vertex AI** ([docs](https://cloud.google.com/vertex-ai/generative-ai/docs/reference/rest/v1/HarmCategory)): Includes `HARM_CATEGORY_JAILBREAK`

## Solution
Updated `update_genai_kwargs()` to filter out `HARM_CATEGORY_JAILBREAK`, preventing it from being sent to the Gemini API endpoint.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Exclude `HARM_CATEGORY_JAILBREAK` from `google.genai` API safety settings in `update_genai_kwargs()` and update tests accordingly.
> 
>   - **Behavior**:
>     - `update_genai_kwargs()` in `utils.py` now excludes `HARM_CATEGORY_JAILBREAK` from safety settings for the `google.genai` API.
>     - Ensures `HARM_CATEGORY_JAILBREAK` is not included in `safety_settings` in `test_utils.py` tests.
>   - **Tests**:
>     - Updated `test_update_genai_kwargs_safety_settings()` and `test_update_genai_kwargs_with_custom_safety_settings()` in `test_utils.py` to verify exclusion of `HARM_CATEGORY_JAILBREAK`.
>     - Added checks for correct handling of safety settings and custom thresholds.
>   - **Misc**:
>     - Minor refactoring in `utils.py` to improve readability of safety settings filtering.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=567-labs%2Finstructor&utm_source=github&utm_medium=referral)<sup> for 8738d7ea5b537609288a8200fe24684f99079925. You can [customize](https://app.ellipsis.dev/567-labs/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->