### PR TITLE
Refactor validation entry points and DSL hooks

### DIFF
--- a/docs/concepts/validation.md
+++ b/docs/concepts/validation.md
@@ -9,7 +9,9 @@ This guide covers validation concepts and best practices when using Instructor f
 
 ## Overview
 
-Validation in Instructor ensures that the output from language models matches your expected schema. This is crucial for:
+Validation in Instructor ensures that the output from language models matches your expected schema. The `instructor.validation`
+module is the primary entry point for runtime helpers like `llm_validator` and `openai_moderation`; legacy shims continue to
+work but will be removed in a future major release. This is crucial for:
 - Data consistency
 - Error handling
 - Type safety
@@ -123,7 +125,7 @@ from typing import Annotated
 # Third-party imports
 from pydantic import BaseModel, BeforeValidator
 import instructor
-from instructor import llm_validator
+from instructor.validation import llm_validator
 
 # Initialize client
 client = instructor.from_provider("openai/gpt-4.1-mini")

--- a/instructor/dsl/base.py
+++ b/instructor/dsl/base.py
@@ -1,0 +1,76 @@
+"""Shared interfaces for Instructor DSL response models."""
+
+from __future__ import annotations
+
+from collections.abc import AsyncGenerator
+from typing import Any, Callable, ClassVar
+
+from ..mode import Mode
+
+ProviderHook = Callable[[Any, dict[str, Any]], tuple[Any, dict[str, Any]]]
+
+
+class DSLProviderHooksMixin:
+    """Mixin that standardizes provider hook behaviour for DSL models."""
+
+    provider_mode_hooks: ClassVar[dict[Mode, ProviderHook]] = {}
+    stream_consumer: ClassVar[bool] = False
+
+    @classmethod
+    def apply_provider_hook(
+        cls,
+        mode: Mode,
+        kwargs: dict[str, Any],
+    ) -> tuple[Any, dict[str, Any]]:
+        """Apply a provider-specific hook if one is registered."""
+
+        hook = cls.provider_mode_hooks.get(mode)
+        if hook is None:
+            return cls, kwargs
+        return hook(cls, kwargs)
+
+    @classmethod
+    def consume_stream_sync(
+        cls,
+        completion: Any,
+        mode: Mode,
+    ) -> list[Any]:
+        """Collect streaming results for synchronous clients."""
+
+        raise NotImplementedError(f"{cls.__name__} does not support streaming consumption")
+
+    @classmethod
+    async def consume_stream_async(
+        cls,
+        completion: AsyncGenerator[Any, None],
+        mode: Mode,
+    ) -> list[Any]:
+        """Collect streaming results for async clients."""
+
+        raise NotImplementedError(f"{cls.__name__} does not support streaming consumption")
+
+    @classmethod
+    def finalize_response(cls, model: Any, raw_response: Any) -> Any:
+        """Finalize a parsed response before returning it to the caller."""
+
+        model._raw_response = raw_response  # type: ignore[attr-defined]
+        return model
+
+
+def get_dsl_provider_hooks(
+    response_model: Any,
+) -> type[DSLProviderHooksMixin] | None:
+    """Return the hook mixin for a response model when available."""
+
+    if isinstance(response_model, type) and issubclass(
+        response_model, DSLProviderHooksMixin
+    ):
+        return response_model
+
+    if isinstance(response_model, DSLProviderHooksMixin):
+        return response_model.__class__
+
+    return None
+
+
+__all__ = ["DSLProviderHooksMixin", "ProviderHook", "get_dsl_provider_hooks"]

--- a/instructor/dsl/iterable.py
+++ b/instructor/dsl/iterable.py
@@ -13,13 +13,15 @@ import json
 from pydantic import BaseModel, Field, create_model
 from ..mode import Mode
 from ..utils import extract_json_from_stream, extract_json_from_stream_async
+from .base import DSLProviderHooksMixin
 
 if TYPE_CHECKING:
     pass
 
 
-class IterableBase:
+class IterableBase(DSLProviderHooksMixin):
     task_type: ClassVar[Optional[type[BaseModel]]] = None
