### PR TITLE
fix(genai): extract thinking_config from user-provided config object

### DIFF
--- a/instructor/providers/gemini/utils.py
+++ b/instructor/providers/gemini/utils.py
@@ -834,6 +834,17 @@ def handle_genai_structured_outputs(
     if new_kwargs.get("stream", False) and not issubclass(response_model, PartialBase):
         response_model = Partial[response_model]
 
+    # Extract thinking_config from user-provided config object if present
+    # This fixes issue #1966 where thinking_config inside config was ignored
+    user_config = new_kwargs.get("config")
+    user_thinking_config = None
+    if user_config is not None and hasattr(user_config, "thinking_config"):
+        user_thinking_config = user_config.thinking_config
+
+    # Prioritize kwarg thinking_config over config.thinking_config
+    if "thinking_config" not in new_kwargs and user_thinking_config is not None:
+        new_kwargs["thinking_config"] = user_thinking_config
+
     if new_kwargs.get("system"):
         system_message = new_kwargs.pop("system")
     elif new_kwargs.get("messages"):
@@ -897,6 +908,17 @@ def handle_genai_tools(
     # Automatically wrap regular models with Partial when streaming is enabled
     if new_kwargs.get("stream", False) and not issubclass(response_model, PartialBase):
         response_model = Partial[response_model]
+
+    # Extract thinking_config from user-provided config object if present
+    # This fixes issue #1966 where thinking_config inside config was ignored
+    user_config = new_kwargs.get("config")
+    user_thinking_config = None
+    if user_config is not None and hasattr(user_config, "thinking_config"):
+        user_thinking_config = user_config.thinking_config
+
+    # Prioritize kwarg thinking_config over config.thinking_config
+    if "thinking_config" not in new_kwargs and user_thinking_config is not None:
+        new_kwargs["thinking_config"] = user_thinking_config
 
     schema = map_to_gemini_function_schema(_get_model_schema(response_model))
     function_definition = types.FunctionDeclaration(


### PR DESCRIPTION
## Summary
- When users pass `thinking_config` inside a `GenerateContentConfig` object, it was being ignored
- This fix extracts `thinking_config` from the user-provided config object
- Prioritizes separate kwarg `thinking_config` over `config.thinking_config`

## Changes
- Modified `handle_genai_structured_outputs()` to extract thinking_config from user config
- Modified `handle_genai_tools()` with the same fix
- Added tests to verify the fix works correctly

## Test plan
- [x] Added unit tests for thinking_config extraction
- [x] Verified kwarg priority over config.thinking_config
- [x] Existing tests pass

Closes #1966
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes issue #1966 by extracting `thinking_config` from user config in `handle_genai_structured_outputs()` and `handle_genai_tools()`, prioritizing kwarg over config.
> 
>   - **Behavior**:
>     - Fixes issue #1966 by extracting `thinking_config` from `config` in `handle_genai_structured_outputs()` and `handle_genai_tools()`.
>     - Prioritizes `thinking_config` kwarg over `config.thinking_config`.
>   - **Tests**:
>     - Adds `test_handle_genai_structured_outputs_thinking_config_in_config()` and `test_handle_genai_tools_thinking_config_in_config()` to verify extraction.
>     - Adds `test_handle_genai_structured_outputs_thinking_config_kwarg_priority()` to verify kwarg priority.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=567-labs%2Finstructor&utm_source=github&utm_medium=referral)<sup> for 09f42bccb6b48aa6a0aae490fc19dcc5f9ddb453. You can [customize](https://app.ellipsis.dev/567-labs/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->