### PR TITLE
Document google genai as preferred

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,27 +3,38 @@
 Get reliable JSON from any LLM. Built on Pydantic for validation, type safety, and IDE support.
 
 ```python
+import asyncio
 import instructor
+from instructor import Mode
 from pydantic import BaseModel
 
 
-# Define what you want
 class User(BaseModel):
     name: str
     age: int
 
 
-# Extract it from natural language
-client = instructor.from_provider("openai/gpt-4o-mini")
-user = client.chat.completions.create(
-    response_model=User,
-    messages=[{"role": "user", "content": "John is 25 years old"}],
-)
+async def main() -> None:
+    client = instructor.from_provider(
+        "google/gemini-2.5-flash",
+        async_client=True,
+        mode=Mode.GENAI_STRUCTURED_OUTPUTS,
+    )
 
-print(user)  # User(name='John', age=25)
+    user = await client.chat.completions.create(
+        response_model=User,
+        messages=[{"role": "user", "content": "John is 25 years old"}],
+    )
+
+    print(user)  # User(name='John', age=25)
+
+
+asyncio.run(main())
 ```
 
 **That's it.** No JSON parsing, no error handling, no retries. Just define a model and get structured data.
+
+> We recommend starting with Google GenAI models. They pair strong structured output support with Instructor's retries, and you can still swap to another provider later without changing your code.
 
 [![PyPI](https://img.shields.io/pypi/v/instructor?style=flat-square)](https://pypi.org/project/instructor/)
 [![Downloads](https://img.shields.io/pypi/dm/instructor?style=flat-square)](https://pypi.org/project/instructor/)
@@ -103,13 +114,14 @@ user = client.chat.completions.create(
 ## Install in seconds
 
 ```bash
-pip install instructor
+uv add "instructor[google-genai]"
 ```
 
-Or with your package manager:
+That command installs Instructor with Google GenAI support, which is our recommended starter setup. Add extra providers only when you need them.
+
 ```bash
-uv add instructor
-poetry add instructor
+uv add "instructor[anthropic]"
+uv add "instructor[mistralai]"
 ```
 
 ## Works with every major provider
@@ -117,28 +129,38 @@ poetry add instructor
 Use the same code with any LLM provider:
 
 ```python
-# OpenAI
-client = instructor.from_provider("openai/gpt-4o")
+import asyncio
+import instructor
+from instructor import Mode
+from pydantic import BaseModel
 
-# Anthropic
-client = instructor.from_provider("anthropic/claude-3-5-sonnet")
 
-# Google
-client = instructor.from_provider("google/gemini-pro")
+async def main() -> None:
+    class User(BaseModel):
+        name: str
+        age: int
 
-# Ollama (local)
-client = instructor.from_provider("ollama/llama3.2")
+    # Google (recommended default)
+    google_client = instructor.from_provider(
+        "google/gemini-2.5-flash",
+        async_client=True,
+        mode=Mode.GENAI_STRUCTURED_OUTPUTS,
+    )
 
-# With API keys directly (no environment variables needed)
-client = instructor.from_provider("openai/gpt-4o", api_key="sk-...")
-client = instructor.from_provider("anthropic/claude-3-5-sonnet", api_key="sk-ant-...")
-client = instructor.from_provider("groq/llama-3.1-8b-instant", api_key="gsk_...")
+    # OpenAI, Anthropic, and others keep the same API surface
+    openai_client = instructor.from_provider("openai/gpt-4o")
+    anthropic_client = instructor.from_provider("anthropic/claude-3-5-sonnet")
+    ollama_client = instructor.from_provider("ollama/llama3.2")
 
-# All use the same API!
-user = client.chat.completions.create(
-    response_model=User,
-    messages=[{"role": "user", "content": "..."}],
-)
+    user = await google_client.chat.completions.create(
+        response_model=User,
+        messages=[{"role": "user", "content": "..."}],
+    )
+
+    print(user)
+
+
+asyncio.run(main())
 ```
 
 ## Production-ready features
@@ -232,10 +254,10 @@ Companies using Instructor include teams at OpenAI, Google, Microsoft, AWS, and 
 Extract structured data from any text:
 
 ```python
-from pydantic import BaseModel
+import asyncio
 import instructor
-
-client = instructor.from_provider("openai/gpt-4o-mini")
+from instructor import Mode
+from pydantic import BaseModel
 
 
 class Product(BaseModel):
@@ -244,13 +266,24 @@ class Product(BaseModel):
     in_stock: bool
 
 
-product = client.chat.completions.create(
-    response_model=Product,
-    messages=[{"role": "user", "content": "iPhone 15 Pro, $999, available now"}],
-)
+async def main() -> None:
+    client = instructor.from_provider(
+        "google/gemini-2.5-flash",
+        async_client=True,
+        mode=Mode.GENAI_STRUCTURED_OUTPUTS,
+    )
 
-print(product)
-# Product(name='iPhone 15 Pro', price=999.0, in_stock=True)
+    product = await client.chat.completions.create(
+        response_model=Product,
+        messages=[
+            {"role": "user", "content": "iPhone 15 Pro, $999, available now"}
+        ],
+    )
+
+    print(product)
+
+
+asyncio.run(main())
 ```
 
 ### Multiple languages

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -15,27 +15,18 @@ This guide will walk you through the basics of using Instructor to extract struc
 
 ## Installation
 
-First, install Instructor:
+First, install Instructor with Google GenAI support:
 
 ```bash
-pip install instructor
+uv add "instructor[google-genai]"
 ```
 
-To use a specific provider, install the appropriate extras:
+Add extras only when you need another provider:
 
 ```bash
-# For OpenAI (included by default)
-pip install instructor
-
-# For Anthropic
-pip install "instructor[anthropic]"
-
-# For other providers
-pip install "instructor[google-genai]"         # For Google/Gemini
-pip install "instructor[vertexai]"             # For Vertex AI
-pip install "instructor[cohere]"               # For Cohere
-pip install "instructor[litellm]"              # For LiteLLM (multiple providers)
-pip install "instructor[mistralai]"            # For Mistral
+uv add "instructor[anthropic]"
+uv add "instructor[mistralai]"
+uv add "instructor[litellm]"
 ```
 
 ## Setting Up Environment
@@ -43,41 +34,52 @@ pip install "instructor[mistralai]"            # For Mistral
 Set your API keys as environment variables:
 
 ```bash
-# For OpenAI
+# For Google GenAI (recommended)
+export GOOGLE_API_KEY=your_google_key
+
+# For Vertex AI deployments
+export GOOGLE_CLOUD_PROJECT=your_project_id
+export GOOGLE_CLOUD_LOCATION=your_region
+
+# For other providers, set their API keys when you need them
 export OPENAI_API_KEY=your_openai_api_key
-
-# For Anthropic
 export ANTHROPIC_API_KEY=your_anthropic_api_key
-
-# For other providers, set relevant API keys
 ```
 
 ## Your First Structured Output
 
-Let's start with a simple example using OpenAI:
+Let's start with a simple example using Google GenAI and the async client:
 
 ```python
+import asyncio
 import instructor
+from instructor import Mode
 from pydantic import BaseModel
 
-# Define your output structure
+
 class UserInfo(BaseModel):
     name: str
     age: int
 
-# Create an instructor client with from_provider
-client = instructor.from_provider("openai/gpt-5-nano")
 
-# Extract structured data
-user_info = client.chat.completions.create(
-    response_model=UserInfo,
-    messages=[
-        {"role": "user", "content": "John Doe is 30 years old."}
-    ],
-)
+async def main() -> None:
+    client = instructor.from_provider(
+        "google/gemini-2.5-flash",
+        async_client=True,
+        mode=Mode.GENAI_STRUCTURED_OUTPUTS,
+    )
 
-print(f"Name: {user_info.name}, Age: {user_info.age}")
-# Output: Name: John Doe, Age: 30
+    user_info = await client.chat.completions.create(
+        response_model=UserInfo,
+        messages=[
+            {"role": "user", "content": "John Doe is 30 years old."}
+        ],
+    )
+
+    print(f"Name: {user_info.name}, Age: {user_info.age}")
+
+
+asyncio.run(main())
 ```
 
 This example demonstrates the core workflow:
@@ -90,26 +92,40 @@ This example demonstrates the core workflow:
 Instructor leverages Pydantic's validation to ensure your data meets requirements:
 
 ```python
+import asyncio
+import instructor
+from instructor import Mode
 from pydantic import BaseModel, Field, field_validator
+
 
 class User(BaseModel):
     name: str
-    age: int = Field(gt=0, lt=120)  # Age must be between 0 and 120
+    age: int = Field(gt=0, lt=120)
 
-    @field_validator('name')
-    def name_must_have_space(cls, v):
-        if ' ' not in v:
-            raise ValueError('Name must include first and last name')
-        return v
+    @field_validator("name")
+    def name_must_have_space(cls, value: str) -> str:
+        if " " not in value:
+            raise ValueError("Name must include first and last name")
+        return value
 
-# This will make the LLM retry if validation fails
-user = client.chat.completions.create(
-    model="gpt-3.5-turbo",
-    response_model=User,
-    messages=[
-        {"role": "user", "content": "Extract: Tom is 25 years old."}
-    ],
-)
+
+async def main() -> None:
+    client = instructor.from_provider(
+        "google/gemini-2.5-flash",
+        async_client=True,
+        mode=Mode.GENAI_STRUCTURED_OUTPUTS,
+    )
+
+    user = await client.chat.completions.create(
+        response_model=User,
+        messages=[{"role": "user", "content": "Extract: Tom is 25 years old."}],
+        max_retries=3,
+    )
+
+    print(user)
+
+
+asyncio.run(main())
 ```
 
 ## Working with Complex Models
@@ -117,8 +133,12 @@ user = client.chat.completions.create(
 Instructor works seamlessly with nested Pydantic models:
 
 ```python
-from pydantic import BaseModel
+import asyncio
+import instructor
 from typing import List
+from instructor import Mode
+from pydantic import BaseModel
+
 
 class Address(BaseModel):
     street: str
@@ -126,22 +146,38 @@ class Address(BaseModel):
     state: str
     zip_code: str
 
+
 class Person(BaseModel):
     name: str
     age: int
     addresses: List[Address]
 
-person = client.chat.completions.create(
-    model="gpt-3.5-turbo",
-    response_model=Person,
-    messages=[
-        {"role": "user", "content": """
-        Extract: John Smith is 35 years old.
-        He has homes at 123 Main St, Springfield, IL 62704 and
-        456 Oak Ave, Chicago, IL 60601.
-        """}
-    ],
-)
+
+async def main() -> None:
+    client = instructor.from_provider(
+        "google/gemini-2.5-flash",
+        async_client=True,
+        mode=Mode.GENAI_STRUCTURED_OUTPUTS,
+    )
+
+    person = await client.chat.completions.create(
+        response_model=Person,
+        messages=[
+            {
+                "role": "user",
+                "content": (
+                    "Extract: John Smith is 35 years old. "
+                    "He has homes at 123 Main St, Springfield, IL 62704 and "
+                    "456 Oak Ave, Chicago, IL 60601."
+                ),
+            }
+        ],
+    )
+
+    print(person)
+
+
+asyncio.run(main())
 ```
 
 ## Streaming Responses
@@ -149,20 +185,41 @@ person = client.chat.completions.create(
 For larger responses or better user experience, use streaming:
 
 ```python
-from instructor import Partial
+import asyncio
+import instructor
+from instructor import Mode
+from pydantic import BaseModel
 
-# Stream the response as it's being generated
-stream = client.chat.completions.create_partial(
-    model="gpt-3.5-turbo",
-    response_model=Person,
-    messages=[
-        {"role": "user", "content": "Extract a detailed person profile for John Smith, 35, who lives in Chicago and Springfield."}
-    ],
-)
 
-for partial in stream:
-    # This will incrementally show the response being built
-    print(partial)
+class Person(BaseModel):
+    name: str
+    age: int
+    summary: str
+
+
+async def main() -> None:
+    client = instructor.from_provider(
+        "google/gemini-2.5-flash",
+        async_client=True,
+        mode=Mode.GENAI_STRUCTURED_OUTPUTS,
+    )
+
+    stream = client.chat.completions.create_partial(
+        response_model=Person,
+        messages=[
+            {
+                "role": "user",
+                "content": "Extract a detailed person profile for John Smith, 35, who lives in Chicago and Springfield.",
+            }
+        ],
+        stream=True,
+    )
+
+    async for partial in stream:
+        print(partial)
+
+
+asyncio.run(main())
 ```
 
 ## Using Different Providers

--- a/docs/index.md
+++ b/docs/index.md
@@ -19,7 +19,7 @@ _Extract structured data from any LLM with type safety, validation, and automati
 
 Instructor is the **most popular Python library** for extracting structured data from Large Language Models (LLMs). With over **3 million monthly downloads, 11k stars, and 100+ contributors**, it's the go-to solution for developers who need reliable, validated outputs from AI models.
 
-Built on top of **Pydantic**, Instructor provides type-safe data extraction with automatic validation, retries, and streaming support. Whether you're using OpenAI's GPT models, Anthropic's Claude, Google's Gemini, **open source models with Ollama**, **DeepSeek**, or any of 15+ supported providers, Instructor ensures your LLM outputs are always structured and validated.
+Built on top of **Pydantic**, Instructor provides type-safe data extraction with automatic validation, retries, and streaming support. We recommend starting with Google's Gemini models through the GenAI SDK, and you can still switch to OpenAI, Anthropic, or any of the 15+ supported providers without changing your application code.
 
 ## Key Features for LLM Data Extraction
 
@@ -35,23 +35,20 @@ Built on top of **Pydantic**, Instructor provides type-safe data extraction with
 
 Install Instructor and start extracting structured data immediately:
 
-=== "pip"
-    ```bash
-    pip install instructor
-    ```
-
 === "uv"
     ```bash
-    uv add instructor
+    uv add "instructor[google-genai]"
     ```
 
 === "poetry"
     ```bash
-    poetry add instructor
+    poetry add "instructor[google-genai]"
     ```
 
 ```python
+import asyncio
 import instructor
+from instructor import Mode
 from pydantic import BaseModel
 
 
@@ -61,14 +58,24 @@ class Person(BaseModel):
     occupation: str
 
 
-client = instructor.from_provider("openai/gpt-5-nano")
-person = client.chat.completions.create(
-    response_model=Person,
-    messages=[
-        {"role": "user", "content": "Extract: John is a 30-year-old software engineer"}
-    ],
-)
-print(person)  # Person(name='John', age=30, occupation='software engineer')
+async def main() -> None:
+    client = instructor.from_provider(
+        "google/gemini-2.5-flash",
+        async_client=True,
+        mode=Mode.GENAI_STRUCTURED_OUTPUTS,
+    )
+
+    person = await client.chat.completions.create(
+        response_model=Person,
+        messages=[
+            {"role": "user", "content": "Extract: John is a 30-year-old software engineer"}
+        ],
+    )
+
+    print(person)
+
+
+asyncio.run(main())
 ```
 
 ## Universal Provider API - One Interface for All LLMs
@@ -76,7 +83,9 @@ print(person)  # Person(name='John', age=30, occupation='software engineer')
 Instructor's **`from_provider`** function provides a unified interface to work with any LLM provider. Switch between OpenAI, Anthropic, Google, Ollama, DeepSeek, and 15+ providers with the same code:
 
 ```python
+import asyncio
 import instructor
+from instructor import Mode
 from pydantic import BaseModel
 
 
@@ -85,23 +94,26 @@ class UserInfo(BaseModel):
     age: int
 
 
-# Works with any provider - same interface everywhere
-client = instructor.from_provider("openai/gpt-4")  # OpenAI
-client = instructor.from_provider("anthropic/claude-3")  # Anthropic
-client = instructor.from_provider("google/gemini-pro")  # Google
-client = instructor.from_provider("ollama/llama3")  # Ollama (local)
-client = instructor.from_provider("deepseek/deepseek-chat")  # DeepSeek
+async def main() -> None:
+    # Works with any provider - same interface everywhere
+    google_client = instructor.from_provider(
+        "google/gemini-2.5-flash",
+        async_client=True,
+        mode=Mode.GENAI_STRUCTURED_OUTPUTS,
+    )
+    openai_client = instructor.from_provider("openai/gpt-4")
+    anthropic_client = instructor.from_provider("anthropic/claude-3")
+    ollama_client = instructor.from_provider("ollama/llama3")
 
-# Pass API keys directly (no environment variables needed)
-client = instructor.from_provider("openai/gpt-4", api_key="sk-...")
-client = instructor.from_provider("anthropic/claude-3", api_key="sk-ant-...")
-client = instructor.from_provider("groq/llama-3.1-8b-instant", api_key="gsk_...")
+    user = await google_client.chat.completions.create(
+        response_model=UserInfo,
+        messages=[{"role": "user", "content": "John Doe is 30 years old."}],
+    )
 
-# Same extraction code works with all providers
-user = client.chat.completions.create(
-    response_model=UserInfo,
-    messages=[{"role": "user", "content": "John Doe is 30 years old."}],
-)
+    print(user)
+
+
+asyncio.run(main())
 ```
 
 The **`from_provider`** API supports both sync and async usage (`async_client=True`) and automatically handles provider-specific configurations, making it effortless to switch between different LLM services.

--- a/docs/learning/getting_started/client_setup.md
+++ b/docs/learning/getting_started/client_setup.md
@@ -2,21 +2,47 @@
 
 Setting up the right client is the first step in using Instructor with various LLM providers. This guide covers how to configure clients for different providers and explains the various modes available.
 
+## Google GenAI (Recommended)
+
+Start with Google's Gemini models using the async client:
+
+```python
+import asyncio
+import instructor
+from instructor import Mode
+
+
+async def main() -> None:
+    client = instructor.from_provider(
+        "google/gemini-2.5-flash",
+        async_client=True,
+        mode=Mode.GENAI_STRUCTURED_OUTPUTS,
+    )
+
+    result = await client.chat.completions.create(
+        response_model=dict,
+        messages=[{"role": "user", "content": "Extract the topic and tone."}],
+    )
+
+    print(result)
+
+
+asyncio.run(main())
+```
+
+Set `vertexai=True` when you need to run against Google Cloud Vertex AI.
+
 ## OpenAI
 
-The most common configuration is with OpenAI:
+OpenAI remains fully supported:
 
 ```python
 import instructor
 from openai import OpenAI
 
-# Default mode (TOOLS)
-client = instructor.from_provider("openai/gpt-5-nano")
-
-# With JSON mode
 client = instructor.from_openai(
     OpenAI(),
-    mode=instructor.Mode.JSON  # Use JSON mode instead
+    mode=instructor.Mode.TOOLS,
 )
 ```
 
@@ -26,25 +52,11 @@ For Anthropic's Claude models:
 
 ```python
 import instructor
-# Default mode (ANTHROPIC_TOOLS)
-client = instructor.from_provider("anthropic/claude-3-5-haiku-latest")
 
-# With JSON mode
-client = instructor.from_provider("anthropic/claude-3-5-haiku-latest", mode=instructor.Mode.JSON)
-```
-
-## Google Gemini
-
-For Google's Gemini models:
-
-```python
-import instructor
-import google.generativeai as genai
-
-genai.configure(api_key="YOUR_API_KEY")
-model = genai.GenerativeModel("gemini-1.5-flash")
-
-client = instructor.from_provider("google/gemini-2.5-flash")
+client = instructor.from_provider(
+    "anthropic/claude-3-5-haiku-latest",
+    mode=instructor.Mode.ANTHROPIC_TOOLS,
+)
 ```
 
 ## Cohere
@@ -78,21 +90,25 @@ Instructor supports different modes for structured extraction:
 ```python
 from instructor import Mode
 
-Mode.TOOLS         # OpenAI function calling format (default for OpenAI)
-Mode.JSON          # Plain JSON generation
-Mode.MD_JSON       # Markdown JSON (used by some providers)
-Mode.ANTHROPIC_TOOLS # Claude tools mode (default for Anthropic)
-Mode.GEMINI_TOOLS  # Gemini tools format
-Mode.GEMINI_JSON   # Gemini JSON format
+Mode.GENAI_STRUCTURED_OUTPUTS  # Preferred for Google GenAI JSON-style responses
+Mode.GENAI_TOOLS               # Google function calling format
+Mode.TOOLS                     # OpenAI function calling format
+Mode.JSON                      # Plain JSON generation
+Mode.MD_JSON                   # Markdown JSON (used by some providers)
+Mode.ANTHROPIC_TOOLS           # Claude tools mode (default for Anthropic)
+Mode.GEMINI_TOOLS              # Legacy Gemini tools format
+Mode.GEMINI_JSON               # Legacy Gemini JSON format
 ```
 
 ### When to Use Each Mode
 
-- **TOOLS/FUNCTION_CALL**: The default for OpenAI. Uses function calling for reliable structured outputs.
+- **GENAI_STRUCTURED_OUTPUTS**: Best default for Google GenAI. Returns JSON that maps straight to your model.
+- **GENAI_TOOLS**: Use when you need Google function calling or tool definitions.
+- **TOOLS/FUNCTION_CALL**: Default for OpenAI. Uses function calling for reliable structured outputs.
 - **JSON**: Works with most providers. The model generates JSON directly.
 - **MD_JSON**: For models that work well with Markdown-formatted JSON.
-- **ANTHROPIC_TOOLS**: The default for Anthropic. Uses Claude's tools API.
-- **GEMINI_TOOLS/GEMINI_JSON**: For Google's Gemini models.
+- **ANTHROPIC_TOOLS**: Default for Anthropic. Uses Claude's tools API.
+- **GEMINI_TOOLS/GEMINI_JSON**: Legacy Gemini modes. Prefer the GenAI modes for new builds.
 
 Choose the mode that works best with your selected provider and model.
 
@@ -103,22 +119,28 @@ For asynchronous operation, use the async versions of the clients:
 ```python
 import asyncio
 import instructor
-from openai import AsyncOpenAI
+from instructor import Mode
 from pydantic import BaseModel
+
 
 class User(BaseModel):
     name: str
     age: int
 
+
 async def extract_user():
-    async_client = instructor.from_provider("openai/gpt-5-nano", async_client=True)
+    async_client = instructor.from_provider(
+        "google/gemini-2.5-flash",
+        async_client=True,
+        mode=Mode.GENAI_STRUCTURED_OUTPUTS,
+    )
     return await async_client.chat.completions.create(
-        model="gpt-3.5-turbo",
         response_model=User,
         messages=[
             {"role": "user", "content": "John is 30 years old."}
-        ]
+        ],
     )
+
 
 user = asyncio.run(extract_user())
 ```
@@ -136,14 +158,11 @@ from openai import OpenAI
 client = instructor.from_openai(
     OpenAI(),
     mode=instructor.Mode.TOOLS,
-    max_retries=2,  # Number of retries for validation failures
+    max_retries=2,
 )
 
 # With API key explicitly defined
 client = instructor.from_provider("openai/gpt-5-nano", mode=instructor.Mode.JSON)
-
-# With organization ID
-client = instructor.from_provider("openai/gpt-5-nano")
 ```
 
 ## Using with Other Providers via OpenAI-Compatible Interface

--- a/docs/learning/getting_started/installation.md
+++ b/docs/learning/getting_started/installation.md
@@ -4,44 +4,38 @@ Learn how to install Instructor, the leading Python library for extracting struc
 
 ## Quick Start: Install Instructor for LLM Development
 
-Get started with structured LLM outputs in seconds. Install Instructor using pip:
+Get started with structured LLM outputs in seconds. Install Instructor with Google GenAI support using `uv`:
 
 ```shell
-pip install instructor
+uv add "instructor[google-genai]"
 ```
 
-Instructor leverages Pydantic for type-safe LLM data extraction:
-
-```shell
-pip install pydantic
-```
-
-> **Pro Tip**: Use `uv` for faster installation: `uv pip install instructor`
+This installs Instructor together with the Google GenAI SDK, which we recommend as the default path for new projects.
 
 ## LLM Provider Installation Guide
 
 Instructor supports 15+ LLM providers. Here's how to install and configure each:
 
-### OpenAI (GPT-4, GPT-3.5)
+### Google GenAI (Gemini Models)
 
-OpenAI is the default LLM provider for Instructor. Perfect for GPT-4 and GPT-3.5-turbo structured outputs:
+Google's Gemini models provide fast multimodal function calling and structured outputs. This is our recommended starting point:
 
 ```shell
-pip install instructor
+uv add "instructor[google-genai]"
 ```
 
-Configure your OpenAI API key for LLM access:
+Configure your Google API key:
 
 ```shell
-export OPENAI_API_KEY=your_openai_key
+export GOOGLE_API_KEY=your_google_key
 ```
 
 ### Anthropic Claude LLM Setup
 
-Extract structured data from Claude 3 models (Opus, Sonnet, Haiku) with native tool support:
+Install the Anthropic extra only when you need Claude models:
 
 ```shell
-pip install "instructor[anthropic]"
+uv add "instructor[anthropic]"
 ```
 
 Configure Claude API access:
@@ -50,26 +44,12 @@ Configure Claude API access:
 export ANTHROPIC_API_KEY=your_anthropic_key
 ```
 
-### Google Gemini LLM Integration
-
-Use Gemini Pro and Flash models for structured outputs with function calling:
-
-```shell
-pip install "instructor[google-genai]"
-```
-
-Set up Gemini API access:
-
-```shell
-export GOOGLE_API_KEY=your_google_key
-```
-
 ### Cohere
 
 To use with Cohere's models:
 
 ```shell
-pip install "instructor[cohere]"
+uv add "instructor[cohere]"
 ```
 
 Set up your Cohere API key:
@@ -83,7 +63,7 @@ export COHERE_API_KEY=your_cohere_key
 To use with Mistral AI's models:
 
 ```shell
-pip install "instructor[mistralai]"
+uv add "instructor[mistralai]"
 ```
 
 Set up your Mistral API key:
@@ -97,7 +77,7 @@ export MISTRAL_API_KEY=your_mistral_key
 To use LiteLLM for accessing multiple providers:
 
 ```shell
-pip install "instructor[litellm]"
+uv add "instructor[litellm]"
 ```
 
 Set up API keys for the providers you want to use.
@@ -107,22 +87,35 @@ Set up API keys for the providers you want to use.
 Test your Instructor installation with this simple LLM structured output example:
 
 ```python
+import asyncio
 import instructor
+from instructor import Mode
 from pydantic import BaseModel
+
+
 class Person(BaseModel):
     name: str
     age: int
 
-client = instructor.from_provider("openai/gpt-5-nano")
-person = client.chat.completions.create(
-    model="gpt-3.5-turbo",
-    response_model=Person,
-    messages=[
-        {"role": "user", "content": "John Doe is 30 years old"}
-    ]
-)
 
-print(f"Name: {person.name}, Age: {person.age}")
+async def verify_install() -> None:
+    client = instructor.from_provider(
+        "google/gemini-2.5-flash",
+        async_client=True,
+        mode=Mode.GENAI_STRUCTURED_OUTPUTS,
+    )
+
+    person = await client.chat.completions.create(
+        response_model=Person,
+        messages=[
+            {"role": "user", "content": "John Doe is 30 years old"}
+        ],
+    )
+
+    print(f"Name: {person.name}, Age: {person.age}")
+
+
+asyncio.run(verify_install())
 ```
 
 ## Next Steps in Your LLM Tutorial Journey
@@ -135,8 +128,8 @@ With Instructor installed, you're ready to build powerful LLM applications:
 
 ## Common Installation Issues
 
-- **Import Errors**: Ensure you've installed the provider-specific extras (e.g., `instructor[anthropic]`)
+- **Import Errors**: Ensure you've added the provider-specific extras (e.g., `uv add "instructor[anthropic]"`)
 - **API Key Issues**: Verify your environment variables are set correctly
-- **Version Conflicts**: Use `pip install --upgrade instructor` to get the latest version
+- **Version Conflicts**: Use `uv pip install --upgrade "instructor[google-genai]"` to get the latest version
 
 Ready to extract structured data from LLMs? Continue to [Your First Extraction](first_extraction.md) →


### PR DESCRIPTION
docs(genai): Prioritize Google GenAI as recommended provider

## Describe your changes

This PR updates the documentation to establish Google GenAI as the preferred, async-first way to get started with Instructor.

Changes include:
- Reworked the top-level README to highlight Google GenAI as the async-first quick start, added the recommended-install callout, and updated the basic extraction demo to match the new guidance.
- Updated the primary docs landing page so every quick-start block installs `instructor[google-genai]` with `uv` and runs an async Google example, while keeping other providers as optional swaps.
- Refreshed the getting-started guides (installation, first extraction, client setup) to default to Google GenAI, reorganize extras as add-ons, and showcase async patterns throughout.

## Issue ticket number and link

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
- [ ] If it is a core feature, I have added thorough tests.
- [ ] If it is a core feature, I have added documentation.

---
[Slack Thread](https://567-studio.slack.com/archives/C08U5CAP8KV/p1762448102454489?thread_ts=1762448102.454489&cid=C08U5CAP8KV)

<a href="https://cursor.com/background-agent?bcId=bc-cc12df4d-388b-47b8-b1a2-a0248c64003a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-cc12df4d-388b-47b8-b1a2-a0248c64003a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