+    stream_consumer: ClassVar[bool] = True
 
     @classmethod
     def from_streaming_response(
@@ -57,6 +59,27 @@ class IterableBase:
             return cls.tasks_from_mistral_chunks(json_chunks, **kwargs)
 
         return cls.tasks_from_chunks_async(json_chunks, **kwargs)
+
+    @classmethod
+    def consume_stream_sync(
+        cls, completion: Iterable[Any], mode: Mode
+    ) -> list[BaseModel]:
+        """Collect streaming chunks synchronously for iterable responses."""
+
+        return list(cls.from_streaming_response(completion, mode=mode))
+
+    @classmethod
+    async def consume_stream_async(
+        cls, completion: AsyncGenerator[Any, None], mode: Mode
+    ) -> list[BaseModel]:
+        """Collect streaming chunks asynchronously for iterable responses."""
+
+        tasks: list[BaseModel] = []
+        async for task in cls.from_streaming_response_async(
+            completion, mode=mode
+        ):
+            tasks.append(task)
+        return tasks
 
     @classmethod
     async def tasks_from_mistral_chunks(
@@ -141,6 +164,12 @@ class IterableBase:
         raise ValueError(
             f"Failed to extract task type with {task_json} for {cls.task_type}"
         )
+
+    @classmethod
+    def finalize_response(cls, model: Any, raw_response: Any) -> list[BaseModel]:
+        """Return the extracted tasks when not streaming."""
+
+        return [task for task in model.tasks]
 
     @staticmethod
     def extract_json(

--- a/instructor/dsl/parallel.py
+++ b/instructor/dsl/parallel.py
@@ -14,6 +14,7 @@ from pydantic import BaseModel
 from collections.abc import Iterable
 
 from ..mode import Mode
+from .base import DSLProviderHooksMixin
 
 if TYPE_CHECKING:
     from ..processing.function_calls import OpenAISchema
@@ -24,7 +25,7 @@ else:
     T = TypeVar("T", bound=BaseModel)
 
 
-class ParallelBase:
+class ParallelBase(DSLProviderHooksMixin):
     def __init__(self, *models: type[BaseModel]):
         # Note that for everything else we've created a class, but for parallel base it is an instance
         assert len(models) > 0, "At least one model is required"
@@ -50,6 +51,12 @@ class ParallelBase:
             yield self.registry[name].model_validate_json(
                 arguments, context=validation_context, strict=strict
             )
+
+    @classmethod
+    def finalize_response(cls, model: Any, raw_response: Any) -> Any:
+        """Return the parallel response unchanged."""
+
+        return model
 
 
 class VertexAIParallelBase(ParallelBase):

--- a/instructor/dsl/partial.py
+++ b/instructor/dsl/partial.py
@@ -32,6 +32,7 @@ from pydantic.fields import FieldInfo
 
 from instructor.mode import Mode
 from instructor.utils import extract_json_from_stream, extract_json_from_stream_async
+from .base import DSLProviderHooksMixin
 
 T_Model = TypeVar("T_Model", bound=BaseModel)
 
@@ -130,7 +131,8 @@ def _make_field_optional(
     return tmp_field.annotation, tmp_field  # type: ignore
 
 
-class PartialBase(Generic[T_Model]):
+class PartialBase(DSLProviderHooksMixin, Generic[T_Model]):
+    stream_consumer: ClassVar[bool] = True
     @classmethod
     @cache
     def get_partial_model(cls) -> type[T_Model]:
@@ -181,6 +183,25 @@ class PartialBase(Generic[T_Model]):
             return cls.writer_model_from_chunks_async(json_chunks, **kwargs)
 
         return cls.model_from_chunks_async(json_chunks, **kwargs)
+
+    @classmethod
+    def consume_stream_sync(
+        cls, completion: Iterable[Any], mode: Mode
+    ) -> list[T_Model]:
+        """Collect streaming partial models synchronously."""
+
+        return list(cls.from_streaming_response(completion, mode=mode))
+
+    @classmethod
+    async def consume_stream_async(
+        cls, completion: AsyncGenerator[Any, None], mode: Mode
+    ) -> list[T_Model]:
+        """Collect streaming partial models asynchronously."""
+
+        results: list[T_Model] = []
+        async for item in cls.from_streaming_response_async(completion, mode=mode):
+            results.append(item)
+        return results
 
     @classmethod
     def writer_model_from_chunks(

--- a/instructor/dsl/validators.py
+++ b/instructor/dsl/validators.py
@@ -1,19 +1,22 @@
-"""Backwards compatibility module for instructor.dsl.validators.
+"""Backwards compatibility module for instructor.dsl.validators."""
 
-This module provides lazy imports to avoid circular import issues.
-"""
+from __future__ import annotations
+
+import warnings
 
 
 def __getattr__(name: str):
     """Lazy import to avoid circular dependencies."""
-    from ..processing import validators as processing_validators
+
+    warnings.warn(
+        "Importing from 'instructor.dsl.validators' is deprecated and will be removed in v2.0.0. "
+        "Please update your imports to use 'instructor.validation'.",
+        DeprecationWarning,
+        stacklevel=2,
+    )
+
     from .. import validation
 
-    # Try processing.validators first
-    if hasattr(processing_validators, name):
-        return getattr(processing_validators, name)
-
-    # Then try validation module
     if hasattr(validation, name):
         return getattr(validation, name)
 

--- a/instructor/processing/response.py
+++ b/instructor/processing/response.py
@@ -35,9 +35,9 @@ Example:
 
 from __future__ import annotations
 
-import inspect
 import logging
-from typing import Any, TypeVar, TYPE_CHECKING
+from collections.abc import AsyncGenerator
+from typing import Any, TypeVar, TYPE_CHECKING, cast
 
 from openai.types.chat import ChatCompletion
 from pydantic import BaseModel
@@ -45,9 +45,7 @@ from typing_extensions import ParamSpec
 
 from instructor.core.exceptions import InstructorError
 
-from ..dsl.iterable import IterableBase
-from ..dsl.parallel import ParallelBase
-from ..dsl.partial import PartialBase
+from ..dsl.base import get_dsl_provider_hooks
 from ..dsl.simple_type import AdapterBase
 
 if TYPE_CHECKING:
@@ -223,20 +221,13 @@ async def process_response_async(
     if response_model is None:
         return response
 
-    if (
-        inspect.isclass(response_model)
-        and issubclass(response_model, (IterableBase, PartialBase))
-        and stream
-    ):
-        # from_streaming_response_async returns an AsyncGenerator
-        # Collect all yielded values into a list
-        # Note: response type varies by mode (ChatCompletion, AsyncGenerator, etc.)
-        tasks = []
-        async for task in response_model.from_streaming_response_async(  # type: ignore[arg-type]
-            cast(AsyncGenerator[Any, None], response),  # type: ignore[arg-type]
+    hook_target = get_dsl_provider_hooks(response_model)
+
+    if hook_target and hook_target.stream_consumer and stream:
+        tasks = await hook_target.consume_stream_async(  # type: ignore[arg-type]
+            cast(AsyncGenerator[Any, None], response),
             mode=mode,
-        ):
-            tasks.append(task)
+        )
         return tasks  # type: ignore
 
     model = response_model.from_response(  # type: ignore
@@ -246,22 +237,20 @@ async def process_response_async(
         mode=mode,
     )
 
-    # ? This really hints at the fact that we need a better way of
-    # ? attaching usage data and the raw response to the model we return.
-    if isinstance(model, IterableBase):
-        logger.debug(f"Returning takes from IterableBase")
-        return [task for task in model.tasks]  # type: ignore
+    if hook_target:
+        result = hook_target.finalize_response(model, response)
+    else:
+        result = model
 
-    if isinstance(response_model, ParallelBase):
-        logger.debug(f"Returning model from ParallelBase")
-        return model
-
-    if isinstance(model, AdapterBase):
+    if isinstance(result, AdapterBase):
         logger.debug(f"Returning model from AdapterBase")
-        return model.content
+        return result.content
 
-    model._raw_response = response
-    return model
+    if hook_target is None:
+        result._raw_response = response  # type: ignore[attr-defined]
+        return result
+
+    return result
 
 
 def process_response(
@@ -329,20 +318,10 @@ def process_response(
         logger.debug("No response model, returning response as is")
         return response
 
-    if (
-        inspect.isclass(response_model)
-        and issubclass(response_model, (IterableBase, PartialBase))
-        and stream
-    ):
-        # from_streaming_response returns a Generator
-        # Collect all yielded values into a list
-        tasks = list(
-            response_model.from_streaming_response(  # type: ignore
-                response,
-                mode=mode,
-            )
-        )
-        return tasks
+    hook_target = get_dsl_provider_hooks(response_model)
+
+    if hook_target and hook_target.stream_consumer and stream:
+        return hook_target.consume_stream_sync(response, mode=mode)
 
     model = response_model.from_response(  # type: ignore
         response,
@@ -351,22 +330,20 @@ def process_response(
         mode=mode,
     )
 
-    # ? This really hints at the fact that we need a better way of
-    # ? attaching usage data and the raw response to the model we return.
-    if isinstance(model, IterableBase):
-        logger.debug(f"Returning takes from IterableBase")
-        return [task for task in model.tasks]  # type: ignore
+    if hook_target:
+        result = hook_target.finalize_response(model, response)
+    else:
+        result = model
 
-    if isinstance(response_model, ParallelBase):
-        logger.debug(f"Returning model from ParallelBase")
-        return model
-
-    if isinstance(model, AdapterBase):
+    if isinstance(result, AdapterBase):
         logger.debug(f"Returning model from AdapterBase")
-        return model.content
+        return result.content
 
-    model._raw_response = response
-    return model
+    if hook_target is None:
+        result._raw_response = response  # type: ignore[attr-defined]
+        return result
+
+    return result
 
 
 def is_typed_dict(cls) -> bool:
@@ -428,6 +405,14 @@ def handle_response_model(
     # Only prepare response_model if it's not None
     if response_model is not None:
         response_model = prepare_response_model(response_model)
+
+    hook_target = (
+        get_dsl_provider_hooks(response_model) if response_model is not None else None
+    )
+    if hook_target:
+        response_model, new_kwargs = hook_target.apply_provider_hook(
+            mode, new_kwargs
+        )
 
     mode_handlers = {  # type: ignore
         Mode.FUNCTIONS: handle_functions,

--- a/instructor/processing/validators.py
+++ b/instructor/processing/validators.py
@@ -1,27 +1,16 @@
-"""Validators that extend OpenAISchema for structured outputs."""
+"""Deprecated shim for validator models."""
 
-from typing import Optional
+from __future__ import annotations
 
-from pydantic import Field
+import warnings
 
-from .function_calls import OpenAISchema
+from ..validation.models import Validator
 
+warnings.warn(
+    "'instructor.processing.validators' is deprecated and will be removed in a future release. "
+    "Import from 'instructor.validation' instead.",
+    DeprecationWarning,
+    stacklevel=2,
+)
 
-class Validator(OpenAISchema):
-    """
-    Validate if an attribute is correct and if not,
-    return a new value with an error message
-    """
-
-    is_valid: bool = Field(
-        default=True,
-        description="Whether the attribute is valid based on the requirements",
-    )
-    reason: Optional[str] = Field(
-        default=None,
-        description="The error message if the attribute is not valid, otherwise None",
-    )
-    fixed_value: Optional[str] = Field(
-        default=None,
-        description="If the attribute is not valid, suggest a new value for the attribute",
-    )
+__all__ = ["Validator"]

--- a/instructor/validation/__init__.py
+++ b/instructor/validation/__init__.py
@@ -8,7 +8,8 @@ from .async_validators import (
     ASYNC_MODEL_VALIDATOR_KEY,
 )
 from ..core.exceptions import AsyncValidationError
-from .llm_validators import Validator, llm_validator, openai_moderation
+from .llm_validators import llm_validator, openai_moderation
+from .models import Validator
 
 __all__ = [
     "AsyncValidationContext",
@@ -17,7 +18,7 @@ __all__ = [
     "async_model_validator",
     "ASYNC_VALIDATOR_KEY",
     "ASYNC_MODEL_VALIDATOR_KEY",
-    "Validator",
     "llm_validator",
     "openai_moderation",
+    "Validator",
 ]

--- a/instructor/validation/llm_validators.py
+++ b/instructor/validation/llm_validators.py
@@ -2,8 +2,8 @@ from typing import Callable
 
 from openai import OpenAI
 
-from ..processing.validators import Validator
 from ..core.client import Instructor
+from .models import Validator
 
 
 def llm_validator(

--- a/instructor/validation/models.py
+++ b/instructor/validation/models.py
@@ -1,0 +1,29 @@
+"""Validation models shared across instructor."""
+
+from __future__ import annotations
+
+from typing import Optional
+
+from pydantic import Field
+
+from ..processing.function_calls import OpenAISchema
+
+
+class Validator(OpenAISchema):
+    """Model used by LLM-powered validators."""
+
+    is_valid: bool = Field(
+        default=True,
+        description="Whether the attribute is valid based on the requirements",
+    )
+    reason: Optional[str] = Field(
+        default=None,
+        description="The error message if the attribute is not valid, otherwise None",
+    )
+    fixed_value: Optional[str] = Field(
+        default=None,
+        description="If the attribute is not valid, suggest a new value for the attribute",
+    )
+
+
+__all__ = ["Validator"]

--- a/instructor/validators.py
+++ b/instructor/validators.py
@@ -1,7 +1,6 @@
-"""Backwards compatibility module for instructor.validators.
+"""Backwards compatibility module for instructor.validators."""
 
-This module provides lazy imports to maintain backwards compatibility.
-"""
+from __future__ import annotations
 
 import warnings
 
@@ -9,22 +8,16 @@ import warnings
 def __getattr__(name: str):
     """Lazy import to provide backward compatibility for validators imports."""
     warnings.warn(
-        f"Importing from 'instructor.validators' is deprecated and will be removed in v2.0.0. "
-        f"Please update your imports to use the new location:\n"
+        "Importing from 'instructor.validators' is deprecated and will be removed in v2.0.0. "
+        "Please update your imports to use the new location:\n"
         "  from instructor.validation import llm_validator, openai_moderation",
         DeprecationWarning,
         stacklevel=2,
     )
 
     from . import validation
-    from .processing import validators as processing_validators
 
-    # Try validation module first
     if hasattr(validation, name):
         return getattr(validation, name)
-
-    # Then try processing.validators
-    if hasattr(processing_validators, name):
-        return getattr(processing_validators, name)
 
     raise AttributeError(f"module '{__name__}' has no attribute '{name}'")


### PR DESCRIPTION
## Summary
- move the LLM validator schema into `instructor.validation` and leave `processing.validators` as a deprecation shim
- add a shared DSL provider hook mixin and update iterable, partial, and parallel bases to use it
- simplify response processing stream handling and document the preferred `instructor.validation` import path

## Testing
- uv run pytest tests/llm/test_openai/test_validators.py *(fails: OPENAI_API_KEY environment variable not set)*

------
https://chatgpt.com/codex/tasks/task_e_69044c46fb7483269553b634a5070d64
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Refactor validation entry points and DSL hooks, moving LLM validator schema, adding a shared DSL provider hook mixin, and updating base classes.
> 
>   - **Behavior**:
>     - Move LLM validator schema to `instructor.validation`, leaving `processing.validators` as a deprecation shim.
>     - Add `DSLProviderHooksMixin` and update `IterableBase`, `PartialBase`, and `ParallelBase` to use it.
>     - Simplify response processing in `response.py` to use `get_dsl_provider_hooks()`.
>   - **Documentation**:
>     - Update `validation.md` to reflect new import paths and deprecation notices.
>   - **Deprecation**:
>     - Add deprecation warnings in `validators.py` and `processing/validators.py` for old import paths.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=567-labs%2Finstructor&utm_source=github&utm_medium=referral)<sup> for ce662d547ba29ec5a758001ad178b5b12bc2d3eb. You can [customize](https://app.ellipsis.dev/567-labs/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->