### PR TITLE
fix(genai): fix Gemini streaming

### DIFF
--- a/instructor/auto_client.py
+++ b/instructor/auto_client.py
@@ -332,9 +332,20 @@ def from_provider(
                 **client_kwargs,
             )  # type: ignore
             if async_client:
-                result = from_genai(client, use_async=True, model=model_name, **kwargs)  # type: ignore
+                result = from_genai(
+                    client,
+                    use_async=True,
+                    model=model_name,
+                    mode=mode if mode else instructor.Mode.GENAI_TOOLS,
+                    **kwargs,
+                )  # type: ignore
             else:
-                result = from_genai(client, model=model_name, **kwargs)  # type: ignore
+                result = from_genai(
+                    client,
+                    model=model_name,
+                    mode=mode if mode else instructor.Mode.GENAI_TOOLS,
+                    **kwargs,
+                )  # type: ignore
             logger.info(
                 "Client initialized",
                 extra={**provider_info, "status": "success"},
@@ -720,9 +731,16 @@ def from_provider(
             )  # type: ignore
             kwargs["model"] = model_name  # Pass model as part of kwargs
             if async_client:
-                result = from_genai(client, use_async=True, **kwargs)  # type: ignore
+                result = from_genai(
+                    client,
+                    use_async=True,
+                    mode=mode if mode else instructor.Mode.GENAI_TOOLS,
+                    **kwargs,
+                )  # type: ignore
             else:
-                result = from_genai(client, **kwargs)  # type: ignore
+                result = from_genai(
+                    client, mode=mode if mode else instructor.Mode.GENAI_TOOLS, **kwargs
+                )  # type: ignore
             logger.info(
                 "Client initialized",
                 extra={**provider_info, "status": "success"},
@@ -762,9 +780,20 @@ def from_provider(
 
             client = genai.Client(vertexai=False, api_key=api_key)
             if async_client:
-                result = from_genai(client, use_async=True, model=model_name, **kwargs)  # type: ignore
+                result = from_genai(
+                    client,
+                    use_async=True,
+                    model=model_name,
+                    mode=mode if mode else instructor.Mode.GENAI_TOOLS,
+                    **kwargs,
+                )  # type: ignore
             else:
-                result = from_genai(client, model=model_name, **kwargs)  # type: ignore
+                result = from_genai(
+                    client,
+                    model=model_name,
+                    mode=mode if mode else instructor.Mode.GENAI_TOOLS,
+                    **kwargs,
+                )  # type: ignore
             logger.info(
                 "Client initialized",
                 extra={**provider_info, "status": "success"},

--- a/tests/test_auto_client.py
+++ b/tests/test_auto_client.py
@@ -265,3 +265,48 @@ def test_api_key_logging():
                     8,
                     extra={"provider": "openai", "operation": "initialize"},
                 )
+
+
+def test_genai_mode_parameter_passed_to_provider():
+    """Test that mode parameter is correctly passed to provider functions."""
+    from unittest.mock import patch, MagicMock
+    import instructor
+
+    with patch("google.genai.Client") as mock_genai_class:
+        mock_client = MagicMock()
+        mock_genai_class.return_value = mock_client
+
+        with patch("instructor.from_genai") as mock_from_genai:
+            mock_instructor = MagicMock()
+            mock_from_genai.return_value = mock_instructor
+
+            from_provider(
+                "google/gemini-2.5-flash",
+                mode=instructor.Mode.GENAI_STRUCTURED_OUTPUTS,
+            )
+
+            mock_from_genai.assert_called_once()
+            _, kwargs = mock_from_genai.call_args
+            assert "mode" in kwargs
+            assert kwargs["mode"] == instructor.Mode.GENAI_STRUCTURED_OUTPUTS
+
+
+def test_genai_mode_defaults_when_not_provided():
+    """Test that GenAI provider uses GENAI_TOOLS mode when mode is not provided."""
+    from unittest.mock import patch, MagicMock
+    import instructor
+
+    with patch("google.genai.Client") as mock_genai_class:
+        mock_client = MagicMock()
+        mock_genai_class.return_value = mock_client
+
+        with patch("instructor.from_genai") as mock_from_genai:
+            mock_instructor = MagicMock()
+            mock_from_genai.return_value = mock_instructor
+
+            from_provider("google/gemini-2.0-flash")
+
+            mock_from_genai.assert_called_once()
+            _, kwargs = mock_from_genai.call_args
+            assert "mode" in kwargs
+            assert kwargs["mode"] == instructor.Mode.GENAI_TOOLS


### PR DESCRIPTION
Fixes #1775 

Resolves streaming functionality in Google GenAI by ensuring the mode parameter is correctly passed to `from_genai()` calls in `auto_client.py`

## Changes

- Updated all `from_genai()` calls in `from_provider()` to explicitly pass the mode parameter
- Defaults to `Mode.GENAI_TOOLS` when no mode is specified for GenAI provider
- Applies to both sync and async client initialization paths
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes Google GenAI streaming by ensuring `mode` parameter is passed in `auto_client.py`, with tests added to verify behavior.
> 
>   - **Behavior**:
>     - Fixes streaming functionality in Google GenAI by passing `mode` parameter to `from_genai()` in `auto_client.py`.
>     - Defaults to `Mode.GENAI_TOOLS` if `mode` is not specified.
>     - Applies to both sync and async client paths.
>   - **Tests**:
>     - Adds `test_genai_mode_parameter_passed_to_provider()` in `test_auto_client.py` to verify `mode` parameter is passed correctly.
>     - Adds `test_genai_mode_defaults_when_not_provided()` in `test_auto_client.py` to verify default mode behavior.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=567-labs%2Finstructor&utm_source=github&utm_medium=referral)<sup> for 61dce8f7a16a6860ab227984d39d9a75d9d558f2. You can [customize](https://app.ellipsis.dev/567-labs/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->