### PR TITLE
fix(auto_client): stop masking runtime ImportErrors in from_provider

### DIFF
--- a/instructor/auto_client.py
+++ b/instructor/auto_client.py
@@ -393,9 +393,19 @@ def from_provider(
             raise
 
     elif provider == "google":
+        # Import google-genai package - catch ImportError only for actual imports
         try:
             import google.genai as genai
             from instructor import from_genai  # type: ignore[attr-defined]
+        except ImportError as e:
+            from .core.exceptions import ConfigurationError
+
+            raise ConfigurationError(
+                "The google-genai package is required to use the Google provider. "
+                "Install it with `pip install google-genai`."
+            ) from e
+
+        try:
             import os
 
             # Remove vertexai from kwargs if present to avoid passing it twice
@@ -441,13 +451,6 @@ def from_provider(
                 extra={**provider_info, "status": "success"},
             )
             return result
-        except ImportError:
-            from .core.exceptions import ConfigurationError
-
-            raise ConfigurationError(
-                "The google-genai package is required to use the Google provider. "
-                "Install it with `pip install google-genai`."
-            ) from None
         except Exception as e:
             logger.error(
                 "Error initializing %s client: %s",
@@ -795,9 +798,19 @@ def from_provider(
             DeprecationWarning,
             stacklevel=2,
         )
+        # Import google-genai package - catch ImportError only for actual imports
         try:
             import google.genai as genai  # type: ignore
             from instructor import from_genai  # type: ignore[attr-defined]
+        except ImportError as e:
+            from .core.exceptions import ConfigurationError
+
+            raise ConfigurationError(
+                "The google-genai package is required to use the VertexAI provider. "
+                "Install it with `pip install google-genai`."
+            ) from e
+
+        try:
             import os
 
             # Get project and location from kwargs or environment
@@ -836,13 +849,6 @@ def from_provider(
                 extra={**provider_info, "status": "success"},
             )
             return result
-        except ImportError:
-            from .core.exceptions import ConfigurationError
-
-            raise ConfigurationError(
-                "The google-genai package is required to use the VertexAI provider. "
-                "Install it with `pip install google-genai`."
-            ) from None
         except Exception as e:
             logger.error(
                 "Error initializing %s client: %s",
@@ -860,9 +866,19 @@ def from_provider(
             DeprecationWarning,
             stacklevel=2,
         )
+        # Import google-genai package - catch ImportError only for actual imports
         try:
             from google import genai
             from instructor import from_genai  # type: ignore[attr-defined]
+        except ImportError as e:
+            from .core.exceptions import ConfigurationError
+
+            raise ConfigurationError(
+                "The google-genai package is required to use the Google GenAI provider. "
+                "Install it with `pip install google-genai`."
+            ) from e
+
+        try:
             import os
 
             # Get API key from kwargs or environment
@@ -889,13 +905,6 @@ def from_provider(
                 extra={**provider_info, "status": "success"},
             )
             return result
-        except ImportError:
-            from .core.exceptions import ConfigurationError
-
-            raise ConfigurationError(
-                "The google-genai package is required to use the Google GenAI provider. "
-                "Install it with `pip install google-genai`."
-            ) from None
         except Exception as e:
             logger.error(
                 "Error initializing %s client: %s",


### PR DESCRIPTION
## Summary

Fixes #1940

When using a SOCKS proxy with the Google provider, `from_provider("google/...")` would incorrectly raise a `ConfigurationError` about missing `google-genai` package, even when the package was installed. The actual issue was a missing `socksio` dependency for httpx's SOCKS support.

**Root cause:** The `except ImportError` block caught ALL import errors, including runtime ones raised during `genai.Client()` initialization (e.g., httpx raising `ImportError` when socksio is missing for SOCKS proxy).

**Fix:** Separated import error handling from client initialization for all affected providers (google, vertexai, generative-ai):
- First `try/except ImportError` now only catches actual package import errors
- Second `try/except Exception` handles all other exceptions during client initialization
- Runtime ImportErrors now propagate correctly with their original message

## Test plan

- [x] Added `test_google_provider_runtime_import_error_propagates` - verifies socksio ImportError propagates correctly
- [x] Added `test_vertexai_provider_runtime_import_error_propagates` - same for deprecated vertexai provider
- [x] Added `test_generative_ai_provider_runtime_import_error_propagates` - same for deprecated generative-ai provider
- [x] All tests pass: `pytest tests/test_auto_client.py -v`
- [x] Linting passes: `ruff check instructor/auto_client.py tests/test_auto_client.py`

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes runtime ImportError masking in `from_provider` for Google-related providers, ensuring correct error propagation.
> 
>   - **Behavior**:
>     - Fixes issue where `from_provider` masked runtime `ImportError` as `ConfigurationError` for Google, VertexAI, and Generative-AI providers.
>     - Separates import error handling from client initialization in `from_provider`.
>     - Runtime `ImportError` now propagates with original message.
>   - **Tests**:
>     - Adds `test_google_provider_runtime_import_error_propagates` to verify `socksio` `ImportError` propagation.
>     - Adds `test_vertexai_provider_runtime_import_error_propagates` for deprecated VertexAI provider.
>     - Adds `test_generative_ai_provider_runtime_import_error_propagates` for deprecated Generative-AI provider.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=567-labs%2Finstructor&utm_source=github&utm_medium=referral)<sup> for 44de2f483b5acdc0ffb5b8c08e2431e52e73fdab. You can [customize](https://app.ellipsis.dev/567-labs/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->