### PR TITLE
feat(v2): implement core infrastructure (registry, handlers, patching)

### DIFF
--- a/instructor/core/__init__.py
+++ b/instructor/core/__init__.py
@@ -11,7 +11,6 @@ from .exceptions import (
     ModeError,
     ClientError,
     AsyncValidationError,
-    FailedAttempt,
     ResponseParsingError,
     MultimodalError,
 )
@@ -32,7 +31,6 @@ __all__ = [
     "ModeError",
     "ClientError",
     "AsyncValidationError",
-    "FailedAttempt",
     "ResponseParsingError",
     "MultimodalError",
     "Hooks",

--- a/instructor/providers/anthropic/client.py
+++ b/instructor/providers/anthropic/client.py
@@ -45,6 +45,12 @@ def from_anthropic(
 ) -> instructor.Instructor | instructor.AsyncInstructor:
     """Create an Instructor instance from an Anthropic client.
 
+    .. deprecated::
+        from_anthropic() is deprecated and will be removed in v2.0.
+        Use instructor.v2.from_anthropic() with Mode instead, or use
+        instructor.from_provider("anthropic/model-name") which automatically
+        routes to the v2 implementation.
+
     Args:
         client: An instance of Anthropic client (sync or async)
         mode: The mode to use for the client (ANTHROPIC_JSON or ANTHROPIC_TOOLS)
@@ -58,6 +64,19 @@ def from_anthropic(
         ModeError: If mode is not one of the valid Anthropic modes
         ClientError: If client is not a valid Anthropic client instance
     """
+    import warnings
+
+    warnings.warn(
+        "from_anthropic() is deprecated and will be removed in v2.0. "
+        "Use instructor.v2.from_anthropic() with Mode instead:\n"
+        "  from instructor.v2 import from_anthropic\n"
+        "  from instructor import Mode\n"
+        "  client = from_anthropic(anthropic_client, Mode.ANTHROPIC_TOOLS)\n"
+        "Or use from_provider() which automatically routes to v2:\n"
+        "  client = instructor.from_provider('anthropic/claude-3-sonnet')",
+        DeprecationWarning,
+        stacklevel=2,
+    )
     valid_modes = {
         instructor.Mode.ANTHROPIC_JSON,
         instructor.Mode.ANTHROPIC_TOOLS,

--- a/instructor/v2/__init__.py
+++ b/instructor/v2/__init__.py
@@ -1,0 +1,46 @@
+"""Instructor v2 - Mode registry system.
+
+v2 uses a registry system that maps Mode enum values directly to handlers.
+This replaces the hardcoded dictionaries in v1 with a dynamic, extensible system.
+
+Usage:
+    from instructor import Mode
+    from instructor.v2 import from_anthropic
+
+    client = from_anthropic(anthropic_client, mode=Mode.ANTHROPIC_TOOLS)
+
+Benefits:
+- Dynamic registration: Modes register themselves via decorators
+- Lazy loading: Handlers loaded only when used
+- Extensible: Easy to add new modes without modifying core
+- Type-safe: Protocols ensure handler compatibility
+"""
+
+from instructor import Mode, Provider
+from instructor.v2.core.handler import ModeHandler
+from instructor.v2.core.protocols import ReaskHandler, RequestHandler, ResponseParser
+from instructor.v2.core.registry import ModeHandlers, ModeRegistry, mode_registry
+
+# Import providers (will auto-register modes)
+try:
+    from instructor.v2.providers.anthropic import from_anthropic
+except ImportError:
+    from_anthropic = None  # type: ignore
+
+__all__ = [
+    # Core types
+    "Provider",
+    "Mode",
+    # Registry
+    "mode_registry",
+    "ModeRegistry",
+    "ModeHandlers",
+    # Handler base class
+    "ModeHandler",
+    # Protocols
+    "RequestHandler",
+    "ReaskHandler",
+    "ResponseParser",
+    # Providers
+    "from_anthropic",
+]

--- a/instructor/v2/core/__init__.py
+++ b/instructor/v2/core/__init__.py
@@ -1,0 +1,16 @@
+"""Core v2 infrastructure - registry, protocols, and mode types."""
+
+from instructor import Mode, Provider
+from instructor.v2.core.protocols import ReaskHandler, RequestHandler, ResponseParser
+from instructor.v2.core.registry import ModeHandlers, ModeRegistry, mode_registry
+
+__all__ = [
+    "Provider",
+    "Mode",
+    "mode_registry",
+    "ModeRegistry",
+    "ModeHandlers",
+    "RequestHandler",
+    "ReaskHandler",
+    "ResponseParser",
+]

--- a/instructor/v2/core/decorators.py
+++ b/instructor/v2/core/decorators.py
@@ -1,0 +1,52 @@
+"""Decorator utilities for v2 mode registration."""
+
+from instructor import Mode, Provider
+from instructor.v2.core.registry import mode_registry
+
+
+def register_mode_handler(
+    provider: Provider,
+    mode: Mode,
+):
+    """Decorator to register a mode handler class.
+
+    The decorated class must implement RequestHandler, ReaskHandler,
+    and ResponseParser protocols via prepare_request, handle_reask,
+    and parse_response methods.
+
+    Args:
+        provider: Provider enum value (for tracking)
+        mode: Mode enum value
+
+    Returns:
+        Decorator function
+
+    Example:
+        >>> from instructor import Mode
+        >>> @register_mode_handler(Provider.ANTHROPIC, Mode.ANTHROPIC_TOOLS)
+        ... class AnthropicToolsHandler:
+        ...     def prepare_request(self, response_model, kwargs):
+        ...         return response_model, kwargs
+        ...     def handle_reask(self, kwargs, response, exception):
+        ...         return kwargs
+        ...     def parse_response(self, response, response_model, **kwargs):
+        ...         return response_model.model_validate(response)
+    """
+
+    def decorator(handler_class: type) -> type:
+        """Register the handler class."""
+        # Instantiate the handler
+        handler = handler_class()
+
+        # Register with the registry
+        mode_registry.register(
+            mode=mode,
+            provider=provider,
+            request_handler=handler.prepare_request,
+            reask_handler=handler.handle_reask,
+            response_parser=handler.parse_response,
+        )
+
+        return handler_class
+
+    return decorator

--- a/instructor/v2/core/handler.py
+++ b/instructor/v2/core/handler.py
@@ -1,0 +1,94 @@
+"""Base handler class for v2 mode handlers.
+
+Provides the common interface and default implementations for mode handlers.
+"""
+
+from abc import ABC, abstractmethod
+from typing import Any
+
+from pydantic import BaseModel
+
+
+class ModeHandler(ABC):
+    """Base class for mode handlers.
+
+    Subclasses must implement prepare_request, handle_reask, and parse_response.
+    These methods define how requests are prepared, errors are handled, and
+    responses are parsed for a specific mode.
+    """
+
+    @abstractmethod
+    def prepare_request(
+        self,
+        response_model: type[BaseModel] | None,
+        kwargs: dict[str, Any],
+    ) -> tuple[type[BaseModel] | None, dict[str, Any]]:
+        """Prepare request kwargs for this mode.
+
+        Args:
+            response_model: Pydantic model to extract (or None for unstructured)
+            kwargs: Original request kwargs from user
+
+        Returns:
+            Tuple of (possibly modified response_model, modified kwargs)
+
+        Example:
+            For TOOLS mode, this adds "tools" and "tool_choice" to kwargs.
+            For JSON mode, this adds JSON schema to system message.
+        """
+        ...
+
+    @abstractmethod
+    def handle_reask(
+        self,
+        kwargs: dict[str, Any],
+        response: Any,
+        exception: Exception,
+    ) -> dict[str, Any]:
+        """Handle validation failure and prepare retry request.
+
+        Args:
+            kwargs: Original request kwargs
+            response: Failed API response
+            exception: Validation exception that occurred
+
+        Returns:
+            Modified kwargs for retry attempt
+
+        Example:
+            For TOOLS mode, appends tool_result with error message.
+            For JSON mode, appends user message with validation error.
+        """
+        ...
+
+    @abstractmethod
+    def parse_response(
+        self,
+        response: Any,
+        response_model: type[BaseModel],
+        validation_context: dict[str, Any] | None = None,
+        strict: bool | None = None,
+    ) -> BaseModel:
+        """Parse API response into validated Pydantic model.
+
+        Args:
+            response: Raw API response
+            response_model: Pydantic model to validate against
+            validation_context: Optional context for Pydantic validation
+            strict: Optional strict validation mode
+
+        Returns:
+            Validated Pydantic model instance
+
+        Raises:
+            ValidationError: If response doesn't match model schema
+
+        Example:
+            For TOOLS mode, extracts tool_use blocks and validates.
+            For JSON mode, extracts JSON from text blocks and validates.
+        """
+        ...
+
+    def __repr__(self) -> str:
+        """String representation of handler."""
+        return f"<{self.__class__.__name__}>"

--- a/instructor/v2/core/patch.py
+++ b/instructor/v2/core/patch.py
@@ -1,0 +1,219 @@
+"""v2 patch mechanism using hierarchical registry.
+
+Simplified patching logic that uses the v2 mode registry for handler dispatch.
+"""
+
+from __future__ import annotations
+
+import logging
+from functools import wraps
+from typing import TYPE_CHECKING, Any, TypeVar
+
+from pydantic import BaseModel
+
+from instructor import Mode, Provider
+from instructor.core.hooks import Hooks
+from instructor.templating import handle_templating
+from instructor.utils import is_async
+from instructor.v2.core.registry import mode_registry
+from instructor.v2.core.retry import retry_async_v2, retry_sync_v2
+
+if TYPE_CHECKING:
+    from collections.abc import Awaitable, Callable
+
+    from tenacity import AsyncRetrying, Retrying
+
+logger = logging.getLogger("instructor.v2")
+
+T_Model = TypeVar("T_Model", bound=BaseModel)
+
+
+def handle_context(
+    context: dict[str, Any] | None = None,
+    validation_context: dict[str, Any] | None = None,
+) -> dict[str, Any] | None:
+    """Handle context and validation_context parameters.
+
+    Args:
+        context: New-style context parameter
+        validation_context: Deprecated validation_context parameter
+
+    Returns:
+        Merged context dict or None
+
+    Raises:
+        ValueError: If both parameters are provided
+    """
+    if context is not None and validation_context is not None:
+        from ..core.exceptions import ConfigurationError
+
+        raise ConfigurationError(
+            "Cannot provide both 'context' and 'validation_context'. "
+            "Use 'context' instead."
+        )
+    if validation_context is not None and context is None:
+        import warnings
+
+        warnings.warn(
+            "'validation_context' is deprecated. Use 'context' instead.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        context = validation_context
+    return context
+
+
+def patch_v2(
+    func: Callable[..., Any],
+    provider: Provider,
+    mode: Mode,
+    default_model: str | None = None,
+) -> Callable[..., T_Model]:
+    """Patch a function to use v2 registry for structured outputs.
+
+    Args:
+        func: Function to patch (e.g., client.messages.create)
+        provider: Provider enum value
+        mode: Mode enum value
+        default_model: Default model to inject if not provided in request
+
+    Returns:
+        Patched function that supports response_model parameter
+    """
+    logger.debug(f"Patching with v2 registry: {provider=}, {mode=}, {default_model=}")
+
+    # Check if handlers are registered
+    if not mode_registry.is_registered(provider, mode):
+        from ..core.exceptions import ConfigurationError
+
+        raise ConfigurationError(
+            f"Mode {mode} is not registered for provider {provider}. "
+            f"Available modes: {mode_registry.list_modes()}"
+        )
+
+    func_is_async = is_async(func)
+
+    if func_is_async:
+        return _create_async_wrapper(func, provider, mode, default_model)
+    else:
+        return _create_sync_wrapper(func, provider, mode, default_model)
+
+
+def _create_sync_wrapper(
+    func: Callable[..., Any],
+    provider: Provider,
+    mode: Mode,
+    default_model: str | None = None,
+) -> Callable[..., T_Model]:
+    """Create synchronous wrapper for patched function."""
+
+    @wraps(func)
+    def new_create_sync(
+        response_model: type[T_Model] | None = None,
+        validation_context: dict[str, Any] | None = None,
+        context: dict[str, Any] | None = None,
+        max_retries: int | Retrying = 1,
+        strict: bool = True,
+        hooks: Hooks | None = None,
+        *args: Any,
+        **kwargs: Any,
+    ) -> T_Model:
+        """Patched synchronous create function."""
+        context = handle_context(context, validation_context)
+
+        # Inject default model if not provided and available
+        if default_model is not None and "model" not in kwargs:
+            kwargs["model"] = default_model
+
+        # Get handlers from registry
+        handlers = mode_registry.get_handlers(provider, mode)
+
+        # Prepare request kwargs using registry handler
+        response_model, new_kwargs = handlers.request_handler(
+            response_model=response_model, kwargs=kwargs
+        )
+
+        # Handle templating
+        new_kwargs = handle_templating(
+            new_kwargs,
+            mode=mode,
+            context=context,
+        )
+
+        # Use v2 retry logic with registry handlers
+        response = retry_sync_v2(
+            func=func,
+            response_model=response_model,
+            provider=provider,
+            mode=mode,
+            context=context,
+            max_retries=max_retries,
+            args=args,
+            kwargs=new_kwargs,
+            strict=strict,
+            hooks=hooks,
+        )
+
+        return response  # type: ignore[return-value]
+
+    return new_create_sync  # type: ignore[return-value]
+
+
+def _create_async_wrapper(
+    func: Callable[..., Awaitable[Any]],
+    provider: Provider,
+    mode: Mode,
+    default_model: str | None = None,
+) -> Callable[..., Awaitable[T_Model]]:
+    """Create asynchronous wrapper for patched function."""
+
+    @wraps(func)
+    async def new_create_async(
+        response_model: type[T_Model] | None = None,
+        validation_context: dict[str, Any] | None = None,
+        context: dict[str, Any] | None = None,
+        max_retries: int | AsyncRetrying = 1,
+        strict: bool = True,
+        hooks: Hooks | None = None,
+        *args: Any,
+        **kwargs: Any,
+    ) -> T_Model:
+        """Patched asynchronous create function."""
+        context = handle_context(context, validation_context)
+
+        # Inject default model if not provided and available
+        if default_model is not None and "model" not in kwargs:
+            kwargs["model"] = default_model
+
+        # Get handlers from registry
+        handlers = mode_registry.get_handlers(provider, mode)
+
+        # Prepare request kwargs using registry handler
+        response_model, new_kwargs = handlers.request_handler(
+            response_model=response_model, kwargs=kwargs
+        )
+
+        # Handle templating
+        new_kwargs = handle_templating(
+            new_kwargs,
+            mode=mode,
+            context=context,
+        )
+
+        # Use v2 retry logic with registry handlers
+        response = await retry_async_v2(
+            func=func,
+            response_model=response_model,
+            provider=provider,
+            mode=mode,
+            context=context,
+            max_retries=max_retries,
+            args=args,
+            kwargs=new_kwargs,
+            strict=strict,
+            hooks=hooks,
+        )
+
+        return response  # type: ignore[return-value]
+
+    return new_create_async  # type: ignore[return-value]

--- a/instructor/v2/core/protocols.py
+++ b/instructor/v2/core/protocols.py
@@ -1,0 +1,92 @@
+"""Protocol definitions for v2 mode handlers.
+
+Defines the interfaces that all mode handlers must implement for type safety
+and consistency across providers.
+"""
+
+from typing import Any, Protocol, TypeVar
+
+from pydantic import BaseModel
+
+T = TypeVar("T", bound=BaseModel)
+
+
+class RequestHandler(Protocol):
+    """Prepares request kwargs for a specific mode.
+
+    Takes the response model and existing kwargs, returns modified kwargs
+    with mode-specific parameters (e.g., tools, response_format).
+    """
+
+    def __call__(
+        self,
+        response_model: type[T] | None,
+        kwargs: dict[str, Any],
+    ) -> tuple[type[T] | None, dict[str, Any]]:
+        """Prepare request kwargs for this mode.
+
+        Args:
+            response_model: The Pydantic model to extract
+            kwargs: Original request kwargs
+
+        Returns:
+            Tuple of (possibly modified response_model, modified kwargs)
+        """
+        ...
+
+
+class ReaskHandler(Protocol):
+    """Handles validation failures and prepares retry requests.
+
+    Takes the original kwargs, failed response, and exception, returns
+    modified kwargs for the retry attempt.
+    """
+
+    def __call__(
+        self,
+        kwargs: dict[str, Any],
+        response: Any,
+        exception: Exception,
+    ) -> dict[str, Any]:
+        """Handle validation failure and prepare retry.
+
+        Args:
+            kwargs: Original request kwargs
+            response: Failed API response
+            exception: Validation exception that occurred
+
+        Returns:
+            Modified kwargs for retry request
+        """
+        ...
+
+
+class ResponseParser(Protocol):
+    """Parses API response into validated Pydantic model.
+
+    Extracts the structured data from the API response and validates
+    it against the response model.
+    """
+
+    def __call__(
+        self,
+        response: Any,
+        response_model: type[T],
+        validation_context: dict[str, Any] | None = None,
+        strict: bool | None = None,
+    ) -> T:
+        """Parse and validate response into model.
+
+        Args:
+            response: Raw API response
+            response_model: Pydantic model to validate against
+            validation_context: Optional context for validation
+            strict: Optional strict validation mode
+
+        Returns:
+            Validated Pydantic model instance
+
+        Raises:
+            ValidationError: If response doesn't match model
+        """
+        ...

--- a/instructor/v2/core/registry.py
+++ b/instructor/v2/core/registry.py
@@ -1,0 +1,262 @@
+"""Mode handler registry for v2.
+
+Central registry mapping Mode enum values to their handler implementations.
+Supports lazy loading, dynamic registration, and queryable API.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Callable
+from instructor import Mode, Provider
+
+from instructor.v2.core.protocols import ReaskHandler, RequestHandler, ResponseParser
+
+
+@dataclass
+class ModeHandlers:
+    """Collection of handlers for a specific mode."""
+
+    request_handler: RequestHandler
+    reask_handler: ReaskHandler
+    response_parser: ResponseParser
+
+
+class ModeRegistry:
+    """Central registry for mode handlers.
+
+    Maps (Provider, Mode) tuples to their handler implementations.
+    Supports lazy loading and dynamic registration.
+
+    Example:
+        >>> registry.register(
+        ...     provider=Provider.ANTHROPIC,
+        ...     mode=Mode.TOOLS,
+        ...     request_handler=handle_request,
+        ...     reask_handler=handle_reask,
+        ...     response_parser=parse_response,
+        ... )
+        >>> # Preferred: get all handlers at once
+        >>> handlers = registry.get_handlers(Provider.ANTHROPIC, Mode.TOOLS)
+        >>> handlers.request_handler(...)
+        >>> handlers.reask_handler(...)
+        >>> handlers.response_parser(...)
+    """
+
+    def __init__(self) -> None:
+        """Initialize empty registry."""
+        self._handlers: dict[Mode, ModeHandlers] = {}
+        self._lazy_loaders: dict[Mode, Callable[[], ModeHandlers]] = {}
+
+    def register(
+        self,
+        provider: Provider,
+        mode: Mode,
+        request_handler: RequestHandler,
+        reask_handler: ReaskHandler,
+        response_parser: ResponseParser,
+    ) -> None:
+        """Register handlers for a mode.
+
+        Args:
+            provider: Provider enum value
+            mode: Mode enum value
+            request_handler: Handler to prepare request kwargs
+            reask_handler: Handler to handle validation failures
+            response_parser: Handler to parse responses
+
+        Raises:
+            ConfigurationError: If mode is already registered
+        """
+        from ..core.exceptions import ConfigurationError
+
+        mode = (provider, mode)
+        if mode in self._handlers:
+            raise ConfigurationError(f"Mode {mode} is already registered")
+
+        self._handlers[mode] = ModeHandlers(
+            request_handler=request_handler,
+            reask_handler=reask_handler,
+            response_parser=response_parser,
+        )
+
+    def register_lazy(
+        self,
+        provider: Provider,
+        mode: Mode,
+        loader: Callable[[], ModeHandlers],
+    ) -> None:
+        """Register a lazy loader for a mode.
+
+        The loader will be called on first access to load handlers.
+
+        Args:
+            provider: Provider enum value
+            mode: Mode enum value
+            loader: Callable that returns ModeHandlers when invoked
+
+        Raises:
+            ConfigurationError: If mode is already registered
+        """
+        from ..core.exceptions import ConfigurationError
+
+        mode = (provider, mode)
+        if mode in self._handlers or mode in self._lazy_loaders:
+            raise ConfigurationError(f"Mode {mode} is already registered")
+
+        self._lazy_loaders[mode] = loader
+
+    def get_handlers(self, provider: Provider, mode: Mode) -> ModeHandlers:
+        """Get all handlers for a mode.
+
+        This is the preferred method for retrieving handlers. It performs
+        a single registry lookup and returns all handlers at once, which is
+        more efficient than calling get_handler() multiple times.
+
+        Args:
+            provider: Provider enum value
+            mode: Mode enum value
+
+        Returns:
+            ModeHandlers with all handler functions (request_handler,
+            reask_handler, response_parser)
+
+        Raises:
+            KeyError: If mode is not registered
+
+        Example:
+            >>> handlers = registry.get_handlers(Provider.ANTHROPIC, Mode.TOOLS)
+            >>> handlers.request_handler(...)
+            >>> handlers.reask_handler(...)
+            >>> handlers.response_parser(...)
+        """
+        mode = (provider, mode)
+
+        # Check if already loaded
+        if mode in self._handlers:
+            return self._handlers[mode]
+
+        # Try lazy loading
+        if mode in self._lazy_loaders:
+            loader = self._lazy_loaders.pop(mode)
+            handlers = loader()
+            self._handlers[mode] = handlers
+            return handlers
+
+        from ..core.exceptions import ConfigurationError
+
+        raise ConfigurationError(
+            f"Mode {mode} is not registered. "
+            f"Available modes: {list(self._handlers.keys())}"
+        )
+
+    def get_handler(
+        self,
+        provider: Provider,
+        mode: Mode,
+        handler_type: str,
+    ) -> RequestHandler | ReaskHandler | ResponseParser:
+        """Get a specific handler for a mode.
+
+        This is a convenience method that internally calls get_handlers().
+        For better performance when you need multiple handlers, use
+        get_handlers() instead and access handlers via the returned object.
+
+        Args:
+            provider: Provider enum value
+            mode: Mode enum value
+            handler_type: One of 'request', 'reask', 'response'
+
+        Returns:
+            The requested handler function
+
+        Raises:
+            KeyError: If mode is not registered
+            ValueError: If handler_type is invalid
+
+        Example:
+            >>> # Prefer this when you need multiple handlers:
+            >>> handlers = registry.get_handlers(Provider.ANTHROPIC, Mode.TOOLS)
+            >>> handlers.request_handler(...)
+            >>> handlers.reask_handler(...)
+
+            >>> # Or use this convenience method for a single handler:
+            >>> handler = registry.get_handler(Provider.ANTHROPIC, Mode.TOOLS, "request")
+        """
+        handlers = self.get_handlers(provider, mode)
+
+        if handler_type == "request":
+            return handlers.request_handler
+        elif handler_type == "reask":
+            return handlers.reask_handler
+        elif handler_type == "response":
+            return handlers.response_parser
+        else:
+            from ..core.exceptions import ConfigurationError
+
+            raise ConfigurationError(
+                f"Invalid handler_type: {handler_type}. "
+                f"Must be 'request', 'reask', or 'response'"
+            )
+
+    def is_registered(self, provider: Provider, mode: Mode) -> bool:
+        """Check if a mode is registered.
+
+        Args:
+            provider: Provider enum value
+            mode: Mode enum value
+
+        Returns:
+            True if mode is registered (eagerly or lazily)
+        """
+        mode = (provider, mode)
+        return mode in self._handlers or mode in self._lazy_loaders
+
+    def get_modes_for_provider(self, provider: Provider) -> list[Mode]:
+        """Get all registered modes for a provider.
+
+        Args:
+            provider: Provider enum value
+
+        Returns:
+            List of Mode values supported by this provider
+        """
+        modes = []
+        for p, mt in self._handlers.keys():
+            if p == provider:
+                modes.append(mt)
+        for p, mt in self._lazy_loaders.keys():
+            if p == provider:
+                modes.append(mt)
+        return sorted(set(modes), key=lambda m: m.value)
+
+    def get_providers_for_mode(self, mode: Mode) -> list[Provider]:
+        """Get all providers that support a mode.
+
+        Args:
+            mode: Mode enum value
+
+        Returns:
+            List of Provider values that support this mode
+        """
+        providers = []
+        for p, mt in self._handlers.keys():
+            if mt == mode:
+                providers.append(p)
+        for p, mt in self._lazy_loaders.keys():
+            if mt == mode:
+                providers.append(p)
+        return sorted(set(providers), key=lambda p: p.value)
+
+    def list_modes(self) -> list[Mode]:
+        """List all registered modes.
+
+        Returns:
+            List of (Provider, Mode) tuples
+        """
+        all_modes = set(self._handlers.keys()) | set(self._lazy_loaders.keys())
+        return sorted(all_modes, key=lambda m: (m[0].value, m[1].value))
+
+
+# Global registry instance
+mode_registry = ModeRegistry()

--- a/instructor/v2/core/retry.py
+++ b/instructor/v2/core/retry.py
@@ -1,0 +1,286 @@
+"""v2 retry mechanism using registry handlers.
+
+Custom retry logic for v2 that uses registry's reask and response_parser
+instead of v1's process_response.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING, Any, TypeVar
+
+from pydantic import BaseModel, ValidationError
+from tenacity import (
+    AsyncRetrying,
+    Retrying,
+    retry_if_exception_type,
+    stop_after_attempt,
+)
+
+from instructor import Mode, Provider
+from instructor.core.exceptions import FailedAttempt, InstructorRetryException
+from instructor.core.retry import extract_messages
+from instructor.v2.core.registry import mode_registry
+
+if TYPE_CHECKING:
+    from collections.abc import Awaitable, Callable
+
+    from instructor.core.hooks import Hooks
+
+logger = logging.getLogger("instructor.v2.retry")
+
+T_Model = TypeVar("T_Model", bound=BaseModel)
+
+
+def retry_sync_v2(
+    func: Callable[..., Any],
+    response_model: type[T_Model] | None,
+    provider: Provider,
+    mode: Mode,
+    context: dict[str, Any] | None,
+    max_retries: int | Retrying,
+    args: tuple[Any, ...],
+    kwargs: dict[str, Any],
+    strict: bool,
+    hooks: Hooks | None = None,
+) -> T_Model:
+    """Sync retry logic using v2 registry handlers.
+
+    Args:
+        func: API function to call
+        response_model: Pydantic model to extract
+        provider: Provider enum
+        mode: Mode enum
+        context: Validation context
+        max_retries: Max retry attempts or Retrying instance
+        args: Positional args for func
+        kwargs: Keyword args for func
+        strict: Strict validation mode
+        hooks: Optional hooks
+
+    Returns:
+        Validated Pydantic model instance
+
+    Raises:
+        InstructorRetryException: If max retries exceeded
+    """
+    if response_model is None:
+        # No structured output, just call the API
+        return func(*args, **kwargs)
+
+    # Get handlers from registry
+    handlers = mode_registry.get_handlers(provider, mode)
+
+    # Setup retrying
+    if isinstance(max_retries, int):
+        max_retries_instance: Retrying = Retrying(
+            stop=stop_after_attempt(max_retries),
+            retry=retry_if_exception_type(ValidationError),
+            reraise=True,
+        )
+    else:
+        max_retries_instance = max_retries
+
+    failed_attempts: list[FailedAttempt] = []
+    last_exception = None
+    total_usage = 0
+
+    try:
+        for attempt in max_retries_instance:
+            with attempt:
+                # Call API
+                if hooks:
+                    hooks.emit_completion_arguments(**kwargs)
+
+                response = func(*args, **kwargs)
+
+                if hooks:
+                    hooks.emit_completion_response(response)
+
+                # Parse response using registry
+                try:
+                    parsed = handlers.response_parser(
+                        response=response,
+                        response_model=response_model,
+                        validation_context=context,
+                        strict=strict,
+                    )
+
+                    return parsed  # type: ignore
+
+                except ValidationError as e:
+                    logger.debug(f"Validation error: {e}")
+                    attempt_number = attempt.retry_state.attempt_number
+                    failed_attempts.append(
+                        FailedAttempt(
+                            attempt_number=attempt_number,
+                            exception=e,
+                            completion=response,
+                        )
+                    )
+                    last_exception = e
+
+                    if hooks:
+                        hooks.emit_parse_error(e)
+
+                    # Prepare reask using registry
+                    kwargs = handlers.reask_handler(
+                        kwargs=kwargs,
+                        response=response,
+                        exception=e,
+                    )
+
+                    # Will retry with modified kwargs
+                    raise
+
+    except Exception as e:
+        # Max retries exceeded
+        if last_exception is None:
+            last_exception = e
+        raise InstructorRetryException(
+            str(last_exception),
+            last_completion=failed_attempts[-1].completion if failed_attempts else None,
+            n_attempts=len(failed_attempts),
+            total_usage=total_usage,
+            messages=extract_messages(kwargs),
+            create_kwargs=kwargs,
+            failed_attempts=failed_attempts,
+        ) from last_exception
+
+    # Should never reach here
+    raise InstructorRetryException(
+        str(last_exception) if last_exception else "Unknown error",
+        last_completion=failed_attempts[-1].completion if failed_attempts else None,
+        n_attempts=len(failed_attempts),
+        total_usage=total_usage,
+        messages=extract_messages(kwargs),
+        create_kwargs=kwargs,
+        failed_attempts=failed_attempts,
+    )
+
+
+async def retry_async_v2(
+    func: Callable[..., Awaitable[Any]],
+    response_model: type[T_Model] | None,
+    provider: Provider,
+    mode: Mode,
+    context: dict[str, Any] | None,
+    max_retries: int | AsyncRetrying,
+    args: tuple[Any, ...],
+    kwargs: dict[str, Any],
+    strict: bool,
+    hooks: Hooks | None = None,
+) -> T_Model:
+    """Async retry logic using v2 registry handlers.
+
+    Args:
+        func: Async API function to call
+        response_model: Pydantic model to extract
+        provider: Provider enum
+        mode: Mode enum
+        context: Validation context
+        max_retries: Max retry attempts or AsyncRetrying instance
+        args: Positional args for func
+        kwargs: Keyword args for func
+        strict: Strict validation mode
+        hooks: Optional hooks
+
+    Returns:
+        Validated Pydantic model instance
+
+    Raises:
+        InstructorRetryException: If max retries exceeded
+    """
+    if response_model is None:
+        # No structured output, just call the API
+        return await func(*args, **kwargs)
+
+    # Get handlers from registry
+    handlers = mode_registry.get_handlers(provider, mode)
+
+    # Setup retrying
+    if isinstance(max_retries, int):
+        max_retries_instance: AsyncRetrying = AsyncRetrying(
+            stop=stop_after_attempt(max_retries),
+            retry=retry_if_exception_type(ValidationError),
+            reraise=True,
+        )
+    else:
+        max_retries_instance = max_retries
+
+    failed_attempts: list[FailedAttempt] = []
+    last_exception = None
+    total_usage = 0
+
+    try:
+        async for attempt in max_retries_instance:
+            with attempt:
+                # Call API
+                if hooks:
+                    hooks.emit_completion_arguments(**kwargs)
+
+                response = await func(*args, **kwargs)
+
+                if hooks:
+                    hooks.emit_completion_response(response)
+
+                # Parse response using registry
+                try:
+                    parsed = handlers.response_parser(
+                        response=response,
+                        response_model=response_model,
+                        validation_context=context,
+                        strict=strict,
+                    )
+
+                    return parsed  # type: ignore
+
+                except ValidationError as e:
+                    logger.debug(f"Validation error: {e}")
+                    attempt_number = attempt.retry_state.attempt_number
+                    failed_attempts.append(
+                        FailedAttempt(
+                            attempt_number=attempt_number,
+                            exception=e,
+                            completion=response,
+                        )
+                    )
+                    last_exception = e
+
+                    if hooks:
+                        hooks.emit_parse_error(e)
+
+                    # Prepare reask using registry
+                    kwargs = handlers.reask_handler(
+                        kwargs=kwargs,
+                        response=response,
+                        exception=e,
+                    )
+
+                    # Will retry with modified kwargs
+                    raise
+
+    except Exception as e:
+        # Max retries exceeded
+        if last_exception is None:
+            last_exception = e
+        raise InstructorRetryException(
+            str(last_exception),
+            last_completion=failed_attempts[-1].completion if failed_attempts else None,
+            n_attempts=len(failed_attempts),
+            total_usage=total_usage,
+            messages=extract_messages(kwargs),
+            create_kwargs=kwargs,
+            failed_attempts=failed_attempts,
+        ) from last_exception
+
+    # Should never reach here
+    raise InstructorRetryException(
+        str(last_exception) if last_exception else "Unknown error",
+        last_completion=failed_attempts[-1].completion if failed_attempts else None,
+        n_attempts=len(failed_attempts),
+        total_usage=total_usage,
+        messages=extract_messages(kwargs),
+        create_kwargs=kwargs,
+        failed_attempts=failed_attempts,
+    )

--- a/instructor/v2/providers/__init__.py
+++ b/instructor/v2/providers/__init__.py
@@ -1,0 +1,3 @@
+"""v2 provider implementations."""
+
+__all__ = ["anthropic"]

--- a/instructor/v2/providers/anthropic/__init__.py
+++ b/instructor/v2/providers/anthropic/__init__.py
@@ -1,0 +1,5 @@
+"""v2 Anthropic provider."""
+
+from instructor.v2.providers.anthropic.client import from_anthropic
+
+__all__ = ["from_anthropic"]

--- a/instructor/v2/providers/anthropic/client.py
+++ b/instructor/v2/providers/anthropic/client.py
@@ -1,0 +1,150 @@
+"""v2 Anthropic client factory.
+
+Creates Instructor instances using v2 hierarchical registry system.
+"""
+
+from __future__ import annotations
+
+from typing import Any, overload
+
+import anthropic
+
+from instructor import AsyncInstructor, Instructor, Mode, Provider
+from instructor.v2.core.patch import patch_v2
+
+# Ensure handlers are registered (decorators auto-register on import)
+from instructor.v2.providers.anthropic import handlers  # noqa: F401
+
+
+@overload
+def from_anthropic(
+    client: (
+        anthropic.Anthropic | anthropic.AnthropicBedrock | anthropic.AnthropicVertex
+    ),
+    mode: Mode = Mode.TOOLS,
+    beta: bool = False,
+    model: str | None = None,
+    **kwargs: Any,
+) -> Instructor: ...
+
+
+@overload
+def from_anthropic(
+    client: (
+        anthropic.AsyncAnthropic
+        | anthropic.AsyncAnthropicBedrock
+        | anthropic.AsyncAnthropicVertex
+    ),
+    mode: Mode = Mode.TOOLS,
+    beta: bool = False,
+    model: str | None = None,
+    **kwargs: Any,
+) -> AsyncInstructor: ...
+
+
+def from_anthropic(
+    client: (
+        anthropic.Anthropic
+        | anthropic.AsyncAnthropic
+        | anthropic.AnthropicBedrock
+        | anthropic.AsyncAnthropicBedrock
+        | anthropic.AsyncAnthropicVertex
+        | anthropic.AnthropicVertex
+    ),
+    mode: Mode = Mode.TOOLS,
+    beta: bool = False,
+    model: str | None = None,
+    **kwargs: Any,
+) -> Instructor | AsyncInstructor:
+    """Create an Instructor instance from an Anthropic client using v2 registry.
+
+    Args:
+        client: An instance of Anthropic client (sync or async)
+        mode: The mode to use (defaults to Mode.TOOLS)
+        beta: Whether to use beta API features (uses client.beta.messages.create)
+        model: Optional model to inject if not provided in requests
+        **kwargs: Additional keyword arguments to pass to the Instructor constructor
+
+    Returns:
+        An Instructor instance (sync or async depending on the client type)
+
+    Raises:
+        ValueError: If mode is not registered
+        TypeError: If client is not a valid Anthropic client instance
+
+    Examples:
+        >>> import anthropic
+        >>> from instructor import Mode
+        >>> from instructor.v2.providers.anthropic import from_anthropic
+        >>>
+        >>> client = anthropic.Anthropic()
+        >>> instructor_client = from_anthropic(client, mode=Mode.TOOLS)
+        >>>
+        >>> # Or use JSON mode
+        >>> instructor_client = from_anthropic(client, mode=Mode.JSON)
+    """
+    from instructor.v2.core.registry import mode_registry
+
+    # Validate mode is registered
+    if not mode_registry.is_registered(Provider.ANTHROPIC, mode):
+        from instructor.core.exceptions import ModeError
+
+        available_modes = mode_registry.get_modes_for_provider(Provider.ANTHROPIC)
+        raise ModeError(
+            mode=mode.value,
+            provider=Provider.ANTHROPIC.value,
+            valid_modes=[m.value for m in available_modes],
+        )
+
+    # Validate client type
+    valid_client_types = (
+        anthropic.Anthropic,
+        anthropic.AsyncAnthropic,
+        anthropic.AnthropicBedrock,
+        anthropic.AnthropicVertex,
+        anthropic.AsyncAnthropicBedrock,
+        anthropic.AsyncAnthropicVertex,
+    )
+
+    if not isinstance(client, valid_client_types):
+        from instructor.core.exceptions import ClientError
+
+        raise ClientError(
+            f"Client must be an instance of one of: {', '.join(t.__name__ for t in valid_client_types)}. "
+            f"Got: {type(client).__name__}"
+        )
+
+    # Get create function (beta or regular)
+    if beta:
+        create = client.beta.messages.create
+    else:
+        create = client.messages.create
+
+    # Patch using v2 registry, passing the model for injection
+    patched_create = patch_v2(
+        func=create,
+        provider=Provider.ANTHROPIC,
+        mode=mode,
+        default_model=model,
+    )
+
+    # Return sync or async instructor
+    if isinstance(
+        client,
+        (anthropic.Anthropic, anthropic.AnthropicBedrock, anthropic.AnthropicVertex),
+    ):
+        return Instructor(
+            client=client,
+            create=patched_create,
+            provider=Provider.ANTHROPIC,
+            mode=mode,
+            **kwargs,
+        )
+    else:
+        return AsyncInstructor(
+            client=client,
+            create=patched_create,
+            provider=Provider.ANTHROPIC,
+            mode=mode,
+            **kwargs,
+        )

--- a/instructor/v2/providers/anthropic/handlers.py
+++ b/instructor/v2/providers/anthropic/handlers.py
@@ -1,0 +1,521 @@
+"""v2 Anthropic mode handlers using class-based pattern.
+
+Each handler class implements prepare_request, handle_reask, and parse_response
+methods, then registers via decorator.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from textwrap import dedent
+from typing import TYPE_CHECKING, Any
+
+from pydantic import BaseModel, Field, TypeAdapter
+from typing import Annotated
+
+if TYPE_CHECKING:
+    from anthropic.types import Message
+
+from instructor import Mode, Provider
+from instructor.core.exceptions import IncompleteOutputException
+from instructor.processing.function_calls import extract_json_from_codeblock
+from instructor.processing.multimodal import Image, Audio, PDF
+from instructor.providers.anthropic.utils import (
+    combine_system_messages,
+    extract_system_messages,
+    generate_anthropic_schema,
+)
+from instructor.v2.core.decorators import register_mode_handler
+from instructor.v2.core.handler import ModeHandler
+
+
+def serialize_message_content(content: Any) -> Any:
+    """Serialize message content, converting Pydantic models to dicts.
+
+    Args:
+        content: Message content (string, list, dict, or Pydantic model)
+
+    Returns:
+        Serialized content with Pydantic models converted to dicts
+    """
+    if isinstance(content, Image):
+        # Convert Image object to Anthropic's expected format
+        source = str(content.source)
+
+        # Determine source type based on the source value
+        if source.startswith(("http://", "https://")):
+            return {
+                "type": "image",
+                "source": {
+                    "type": "url",
+                    "url": source,
+                },
+            }
+        elif source.startswith("data:"):
+            # Base64-encoded data URL
+            return {
+                "type": "image",
+                "source": {
+                    "type": "base64",
+                    "media_type": content.media_type,
+                    "data": content.data or source.split(",")[1],
+                },
+            }
+        else:
+            # File path or base64 string
+            return {
+                "type": "image",
+                "source": {
+                    "type": "base64",
+                    "media_type": content.media_type,
+                    "data": content.data or source,
+                },
+            }
+    elif isinstance(content, PDF):
+        # Convert PDF object to Anthropic's expected format
+        source = str(content.source)
+
+        if source.startswith(("http://", "https://")):
+            return {
+                "type": "document",
+                "source": {
+                    "type": "url",
+                    "url": source,
+                },
+            }
+        elif source.startswith("data:"):
+            return {
+                "type": "document",
+                "source": {
+                    "type": "base64",
+                    "media_type": "application/pdf",
+                    "data": content.data or source.split(",")[1],
+                },
+            }
+        else:
+            return {
+                "type": "document",
+                "source": {
+                    "type": "base64",
+                    "media_type": "application/pdf",
+                    "data": content.data or source,
+                },
+            }
+    elif isinstance(content, Audio):
+        # Audio handling similar to Image
+        source = str(content.source)
+
+        if source.startswith(("http://", "https://")):
+            return {
+                "type": "audio",
+                "source": {
+                    "type": "url",
+                    "url": source,
+                },
+            }
+        else:
+            return {
+                "type": "audio",
+                "source": {
+                    "type": "base64",
+                    "media_type": content.media_type,
+                    "data": content.data or source,
+                },
+            }
+    elif isinstance(content, str):
+        # Convert plain text strings to Anthropic's text content format
+        return {
+            "type": "text",
+            "text": content,
+        }
+    elif isinstance(content, list):
+        # Process list content recursively
+        return [serialize_message_content(item) for item in content]
+    elif isinstance(content, dict):
+        # Check if already in Anthropic format (has "type" key)
+        if "type" in content:
+            # Already formatted, just recurse on values
+            return {k: serialize_message_content(v) for k, v in content.items()}
+        # Plain dict, recurse on values
+        return {k: serialize_message_content(v) for k, v in content.items()}
+    elif hasattr(content, "model_dump"):
+        # Handle any other Pydantic BaseModel
+        return content.model_dump()
+    else:
+        return content
+
+
+def process_messages_for_anthropic(
+    messages: list[dict[str, Any]],
+) -> list[dict[str, Any]]:
+    """Process messages to serialize any Pydantic models in content.
+
+    Args:
+        messages: List of message dicts
+
+    Returns:
+        Processed messages with serialized content
+    """
+    processed = []
+    for message in messages:
+        msg_copy = message.copy()
+        if "content" in msg_copy:
+            content = msg_copy["content"]
+            # Only deeply process list content - convert strings/objects to proper format
+            # If content is a string, leave it as-is (Anthropic accepts plain strings)
+            # If content is a list, process each item
+            if isinstance(content, list):
+                msg_copy["content"] = serialize_message_content(content)
+            elif isinstance(content, (Image, Audio, PDF)) or hasattr(
+                content, "model_dump"
+            ):
+                # Serialize Pydantic models to dict
+                msg_copy["content"] = serialize_message_content(content)
+            # Leave strings as-is, and dicts with "type" key as-is
+        processed.append(msg_copy)
+    return processed
+
+
+@register_mode_handler(Provider.ANTHROPIC, Mode.TOOLS)
+class AnthropicToolsHandler(ModeHandler):
+    """Handler for Anthropic TOOLS mode.
+
+    Generates tool schemas, forces tool use, and parses tool_use blocks.
+    """
+
+    def prepare_request(
+        self,
+        response_model: type[BaseModel] | None,
+        kwargs: dict[str, Any],
+    ) -> tuple[type[BaseModel] | None, dict[str, Any]]:
+        """Prepare request kwargs for TOOLS mode.
+
+        Args:
+            response_model: Pydantic model to extract (or None)
+            kwargs: Original request kwargs
+
+        Returns:
+            Tuple of (response_model, modified_kwargs)
+        """
+        new_kwargs = kwargs.copy()
+
+        # Extract and combine system messages BEFORE serializing message content
+        system_messages = extract_system_messages(new_kwargs.get("messages", []))
+
+        if system_messages:
+            new_kwargs["system"] = combine_system_messages(
+                new_kwargs.get("system"), system_messages
+            )
+
+        # Remove system messages from messages list
+        new_kwargs["messages"] = [
+            m for m in new_kwargs.get("messages", []) if m["role"] != "system"
+        ]
+
+        # Serialize message content AFTER extracting system messages
+        if "messages" in new_kwargs:
+            new_kwargs["messages"] = process_messages_for_anthropic(
+                new_kwargs["messages"]
+            )
+
+        if response_model is None:
+            # Just return with processed messages and extracted system
+            return None, new_kwargs
+
+        # Generate tool schema
+        tool_descriptions = generate_anthropic_schema(response_model)
+        new_kwargs["tools"] = [tool_descriptions]
+        new_kwargs["tool_choice"] = {
+            "type": "tool",
+            "name": response_model.__name__,
+        }
+
+        return response_model, new_kwargs
+
+    def handle_reask(
+        self,
+        kwargs: dict[str, Any],
+        response: Message,
+        exception: Exception,
+    ) -> dict[str, Any]:
+        """Handle validation failure for TOOLS mode.
+
+        Args:
+            kwargs: Original request kwargs
+            response: Failed API response
+            exception: Validation exception
+
+        Returns:
+            Modified kwargs for retry
+        """
+        kwargs = kwargs.copy()
+        from anthropic.types import Message
+
+        from instructor.core.exceptions import ResponseParsingError
+
+        if not isinstance(response, Message):
+            raise ResponseParsingError(
+                "Response must be an Anthropic Message",
+                mode="ANTHROPIC_TOOLS",
+                raw_response=response,
+            )
+
+        # Extract assistant's response
+        assistant_content = []
+        tool_use_id = None
+        for content in response.content:
+            assistant_content.append(content.model_dump())
+            if content.type == "tool_use":
+                tool_use_id = content.id
+
+        # Build reask messages
+        reask_msgs = [{"role": "assistant", "content": assistant_content}]
+
+        if tool_use_id is not None:
+            # Tool was called, return error as tool_result
+            reask_msgs.append(
+                {
+                    "role": "user",
+                    "content": [
+                        {
+                            "type": "tool_result",
+                            "tool_use_id": tool_use_id,
+                            "content": f"Validation Error found:\n{exception}\nRecall the function correctly, fix the errors",
+                            "is_error": True,
+                        }
+                    ],
+                }
+            )
+        else:
+            # No tool call, ask for correction
+            reask_msgs.append(
+                {
+                    "role": "user",
+                    "content": f"Validation Error due to no tool invocation:\n{exception}\nRecall the function correctly, fix the errors",
+                }
+            )
+
+        kwargs["messages"].extend(reask_msgs)
+        return kwargs
+
+    def parse_response(
+        self,
+        response: Any,
+        response_model: type[BaseModel],
+        validation_context: dict[str, Any] | None = None,
+        strict: bool | None = None,
+    ) -> BaseModel:
+        """Parse TOOLS mode response.
+
+        Args:
+            response: Anthropic API response
+            response_model: Pydantic model to validate against
+            validation_context: Optional context for validation
+            strict: Optional strict validation mode
+
+        Returns:
+            Validated Pydantic model instance
+
+        Raises:
+            IncompleteOutputException: If response hit max_tokens
+            ValidationError: If response doesn't match model
+        """
+        from anthropic.types import Message
+
+        if isinstance(response, Message) and response.stop_reason == "max_tokens":
+            raise IncompleteOutputException(last_completion=response)
+
+        # Extract tool calls
+        tool_calls = [
+            json.dumps(c.input) for c in response.content if c.type == "tool_use"
+        ]
+
+        # Validate exactly one tool call
+        tool_calls_validator = TypeAdapter(
+            Annotated[list[Any], Field(min_length=1, max_length=1)]
+        )
+        tool_call = tool_calls_validator.validate_python(tool_calls)[0]
+
+        parsed = response_model.model_validate_json(
+            tool_call, context=validation_context, strict=strict
+        )
+
+        # Attach raw response for access via create_with_completion
+        parsed._raw_response = response  # type: ignore
+
+        return parsed
+
+
+@register_mode_handler(Provider.ANTHROPIC, Mode.JSON)
+class AnthropicJSONHandler(ModeHandler):
+    """Handler for Anthropic JSON mode.
+
+    Injects JSON schema into system message and parses JSON from text blocks.
+    """
+
+    def prepare_request(
+        self,
+        response_model: type[BaseModel] | None,
+        kwargs: dict[str, Any],
+    ) -> tuple[type[BaseModel] | None, dict[str, Any]]:
+        """Prepare request kwargs for JSON mode.
+
+        Args:
+            response_model: Pydantic model to extract (or None)
+            kwargs: Original request kwargs
+
+        Returns:
+            Tuple of (response_model, modified_kwargs)
+        """
+        new_kwargs = kwargs.copy()
+
+        # Extract and combine system messages BEFORE serializing message content
+        system_messages = extract_system_messages(new_kwargs.get("messages", []))
+
+        if system_messages:
+            new_kwargs["system"] = combine_system_messages(
+                new_kwargs.get("system"), system_messages
+            )
+
+        # Remove system messages from messages list
+        new_kwargs["messages"] = [
+            m for m in new_kwargs.get("messages", []) if m["role"] != "system"
+        ]
+
+        # Serialize message content AFTER extracting system messages
+        if "messages" in new_kwargs:
+            new_kwargs["messages"] = process_messages_for_anthropic(
+                new_kwargs["messages"]
+            )
+
+        if response_model is None:
+            return None, new_kwargs
+
+        # Add JSON schema to system message
+        json_schema_message = dedent(
+            f"""
+            As a genius expert, your task is to understand the content and provide
+            the parsed objects in json that match the following json_schema:\n
+
+            {json.dumps(response_model.model_json_schema(), indent=2, ensure_ascii=False)}
+
+            Make sure to return an instance of the JSON, not the schema itself
+            """
+        )
+
+        new_kwargs["system"] = combine_system_messages(
+            new_kwargs.get("system"),
+            [{"type": "text", "text": json_schema_message}],
+        )
+
+        return response_model, new_kwargs
+
+    def handle_reask(
+        self,
+        kwargs: dict[str, Any],
+        response: Message,
+        exception: Exception,
+    ) -> dict[str, Any]:
+        """Handle validation failure for JSON mode.
+
+        Args:
+            kwargs: Original request kwargs
+            response: Failed API response
+            exception: Validation exception
+
+        Returns:
+            Modified kwargs for retry
+        """
+        kwargs = kwargs.copy()
+        from anthropic.types import Message
+
+        from instructor.core.exceptions import ResponseParsingError
+
+        if not isinstance(response, Message):
+            raise ResponseParsingError(
+                "Response must be an Anthropic Message",
+                mode="JSON",
+                raw_response=response,
+            )
+
+        # Filter for text blocks to handle ThinkingBlock and other non-text content
+        text_blocks = [c for c in response.content if c.type == "text"]
+        if not text_blocks:
+            text_content = "No text content found in response"
+        else:
+            # Use the last text block
+            text_content = text_blocks[-1].text
+
+        reask_msg = {
+            "role": "user",
+            "content": f"""Validation Errors found:\n{exception}\nRecall the function correctly, fix the errors found in the following attempt:\n{text_content}""",
+        }
+        kwargs["messages"].append(reask_msg)
+        return kwargs
+
+    def parse_response(
+        self,
+        response: Any,
+        response_model: type[BaseModel],
+        validation_context: dict[str, Any] | None = None,
+        strict: bool | None = None,
+    ) -> BaseModel:
+        """Parse JSON mode response.
+
+        Args:
+            response: Anthropic API response
+            response_model: Pydantic model to validate against
+            validation_context: Optional context for validation
+            strict: Optional strict validation mode
+
+        Returns:
+            Validated Pydantic model instance
+
+        Raises:
+            IncompleteOutputException: If response hit max_tokens
+            ValidationError: If response doesn't match model
+        """
+        from anthropic.types import Message
+
+        if hasattr(response, "choices"):
+            # Handle OpenAI-style response (shouldn't happen for Anthropic)
+            completion = response.choices[0]
+            if completion.finish_reason == "length":
+                raise IncompleteOutputException(last_completion=completion)
+            text = completion.message.content
+        else:
+            from instructor.core.exceptions import ResponseParsingError
+
+            if not isinstance(response, Message):
+                raise ResponseParsingError(
+                    "Response must be an Anthropic Message",
+                    mode="JSON",
+                    raw_response=response,
+                )
+            if response.stop_reason == "max_tokens":
+                raise IncompleteOutputException(last_completion=response)
+
+            # Find the last text block
+            text_blocks = [c for c in response.content if c.type == "text"]
+            last_block = text_blocks[-1]
+
+            # Strip raw control characters (0x00-0x1F)
+            text = re.sub(r"[\u0000-\u001F]", "", last_block.text)
+
+        # Extract JSON from potential code block
+        extra_text = extract_json_from_codeblock(text)
+
+        if strict:
+            parsed = response_model.model_validate_json(
+                extra_text, context=validation_context, strict=strict
+            )
+        else:
+            parsed = response_model.model_validate_json(
+                extra_text, context=validation_context
+            )
+
+        # Attach raw response for access via create_with_completion
+        parsed._raw_response = response  # type: ignore
+
+        return parsed

--- a/tests/llm/test_anthropic/util.py
+++ b/tests/llm/test_anthropic/util.py
@@ -1,6 +1,9 @@
 import instructor
 
-models = ["anthropic/claude-3-7-sonnet-latest"]
+models = ["anthropic/claude-4-5-haiku-latest"]
 modes = [
     instructor.Mode.ANTHROPIC_TOOLS,
+    instructor.Mode.ANTHROPIC_JSON,
+    instructor.Mode.JSON,
+    instructor.Mode.TOOLS,
 ]

--- a/tests/v2/test_anthropic_integration.py
+++ b/tests/v2/test_anthropic_integration.py
@@ -1,0 +1,102 @@
+"""Integration tests for v2 Anthropic implementation.
+
+Tests that verify the v2 hierarchical registry works end-to-end with Anthropic.
+"""
+
+import pytest
+from pydantic import BaseModel
+
+from instructor import Mode
+from instructor.v2 import Provider, from_anthropic, mode_registry
+
+
+class User(BaseModel):
+    """Test model for extraction."""
+
+    name: str
+    age: int
+
+
+def test_anthropic_tools_mode_registered():
+    """Verify Anthropic TOOLS mode is registered in v2 registry."""
+    assert mode_registry.is_registered(Provider.ANTHROPIC, Mode.TOOLS)
+
+    handlers = mode_registry.get_handlers(Provider.ANTHROPIC, Mode.TOOLS)
+    assert handlers.request_handler is not None
+    assert handlers.reask_handler is not None
+    assert handlers.response_parser is not None
+
+
+def test_anthropic_json_mode_registered():
+    """Verify Anthropic JSON mode is registered in v2 registry."""
+    assert mode_registry.is_registered(Provider.ANTHROPIC, Mode.JSON)
+
+    handlers = mode_registry.get_handlers(Provider.ANTHROPIC, Mode.JSON)
+    assert handlers.request_handler is not None
+    assert handlers.reask_handler is not None
+    assert handlers.response_parser is not None
+
+
+@pytest.mark.skip(reason="Requires Anthropic API key")
+def test_v2_from_anthropic_tools_mode():
+    """Test v2 from_anthropic() with TOOLS mode."""
+    import anthropic
+
+    client = anthropic.Anthropic()
+    instructor_client = from_anthropic(client, Mode.TOOLS)
+
+    assert instructor_client is not None
+
+
+@pytest.mark.skip(reason="Requires Anthropic API key")
+def test_v2_from_anthropic_json_mode():
+    """Test v2 from_anthropic() with JSON mode."""
+    import anthropic
+
+    client = anthropic.Anthropic()
+    instructor_client = from_anthropic(client, Mode.JSON)
+
+    assert instructor_client is not None
+
+
+@pytest.mark.skip(reason="Requires Anthropic API key")
+def test_v2_from_anthropic_async():
+    """Test v2 from_anthropic() with async client."""
+    import anthropic
+
+    client = anthropic.AsyncAnthropic()
+    instructor_client = from_anthropic(client, Mode.TOOLS)
+
+    assert instructor_client is not None
+    # Should return AsyncInstructor for async client
+    from instructor import AsyncInstructor
+
+    assert isinstance(instructor_client, AsyncInstructor)
+
+
+@pytest.mark.skip(reason="Requires Anthropic API key")
+def test_v2_from_anthropic_invalid_mode():
+    """Test v2 from_anthropic() with unregistered mode type."""
+    import anthropic
+
+    client = anthropic.Anthropic()
+
+    # PARALLEL_TOOLS not implemented in v2 yet
+    with pytest.raises(ValueError, match="not registered"):
+        from_anthropic(client, Mode.ANTHROPIC_PARALLEL_TOOLS)
+
+
+def test_query_anthropic_modes():
+    """Test querying v2 registry for Anthropic modes."""
+    modes = mode_registry.get_modes_for_provider(Provider.ANTHROPIC)
+
+    assert Mode.TOOLS in modes
+    assert Mode.JSON in modes
+    assert len(modes) == 2  # Only TOOLS and JSON for now
+
+
+def test_query_tools_providers():
+    """Test querying v2 registry for TOOLS mode providers."""
+    providers = mode_registry.get_providers_for_mode(Mode.TOOLS)
+
+    assert Provider.ANTHROPIC in providers

--- a/tests/v2/test_registry.py
+++ b/tests/v2/test_registry.py
@@ -1,0 +1,91 @@
+"""Tests for v2 mode registry."""
+
+import pytest
+
+from instructor import Mode
+from instructor.v2 import Provider, mode_registry
+from instructor.v2.core.decorators import register_mode_handler
+
+
+def test_registry_registration():
+    """Test basic registration."""
+
+    @register_mode_handler(Provider.OPENAI, Mode.TOOLS)
+    class TestHandler:
+        def prepare_request(self, response_model, kwargs):
+            return response_model, kwargs
+
+        def handle_reask(self, kwargs, _response, _exception):
+            return kwargs
+
+        def parse_response(self, _response, response_model, **_kwargs):
+            return response_model()
+
+    # Check it's registered
+    assert mode_registry.is_registered(Provider.OPENAI, Mode.TOOLS)
+
+    # Get handlers
+    handlers = mode_registry.get_handlers(Provider.OPENAI, Mode.TOOLS)
+    assert handlers.request_handler is not None
+    assert handlers.reask_handler is not None
+    assert handlers.response_parser is not None
+
+
+def test_registry_get_handler():
+    """Test getting specific handler types."""
+
+    @register_mode_handler(Provider.GEMINI, Mode.JSON)
+    class TestHandler:
+        def prepare_request(self, response_model, _kwargs):
+            return response_model, {"test": "request"}
+
+        def handle_reask(self, _kwargs, _response, _exception):
+            return {"test": "reask"}
+
+        def parse_response(self, _response, response_model, **_kwargs):
+            return response_model()
+
+    # Get individual handlers
+    request_handler = mode_registry.get_handler(Provider.GEMINI, Mode.JSON, "request")
+    result = request_handler(None, {})
+    assert result[1]["test"] == "request"
+
+    reask_handler = mode_registry.get_handler(Provider.GEMINI, Mode.JSON, "reask")
+    result = reask_handler({}, None, None)
+    assert result["test"] == "reask"
+
+
+def test_registry_query_by_provider():
+    """Test querying modes for a provider."""
+    # Anthropic should have TOOLS and JSON registered
+    modes = mode_registry.get_modes_for_provider(Provider.ANTHROPIC)
+    assert Mode.TOOLS in modes
+    assert Mode.JSON in modes
+
+
+def test_registry_query_by_mode_type():
+    """Test querying providers for a mode type."""
+    # TOOLS should be supported by Anthropic (and possibly others)
+    providers = mode_registry.get_providers_for_mode(Mode.TOOLS)
+    assert Provider.ANTHROPIC in providers
+
+
+def test_registry_list_modes():
+    """Test listing all registered modes."""
+    all_modes = mode_registry.list_modes()
+
+    # Should include Anthropic modes
+    assert (Provider.ANTHROPIC, Mode.TOOLS) in all_modes
+    assert (Provider.ANTHROPIC, Mode.JSON) in all_modes
+
+
+def test_registry_not_registered():
+    """Test error when mode not registered."""
+    with pytest.raises(KeyError, match="not registered"):
+        mode_registry.get_handlers(Provider.COHERE, Mode.TOOLS)
+
+
+def test_registry_invalid_handler_type():
+    """Test error for invalid handler type."""
+    with pytest.raises(ValueError, match="Invalid handler_type"):
+        mode_registry.get_handler(Provider.ANTHROPIC, Mode.TOOLS, "invalid_type")

--- a/tests/v2/test_routing.py
+++ b/tests/v2/test_routing.py
@@ -1,0 +1,72 @@
+"""Tests for from_provider() routing to v2.
+
+Verifies that from_provider("anthropic/...") routes to v2 implementation.
+"""
+
+import warnings
+
+import pytest
+
+
+@pytest.mark.skip(reason="Requires Anthropic API key")
+def test_from_provider_routes_to_v2():
+    """Test that from_provider() routes Anthropic to v2."""
+    import instructor
+
+    # from_provider should route to v2 for Anthropic
+    client = instructor.from_provider("anthropic/claude-3-5-sonnet-20241022")
+
+    assert client is not None
+    # Verify it's using v2 by checking the mode is a tuple
+    assert isinstance(client.mode, tuple)
+    assert len(client.mode) == 2
+
+
+@pytest.mark.skip(reason="Requires Anthropic API key")
+def test_from_provider_anthropic_async():
+    """Test that from_provider() routes async Anthropic to v2."""
+    import instructor
+
+    client = instructor.from_provider(
+        "anthropic/claude-3-5-sonnet-20241022", async_client=True
+    )
+
+    assert client is not None
+    from instructor import AsyncInstructor
+
+    assert isinstance(client, AsyncInstructor)
+    # Verify it's using v2
+    assert isinstance(client.mode, tuple)
+
+
+def test_old_from_anthropic_deprecation_warning():
+    """Test that old from_anthropic() emits deprecation warning."""
+    import anthropic
+    from instructor import from_anthropic
+
+    client = anthropic.Anthropic()
+
+    with warnings.catch_warnings(record=True) as w:
+        warnings.simplefilter("always")
+        instructor_client = from_anthropic(client)
+
+        # Should emit deprecation warning
+        assert len(w) == 1
+        assert issubclass(w[0].category, DeprecationWarning)
+        assert "deprecated" in str(w[0].message).lower()
+        assert "v2" in str(w[0].message)
+
+
+@pytest.mark.skip(reason="Requires Anthropic API key")
+def test_from_provider_with_mode_compatibility():
+    """Test that from_provider() handles v1 Mode enum for compatibility."""
+    import instructor
+
+    # Passing v1 Mode should still work (gets converted to v2 Mode)
+    client = instructor.from_provider(
+        "anthropic/claude-3-5-sonnet-20241022", mode=instructor.Mode.TOOLS
+    )
+
+    assert client is not None
+    # Should be converted to v2 tuple mode
+    assert isinstance(client.mode, tuple)


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Introduces v2 infrastructure with a dynamic registry for mode handling, implements Anthropic provider support, deprecates old `from_anthropic`, and adds comprehensive tests.
> 
>   - **Infrastructure**:
>     - Introduces v2 infrastructure with a dynamic registry system for mode handling in `instructor/v2/__init__.py` and `instructor/v2/core/registry.py`.
>     - Implements `ModeHandler`, `RequestHandler`, `ReaskHandler`, and `ResponseParser` protocols in `instructor/v2/core/protocols.py`.
>     - Adds `patch_v2` function in `instructor/v2/core/patch.py` for patching functions using the v2 registry.
>   - **Providers**:
>     - Implements Anthropic provider support in v2 with `from_anthropic` in `instructor/v2/providers/anthropic/client.py`.
>     - Adds handlers for Anthropic TOOLS and JSON modes in `instructor/v2/providers/anthropic/handlers.py`.
>   - **Deprecation**:
>     - Deprecates `from_anthropic` in `instructor/providers/anthropic/client.py` with a warning to use v2.
>   - **Testing**:
>     - Adds integration tests for v2 Anthropic implementation in `tests/v2/test_anthropic_integration.py`.
>     - Adds tests for v2 mode registry in `tests/v2/test_registry.py`.
>     - Adds routing tests for `from_provider` in `tests/v2/test_routing.py`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=567-labs%2Finstructor&utm_source=github&utm_medium=referral)<sup> for a5e947948b063f091bdea4c5bf05a21eabcd07f9. You can [customize](https://app.ellipsis.dev/567-labs/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->