### PR TITLE
Doc / Removed model reference in client.create of extraction example.

### DIFF
--- a/docs/learning/getting_started/first_extraction.md
+++ b/docs/learning/getting_started/first_extraction.md
@@ -24,7 +24,6 @@ client = instructor.from_provider("openai/gpt-5-nano")
 
 # 3. Extract structured data from LLM
 person = client.create(
-    model="gpt-3.5-turbo",  # Works with GPT-4, Claude, Gemini, etc.
     response_model=Person,   # Type-safe extraction
     messages=[
         {"role": "user", "content": "John Doe is 30 years old"}


### PR DESCRIPTION
client.create is specifying the model once agin, while model is already specified in instructor.from_provider. 
Removed model agreement to avoid confusion to the reader.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Remove redundant `model` parameter in `client.create()` example in `first_extraction.md`.
> 
>   - **Documentation**:
>     - Removed redundant `model` parameter in `client.create()` in `first_extraction.md` example, as the model is already specified in `instructor.from_provider()`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=567-labs%2Finstructor&utm_source=github&utm_medium=referral)<sup> for 383652de4f83f30cd77051cb0442319808f88dc8. You can [customize](https://app.ellipsis.dev/567-labs/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->