### PR TITLE
Refactor Anthropic v2 handlers to use registry streaming pipeline

### DIFF
--- a/tests/v2/providers/anthropic/test_handlers.py
+++ b/tests/v2/providers/anthropic/test_handlers.py
@@ -1,0 +1,99 @@
+"""Tests for Anthropic handlers routed through process_response."""
+
+from __future__ import annotations
+
+from collections.abc import Generator
+from dataclasses import dataclass
+
+from pydantic import BaseModel
+
+from instructor.mode import Mode
+from instructor.dsl.iterable import IterableBase
+from instructor.dsl.parallel import AnthropicParallelBase
+from instructor.processing.response import process_response
+
+
+class StreamItem(BaseModel):
+    value: int
+
+
+class SimpleIterable(IterableBase):
+    """Minimal iterable model for testing streaming integration."""
+
+    task_type = StreamItem
+
+    @classmethod
+    def from_streaming_response(
+        cls, completion: Generator[dict[str, int], None, None], mode: Mode, **_: object
+    ) -> Generator[StreamItem, None, None]:
+        for payload in completion:
+            yield StreamItem.model_validate(payload)
+
+
+@dataclass
+class FakeToolContent:
+    """Simplified tool_use block for parallel parsing tests."""
+
+    type: str
+    name: str
+    input: dict[str, object]
+
+
+@dataclass
+class FakeMessage:
+    """Minimal Anthropic message stand-in for tests."""
+
+    content: list[FakeToolContent]
+    stop_reason: str | None = None
+
+
+class ToolA(BaseModel):
+    foo: int
+
+
+class ToolB(BaseModel):
+    bar: str
+
+
+def test_process_response_streaming_iterable_uses_registry():
+    """Streaming iterable models should be parsed via Anthropic handler."""
+
+    response = ({"value": 1}, {"value": 2})
+
+    result = process_response(
+        response=response,
+        response_model=SimpleIterable,
+        stream=True,
+        validation_context=None,
+        strict=True,
+        mode=Mode.ANTHROPIC_TOOLS,
+    )
+
+    assert [item.value for item in result] == [1, 2]
+
+
+def test_process_response_parallel_tools_matches_previous_behavior():
+    """Parallel tool responses should yield validated models via handler."""
+
+    response = FakeMessage(
+        content=[
+            FakeToolContent(type="tool_use", name="ToolA", input={"foo": 5}),
+            FakeToolContent(type="tool_use", name="ToolB", input={"bar": "x"}),
+        ]
+    )
+
+    parallel_model = AnthropicParallelBase(ToolA, ToolB)
+
+    parsed = process_response(
+        response=response,
+        response_model=parallel_model,
+        stream=False,
+        validation_context=None,
+        strict=True,
+        mode=Mode.ANTHROPIC_PARALLEL_TOOLS,
+    )
+
+    assert [model.model_dump() for model in parsed] == [
+        {"foo": 5},
+        {"bar": "x"},
+    ]

--- a/tests/v2/test_anthropic_integration.py
+++ b/tests/v2/test_anthropic_integration.py
@@ -29,9 +29,11 @@ def test_anthropic_tools_mode_registered():
 
 def test_anthropic_json_mode_registered():
     """Verify Anthropic JSON mode is registered in v2 registry."""
-    assert mode_registry.is_registered(Provider.ANTHROPIC, Mode.JSON)
+    assert mode_registry.is_registered(Provider.ANTHROPIC, Mode.ANTHROPIC_JSON)
 
-    handlers = mode_registry.get_handlers(Provider.ANTHROPIC, Mode.JSON)
+    handlers = mode_registry.get_handlers(
+        Provider.ANTHROPIC, Mode.ANTHROPIC_JSON
+    )
     assert handlers.request_handler is not None
     assert handlers.reask_handler is not None
     assert handlers.response_parser is not None
@@ -54,7 +56,7 @@ def test_v2_from_anthropic_json_mode():
     import anthropic
 
     client = anthropic.Anthropic()
-    instructor_client = from_anthropic(client, Mode.JSON)
+    instructor_client = from_anthropic(client, Mode.ANTHROPIC_JSON)
 
     assert instructor_client is not None
 
@@ -91,9 +93,10 @@ def test_query_anthropic_modes():
     modes = mode_registry.get_modes_for_provider(Provider.ANTHROPIC)
 
     assert Mode.TOOLS in modes
-    assert Mode.JSON in modes
+    assert Mode.ANTHROPIC_JSON in modes
     assert Mode.ANTHROPIC_REASONING_TOOLS in modes
-    assert len(modes) == 3  # TOOLS, JSON, and ANTHROPIC_REASONING_TOOLS
+    assert Mode.ANTHROPIC_PARALLEL_TOOLS in modes
+    assert len(modes) == 4
 
 
 def test_query_tools_providers():


### PR DESCRIPTION
## Summary
- introduce a shared Anthropic handler base with DSL-aware parsing, add explicit parallel tooling support, and register handlers for JSON, tools, and reasoning modes
- route `process_response` and its async counterpart through the v2 mode registry for Anthropic modes while preserving existing fallbacks
- add regression tests covering streaming iterable parsing and parallel tool responses to ensure behavior matches the previous implementation

## Testing
- `ANTHROPIC_API_KEY=dummy uv run pytest tests/v2/providers/anthropic/test_handlers.py`


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6914e310e3f483269b1d73f75eabe564)
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Refactor Anthropic v2 handlers to use a registry streaming pipeline, introduce a shared handler base, and add regression tests.
> 
>   - **Behavior**:
>     - Refactor Anthropic v2 handlers to use a registry streaming pipeline in `handlers.py`.
>     - Introduce shared `AnthropicHandlerBase` with DSL-aware parsing and parallel tooling support.
>     - Register handlers for JSON, tools, and reasoning modes.
>     - Route `process_response` and `process_response_async` through v2 mode registry for Anthropic modes in `response.py`.
>   - **Testing**:
>     - Add regression tests in `test_handlers.py` for streaming iterable parsing and parallel tool responses.
>     - Update integration tests in `test_anthropic_integration.py` to verify mode registration and behavior.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=567-labs%2Finstructor&utm_source=github&utm_medium=referral)<sup> for 195513483ca2cda1c64ff282f25dd1c993cce329. You can [customize](https://app.ellipsis.dev/567-labs/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->