### PR TITLE
fix: Gemini HARM_CATEGORY_JAILBREAK and Anthropic tool_result blocks

### DIFF
--- a/instructor/providers/anthropic/utils.py
+++ b/instructor/providers/anthropic/utils.py
@@ -156,11 +156,7 @@ def reask_anthropic_tools(
     tool_use_id = None
     for content in response.content:
         assistant_content.append(content.model_dump())  # type: ignore
-        if (
-            content.type == "tool_use"
-            and isinstance(exception, (ValidationError, InstructorValidationError))
-            and content.name == exception.title
-        ):
+        if content.type == "tool_use":
             tool_use_id = content.id
 
     reask_msgs = [{"role": "assistant", "content": assistant_content}]  # type: ignore

--- a/instructor/providers/gemini/utils.py
+++ b/instructor/providers/gemini/utils.py
@@ -248,10 +248,15 @@ def update_genai_kwargs(
 
     # Filter out image related harm categories which are not
     # supported for text based models
+    # Exclude JAILBREAK category as it's only for Vertex AI, not google.genai
+    excluded_categories = {HarmCategory.HARM_CATEGORY_UNSPECIFIED}
+    if hasattr(HarmCategory, 'HARM_CATEGORY_JAILBREAK'):
+        excluded_categories.add(HarmCategory.HARM_CATEGORY_JAILBREAK)
+
     supported_categories = [
         c
         for c in HarmCategory
-        if c != HarmCategory.HARM_CATEGORY_UNSPECIFIED
+        if c not in excluded_categories
         and not c.name.startswith("HARM_CATEGORY_IMAGE_")
     ]
 

--- a/tests/llm/test_genai/test_utils.py
+++ b/tests/llm/test_genai/test_utils.py
@@ -34,10 +34,15 @@ def test_update_genai_kwargs_safety_settings():
     """Test that safety settings are properly configured."""
     from google.genai.types import HarmCategory, HarmBlockThreshold
 
+    # Exclude JAILBREAK category as it's only for Vertex AI, not google.genai
+    excluded_categories = {HarmCategory.HARM_CATEGORY_UNSPECIFIED}
+    if hasattr(HarmCategory, 'HARM_CATEGORY_JAILBREAK'):
+        excluded_categories.add(HarmCategory.HARM_CATEGORY_JAILBREAK)
+
     supported_categories = [
         c
         for c in HarmCategory
-        if c != HarmCategory.HARM_CATEGORY_UNSPECIFIED
+        if c not in excluded_categories
         and not c.name.startswith("HARM_CATEGORY_IMAGE_")
     ]
 
@@ -65,10 +70,15 @@ def test_update_genai_kwargs_with_custom_safety_settings():
     """Test that custom safety settings are properly handled."""
     from google.genai.types import HarmCategory, HarmBlockThreshold
 
+    # Exclude JAILBREAK category as it's only for Vertex AI, not google.genai
+    excluded_categories = {HarmCategory.HARM_CATEGORY_UNSPECIFIED}
+    if hasattr(HarmCategory, 'HARM_CATEGORY_JAILBREAK'):
+        excluded_categories.add(HarmCategory.HARM_CATEGORY_JAILBREAK)
+
     supported_categories = [
         c
         for c in HarmCategory
-        if c != HarmCategory.HARM_CATEGORY_UNSPECIFIED
+        if c not in excluded_categories
         and not c.name.startswith("HARM_CATEGORY_IMAGE_")
     ]
 


### PR DESCRIPTION
## Summary

This PR combines critical fixes from PR #1863 and PR #1832.

## Changes

### 1. Handle missing HARM_CATEGORY_JAILBREAK in google.genai

**Problem:** The HARM_CATEGORY_JAILBREAK category is only available in Vertex AI, not in the google.genai API.

**Solution:**
- Use hasattr check for HARM_CATEGORY_JAILBREAK compatibility
- Ensures code works across different google.genai versions
- Fixes 400 errors when using Gemini API safety settings

**Files:** instructor/providers/gemini/utils.py, tests/llm/test_genai/test_utils.py

### 2. Ensure tool_result blocks for all Anthropic tool_use responses

**Problem:** When validation fails in ANTHROPIC_TOOLS mode, retry mechanism creates malformed messages.

**Solution:**  
- Simplified condition to always create tool_result block for any tool_use
- Removes check for exception type and title matching
- Fixes 400 error from Anthropic API

**Files:** instructor/providers/anthropic/utils.py

## Testing

Run tests:
```bash
uv run pytest tests/llm/test_genai/test_utils.py -v
```

## Credits

- Based on PR #1863 by @DaveOkpare 
- Based on PR #1832 by @jxnl

Co-authored-by: DaveOkpare <DaveOkpare@users.noreply.github.com>
Co-authored-by: Claude <noreply@anthropic.com>
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes handling of `HARM_CATEGORY_JAILBREAK` in `google.genai` and ensures `tool_result` blocks for Anthropic `tool_use` responses.
> 
>   - **Behavior**:
>     - Fix missing `HARM_CATEGORY_JAILBREAK` handling in `update_genai_kwargs()` in `utils.py` for `google.genai`.
>     - Ensure `tool_result` blocks are created for all `tool_use` responses in `reask_anthropic_tools()` in `utils.py`.
>   - **Testing**:
>     - Updated tests in `test_utils.py` to verify `HARM_CATEGORY_JAILBREAK` exclusion and `tool_result` block creation.
>   - **Misc**:
>     - Simplified condition checks in `reask_anthropic_tools()` to remove exception type and title matching.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=567-labs%2Finstructor&utm_source=github&utm_medium=referral)<sup> for 80970beb983a8f34739d4966c02621a3fd7cba00. You can [customize](https://app.ellipsis.dev/567-labs/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->