### PR TITLE
fix: OpenAI provider in from_provider ignores base_url kwarg

### DIFF
--- a/instructor/auto_client.py
+++ b/instructor/auto_client.py
@@ -160,10 +160,29 @@ def from_provider(
             import openai
             from instructor import from_openai  # type: ignore[attr-defined]
 
+            # Extract base_url and other OpenAI client parameters from kwargs
+            base_url = kwargs.pop("base_url", None)
+            openai_client_kwargs = {}
+            for key in (
+                "organization",
+                "timeout",
+                "max_retries",
+                "default_headers",
+                "http_client",
+                "app_info",
+            ):
+                if key in kwargs:
+                    openai_client_kwargs[key] = kwargs.pop(key)
+
+            # Build client kwargs, including base_url if provided
+            client_kwargs = {"api_key": api_key, **openai_client_kwargs}
+            if base_url is not None:
+                client_kwargs["base_url"] = base_url
+
             client = (
-                openai.AsyncOpenAI(api_key=api_key)
+                openai.AsyncOpenAI(**client_kwargs)
                 if async_client
-                else openai.OpenAI(api_key=api_key)
+                else openai.OpenAI(**client_kwargs)
             )
             result = from_openai(
                 client,

--- a/tests/test_auto_client.py
+++ b/tests/test_auto_client.py
@@ -270,6 +270,79 @@ def test_api_key_logging():
                 )
 
 
+def test_openai_provider_respects_base_url():
+    """Ensure OpenAI provider passes base_url to client constructor."""
+    from unittest.mock import patch, MagicMock
+
+    with patch("openai.OpenAI") as mock_openai_class:
+        mock_client = MagicMock()
+        mock_openai_class.return_value = mock_client
+
+        with patch("instructor.from_openai") as mock_from_openai:
+            mock_instructor = MagicMock()
+            mock_from_openai.return_value = mock_instructor
+
+            client = from_provider(
+                "openai/gpt-4",
+                base_url="https://api.example.com/v1",
+                api_key="test-key",
+            )
+
+            _, kwargs = mock_openai_class.call_args
+            assert kwargs["base_url"] == "https://api.example.com/v1"
+            assert kwargs["api_key"] == "test-key"
+            mock_from_openai.assert_called_once()
+            assert client is mock_instructor
+
+
+def test_openai_provider_async_client_with_base_url():
+    """Ensure OpenAI provider passes base_url to async client constructor."""
+    from unittest.mock import patch, MagicMock
+
+    with patch("openai.AsyncOpenAI") as mock_async_openai_class:
+        mock_client = MagicMock()
+        mock_async_openai_class.return_value = mock_client
+
+        with patch("instructor.from_openai") as mock_from_openai:
+            mock_instructor = MagicMock()
+            mock_from_openai.return_value = mock_instructor
+
+            client = from_provider(
+                "openai/gpt-4",
+                async_client=True,
+                base_url="https://api.example.com/v1",
+                api_key="test-key",
+            )
+
+            mock_async_openai_class.assert_called_once()
+            _, kwargs = mock_async_openai_class.call_args
+            assert kwargs["base_url"] == "https://api.example.com/v1"
+            assert kwargs["api_key"] == "test-key"
+            mock_from_openai.assert_called_once()
+            assert client is mock_instructor
+
+
+def test_openai_provider_without_base_url():
+    """Ensure OpenAI provider works without base_url (defaults to api.openai.com)."""
+    from unittest.mock import patch, MagicMock
+
+    with patch("openai.OpenAI") as mock_openai_class:
+        mock_client = MagicMock()
+        mock_openai_class.return_value = mock_client
+
+        with patch("instructor.from_openai") as mock_from_openai:
+            mock_instructor = MagicMock()
+            mock_from_openai.return_value = mock_instructor
+
+            client = from_provider("openai/gpt-4", api_key="test-key")
+
+            _, kwargs = mock_openai_class.call_args
+            assert "base_url" not in kwargs
+            assert kwargs["api_key"] == "test-key"
+            mock_from_openai.assert_called_once()
+            assert client is mock_instructor
+
+
 def test_databricks_provider_uses_environment_configuration():
     """Ensure Databricks provider pulls host and token from the environment."""
     from unittest.mock import patch, MagicMock


### PR DESCRIPTION
Fixes: OpenAI provider in from_provider ignores base_url kwarg (can't point client to custom endpoint) https://github.com/567-labs/instructor/issues/1921


<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes `from_provider` to pass `base_url` to OpenAI clients and adds tests to verify this behavior.
> 
>   - **Behavior**:
>     - Fixes `from_provider` in `auto_client.py` to correctly pass `base_url` to OpenAI client constructors.
>     - Handles both `AsyncOpenAI` and `OpenAI` clients.
>   - **Tests**:
>     - Adds `test_openai_provider_respects_base_url()` in `test_auto_client.py` to verify `base_url` is passed to `OpenAI`.
>     - Adds `test_openai_provider_async_client_with_base_url()` to verify `base_url` is passed to `AsyncOpenAI`.
>     - Adds `test_openai_provider_without_base_url()` to ensure default behavior when `base_url` is not provided.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=567-labs%2Finstructor&utm_source=github&utm_medium=referral)<sup> for 0ea8e907960dfd2d45a3071749f0e9b231c997b6. You can [customize](https://app.ellipsis.dev/567-labs/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->