### PR TITLE
feat: use uv for dependency installation in build script

### DIFF
--- a/build_mkdocs.sh
+++ b/build_mkdocs.sh
@@ -1,3 +1,4 @@
-pip install -r requirements.txt
-pip install -r requirements-doc.txt
+pip install uv
+uv pip install -r requirements.txt
+uv pip install -r requirements-doc.txt
 mkdocs build


### PR DESCRIPTION
## Summary
Update build_mkdocs.sh to use uv for installing dependencies instead of pip directly.

## Changes
- Install uv via pip first
- Use `uv pip install` for both requirements.txt and requirements-doc.txt
- This allows testing uv in the Cloudflare Workers build environment

## Testing
Deploy this branch to Cloudflare to verify uv works in the build environment.

🤖 Generated with Claude Code
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Update `build_mkdocs.sh` to use `uv` for dependency installation instead of `pip` directly.
> 
>   - **Behavior**:
>     - Update `build_mkdocs.sh` to use `uv` for dependency installation instead of `pip` directly.
>     - Install `uv` via `pip` first, then use `uv pip install` for `requirements.txt` and `requirements-doc.txt`.
>     - Intended to test `uv` in the Cloudflare Workers build environment.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=567-labs%2Finstructor&utm_source=github&utm_medium=referral)<sup> for dc3957ad31122363d5c04ee05a5e2d3362b96305. You can [customize](https://app.ellipsis.dev/567-labs/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->