### PR TITLE
Fix the issue

### DIFF
--- a/docs/integrations/databricks.md
+++ b/docs/integrations/databricks.md
@@ -12,27 +12,27 @@ description: Guide to using instructor with Databricks models
 First, install the required packages:
 
 ```bash
-pip install instructor
+uv pip install instructor openai
 ```
 
-You'll need a Databricks API key and workspace URL which you can set as environment variables:
+Set your Databricks workspace URL and token as environment variables:
 
 ```bash
-export DATABRICKS_API_KEY=your_api_key_here
-export DATABRICKS_HOST=your_workspace_url
+export DATABRICKS_TOKEN="your_personal_access_token"
+export DATABRICKS_HOST="https://your-workspace.cloud.databricks.com"
 ```
+
+`DATABRICKS_API_KEY` and `DATABRICKS_WORKSPACE_URL` are also supported if you prefer those names. The provider appends `/serving-endpoints` automatically, so the host only needs the base workspace URL.
 
 ## Basic Example
 
 Here's how to extract structured data from Databricks models:
 
 ```python
-import os
 import instructor
-from openai import OpenAI
 from pydantic import BaseModel
 
-# Initialize the client with Databricks base URL
+# Initialize the client; host and token are read from the environment
 client = instructor.from_provider(
     "databricks/dbrx-instruct",
     mode=instructor.Mode.TOOLS,
@@ -54,6 +54,8 @@ user = client.chat.completions.create(
 print(user)
 # Output: UserExtract(name='Jason', age=25)
 ```
+
+If you need to point at a different workspace or testing endpoint, pass `base_url="https://alt-workspace.cloud.databricks.com/serving-endpoints"`. The helper will use that value as-is without adding another suffix.
 
 ### Async Example
 


### PR DESCRIPTION
feat: add Databricks provider support

## Describe your changes

This PR introduces full support for Databricks as a provider in `instructor.from_provider`. It enables seamless integration with Databricks models by:
- Implementing automatic resolution of API keys and host URLs from environment variables (`DATABRICKS_TOKEN`, `DATABRICKS_HOST`, etc.) or direct arguments.
- Normalizing Databricks base URLs to correctly point to `/serving-endpoints`.
- Delegating to `openai.OpenAI` or `openai.AsyncOpenAI` for client functionality.
- Adding dedicated unit tests to ensure correct configuration and functionality.
- Updating the Databricks integration documentation with clear setup instructions and usage examples.

This allows users to initialize Databricks clients using `instructor.from_provider("databricks/...")` with minimal configuration.

## Issue ticket number and link

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
- [ ] If it is a core feature, I have added thorough tests.
- [ ] If it is a core feature, I have added documentation.

---
[Slack Thread](https://567-studio.slack.com/archives/C08U5CAP8KV/p1762892632656749?thread_ts=1762892632.656749&cid=C08U5CAP8KV)

<a href="https://cursor.com/background-agent?bcId=bc-b04d40b2-8179-493d-bbd1-6d637fa703f0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-b04d40b2-8179-493d-bbd1-6d637fa703f0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>


<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds Databricks provider support to `instructor.from_provider`, including environment-based configuration, URL normalization, and OpenAI client delegation.
> 
>   - **Behavior**:
>     - Adds Databricks support to `instructor.from_provider` in `auto_client.py`, resolving API keys and host URLs from environment variables or arguments.
>     - Normalizes Databricks base URLs to `/serving-endpoints`.
>     - Delegates client functionality to `openai.OpenAI` or `openai.AsyncOpenAI`.
>     - Allows initialization of Databricks clients with `instructor.from_provider("databricks/...")`.
>   - **Documentation**:
>     - Updates `databricks.md` with setup instructions and usage examples.
>   - **Testing**:
>     - Adds unit tests in `test_auto_client.py` for environment configuration, custom base URL, async client, and error handling for missing token or host.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=567-labs%2Finstructor&utm_source=github&utm_medium=referral)<sup> for 80700436347445d9f7637a88d43da1421b7ffc1a. You can [customize](https://app.ellipsis.dev/567-labs/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->