### PR TITLE
feat(partial): completeness-based streaming validation

### DIFF
--- a/instructor/dsl/json_tracker.py
+++ b/instructor/dsl/json_tracker.py
@@ -1,0 +1,302 @@
+"""
+JSON Completeness Tracker for Partial Streaming.
+
+Tracks which parts of accumulated JSON are "closed" (complete) vs "open" (incomplete).
+A closed object/array has matching braces/brackets; an open one is still being streamed.
+
+This enables validation to run only on complete sub-objects, avoiding validation
+errors on incomplete data during streaming.
+"""
+
+from __future__ import annotations
+
+
+class JsonCompleteness:
+    """
+    Track completeness of JSON structures during streaming.
+
+    A JSON structure is "complete" if:
+    - Objects: start with { and end with }
+    - Arrays: start with [ and end with ]
+    - Scalars (strings, numbers, booleans, null): always complete once parsed
+
+    Example:
+        tracker = JsonCompleteness()
+
+        # Incomplete - missing closing brace
+        tracker.analyze('{"name": "Alice", "address": {"city": "NY')
+        tracker.is_path_complete("")  # False - root object incomplete
+        tracker.is_path_complete("name")  # True - string is complete
+        tracker.is_path_complete("address")  # False - nested object incomplete
+
+        # Complete
+        tracker.analyze('{"name": "Alice"}')
+        tracker.is_path_complete("")  # True - root object complete
+    """
+
+    def __init__(self) -> None:
+        self._json_str: str = ""
+        self._complete_paths: set[str] = set()
+        self._path_positions: dict[str, tuple[int, int]] = {}  # path -> (start, end)
+
+    def analyze(self, json_str: str) -> None:
+        """
+        Analyze a JSON string and determine completeness of each sub-structure.
+
+        Args:
+            json_str: The accumulated JSON string (may be incomplete)
+        """
+        self._json_str = json_str
+        self._complete_paths = set()
+        self._path_positions = {}
+
+        if not json_str.strip():
+            return
+
+        # Parse and track completeness
+        self._analyze_structure(json_str, "", 0)
+
+    def _analyze_structure(self, json_str: str, path: str, start_pos: int) -> int:
+        """
+        Recursively analyze JSON structure and track completeness.
+
+        Returns the position after the current structure, or -1 if incomplete.
+        """
+        s = json_str[start_pos:].lstrip()
+        if not s:
+            return -1
+
+        pos = start_pos + (
+            len(json_str) - start_pos - len(json_str[start_pos:].lstrip())
+        )
+
+        if s[0] == "{":
+            return self._analyze_object(json_str, path, pos)
+        elif s[0] == "[":
+            return self._analyze_array(json_str, path, pos)
+        elif s[0] == '"':
+            return self._analyze_string(json_str, path, pos)
+        elif s[0] in "-0123456789":
+            return self._analyze_number(json_str, path, pos)
+        elif s.startswith("true"):
+            self._mark_complete(path, pos, pos + 4)
+            return pos + 4
+        elif s.startswith("false"):
+            self._mark_complete(path, pos, pos + 5)
+            return pos + 5
+        elif s.startswith("null"):
+            self._mark_complete(path, pos, pos + 4)
+            return pos + 4
+        else:
+            return -1  # Invalid or incomplete
+
+    def _analyze_object(self, json_str: str, path: str, start_pos: int) -> int:
+        """Analyze a JSON object. Returns end position or -1 if incomplete."""
+        pos = start_pos + 1  # Skip opening {
+        first = True
+
+        while pos < len(json_str):
+            # Skip whitespace
+            while pos < len(json_str) and json_str[pos] in " \t\n\r":
+                pos += 1
+
+            if pos >= len(json_str):
+                return -1  # Incomplete
+
+            if json_str[pos] == "}":
+                # Object is complete
+                self._mark_complete(path, start_pos, pos + 1)
+                return pos + 1
+
+            if not first:
+                if json_str[pos] != ",":
+                    return -1  # Invalid
+                pos += 1
+                # Skip whitespace after comma
+                while pos < len(json_str) and json_str[pos] in " \t\n\r":
+                    pos += 1
+                if pos >= len(json_str):
+                    return -1
+
+            first = False
+
+            # Parse key
+            if pos >= len(json_str) or json_str[pos] != '"':
+                return -1  # Invalid or incomplete
+
+            key_start = pos
+            pos = self._skip_string(json_str, pos)
+            if pos == -1:
+                return -1  # Incomplete string
+
+            key = json_str[key_start + 1 : pos - 1]  # Extract key without quotes
+
+            # Skip whitespace and colon
+            while pos < len(json_str) and json_str[pos] in " \t\n\r":
+                pos += 1
+            if pos >= len(json_str) or json_str[pos] != ":":
+                return -1
+            pos += 1
+
+            # Parse value
+            child_path = f"{path}.{key}" if path else key
+            pos = self._analyze_structure(json_str, child_path, pos)
+            if pos == -1:
+                return -1  # Incomplete value
+
+        return -1  # Incomplete (no closing brace)
+
+    def _analyze_array(self, json_str: str, path: str, start_pos: int) -> int:
+        """Analyze a JSON array. Returns end position or -1 if incomplete."""
+        pos = start_pos + 1  # Skip opening [
+        index = 0
+        first = True
+
+        while pos < len(json_str):
+            # Skip whitespace
+            while pos < len(json_str) and json_str[pos] in " \t\n\r":
+                pos += 1
+
+            if pos >= len(json_str):
+                return -1  # Incomplete
+
+            if json_str[pos] == "]":
+                # Array is complete
+                self._mark_complete(path, start_pos, pos + 1)
+                return pos + 1
+
+            if not first:
+                if json_str[pos] != ",":
+                    return -1  # Invalid
+                pos += 1
+                # Skip whitespace after comma
+                while pos < len(json_str) and json_str[pos] in " \t\n\r":
+                    pos += 1
+                if pos >= len(json_str):
+                    return -1
+
+            first = False
+
+            # Parse element
+            child_path = f"{path}[{index}]"
+            pos = self._analyze_structure(json_str, child_path, pos)
+            if pos == -1:
+                return -1  # Incomplete element
+
+            index += 1
+
+        return -1  # Incomplete (no closing bracket)
+
+    def _analyze_string(self, json_str: str, path: str, start_pos: int) -> int:
+        """Analyze a JSON string. Returns end position or -1 if incomplete."""
+        pos = self._skip_string(json_str, start_pos)
+        if pos != -1:
+            self._mark_complete(path, start_pos, pos)
+        return pos
+
+    def _skip_string(self, json_str: str, start_pos: int) -> int:
+        """Skip a JSON string, handling escapes. Returns position after closing quote or -1."""
+        pos = start_pos + 1  # Skip opening quote
+        while pos < len(json_str):
+            c = json_str[pos]
+            if c == "\\":
+                pos += 2  # Skip escape sequence
+            elif c == '"':
+                return pos + 1  # Found closing quote
+            else:
+                pos += 1
+        return -1  # Incomplete string
+
+    def _analyze_number(self, json_str: str, path: str, start_pos: int) -> int:
+        """Analyze a JSON number. Returns end position or -1 if incomplete."""
+        pos = start_pos
+
+        # Optional minus
+        if pos < len(json_str) and json_str[pos] == "-":
+            pos += 1
+
+        # Integer part
+        if pos >= len(json_str):
+            return -1
+        if json_str[pos] == "0":
+            pos += 1
+        elif json_str[pos] in "123456789":
+            pos += 1
+            while pos < len(json_str) and json_str[pos] in "0123456789":
+                pos += 1
+        else:
+            return -1
+
+        # Fractional part
+        if pos < len(json_str) and json_str[pos] == ".":
+            pos += 1
+            if pos >= len(json_str) or json_str[pos] not in "0123456789":
+                return -1  # Incomplete fraction
+            while pos < len(json_str) and json_str[pos] in "0123456789":
+                pos += 1
+
+        # Exponent part
+        if pos < len(json_str) and json_str[pos] in "eE":
+            pos += 1
+            if pos < len(json_str) and json_str[pos] in "+-":
+                pos += 1
+            if pos >= len(json_str) or json_str[pos] not in "0123456789":
+                return -1  # Incomplete exponent
+            while pos < len(json_str) and json_str[pos] in "0123456789":
+                pos += 1
+
+        # Check if we're at a valid terminator (or end of partial JSON)
+        if pos < len(json_str) and json_str[pos] not in " \t\n\r,}]":
+            return -1  # Number continues or is invalid
+
+        self._mark_complete(path, start_pos, pos)
+        return pos
+
+    def _mark_complete(self, path: str, start_pos: int, end_pos: int) -> None:
+        """Mark a path as complete."""
+        self._complete_paths.add(path)
+        self._path_positions[path] = (start_pos, end_pos)
+
+    def is_path_complete(self, path: str) -> bool:
+        """
+        Check if the sub-structure at the given path is complete.
+
+        Args:
+            path: Dot-separated path (e.g., "user.address.city", "items[0]")
+                  Use "" for root object.
+
+        Returns:
+            True if the structure at path is complete (closed), False otherwise.
+        """
+        return path in self._complete_paths
+
+    def get_complete_paths(self) -> set[str]:
+        """Return all paths that are complete."""
+        return self._complete_paths.copy()
+
+    def is_root_complete(self) -> bool:
+        """Check if the root JSON structure is complete."""
+        return "" in self._complete_paths
+
+
+def is_json_complete(json_str: str) -> bool:
+    """
+    Quick check if a JSON string represents a complete structure.
+
+    Uses jiter in strict mode - parsing fails if JSON is incomplete.
+
+    Args:
+        json_str: The JSON string to check
+
+    Returns:
+        True if the JSON is complete (all braces/brackets matched)
+    """
+    from jiter import from_json
+
+    if not json_str or not json_str.strip():
+        return False
+    try:
+        from_json(json_str.encode())  # No partial_mode = strict parsing
+        return True
+    except Exception:
+        return False


### PR DESCRIPTION
## Summary

This PR introduces **completeness-based validation** for `Partial` streaming - a fundamental improvement over the current approach of running validation on every chunk and working around failures.

### The Problem

Field constraints fail during streaming because validation runs on incomplete data:

```python
class User(BaseModel):
    name: str = Field(min_length=5)

# During streaming:
# Chunk 1: {"name": "Al      → ValidationError: min_length=5 failed on "Al"
# Chunk 2: {"name": "Alic    → ValidationError: min_length=5 failed on "Alic"  
# Chunk 3: {"name": "Alice"} → ✓ Finally passes
```

This affects all field constraints: `min_length`, `max_length`, `ge`, `le`, `gt`, `lt`, `pattern`, `multiple_of`, etc.

PR #1994 fixed model validators by wrapping them with streaming context checks, but field constraints still fail.

### The Solution

**Only validate JSON structures that are structurally complete** (closed with matching braces/brackets).

- **Incomplete JSON** (`{"name": "Al`): Use `model_construct()` - skips ALL validation
- **Complete JSON** (`{"name": "Alice"}`): Use `model_validate()` - full validation

This is a principled solution that handles all validation types uniformly, rather than fixing them one at a time.

## Implementation

### New File: `instructor/dsl/json_tracker.py`

`JsonCompleteness` class that analyzes JSON strings to determine which paths are complete:

```python
tracker = JsonCompleteness()
tracker.analyze('{"user": {"name": "Alice"}, "items": [1, 2')

tracker.is_root_complete()           # False - root object not closed
tracker.is_path_complete("user")     # True - user object is closed
tracker.is_path_complete("items")    # False - array not closed
```

Handles edge cases: strings containing braces, escaped quotes, nested structures.

### Modified: `instructor/dsl/partial.py`

1. **`process_potential_object()`** - Now uses completeness-based logic:
   ```python
   if tracker.is_root_complete() and has_data:
       return original_model.model_validate(parsed)  # Full validation
   else:
       return _build_partial_object(...)  # model_construct, no validation
   ```

2. **`_build_partial_object()`** / **`_build_partial_list()`** - Recursively build partial objects, validating only complete nested structures

3. **Deprecated `PartialLiteralMixin`** - No longer needed; emits deprecation warning

4. **Always use `trailing-strings` mode** - Preserves incomplete data during streaming

## Before/After Comparison

| Validation Type | Before (main) | After (this PR) |
|-----------------|---------------|-----------------|
| Field constraints (`min_length`, etc.) | ❌ Fails on incomplete | ✅ Skipped until complete |
| Field validators (`@field_validator`) | ❌ Fails on incomplete | ✅ Skipped until complete |
| Model validators (`@model_validator`) | ⚠️ Context-wrapped | ✅ Skipped via model_construct |
| Literal/Enum types | ⚠️ Needs PartialLiteralMixin | ✅ Automatic |
| Required fields | ⚠️ Complex workarounds | ✅ Skipped until complete |

## Example

```python
from pydantic import BaseModel, Field
from instructor.dsl.partial import Partial

class User(BaseModel):
    name: str = Field(min_length=5)
    email: str

PartialUser = Partial[User]

# This now works - validation skipped on incomplete JSON
chunks = ['{"name": "Al', '{"name": "Alice", "email": "a@b.com"}']
for chunk in chunks:
    for result in PartialUser.model_from_chunks([chunk]):
        print(result.name)  # "Al", then "Alice"
```

## Test Results

All **45 tests pass**, including:
- `TestJsonCompletenessTracker` (14 tests)
- `TestFieldConstraintsDuringStreaming` (7 tests) 
- `TestModelValidatorsDuringStreaming` (4 tests)
- `TestRecursiveModels` (6 tests)

## Breaking Changes

1. **`PartialLiteralMixin` deprecated** - Still works but emits warning. Can be safely removed.

2. **Partial values now preserved** - Incomplete strings like `"act"` are stored instead of dropped. Code checking for `None` to detect incomplete fields should be updated.

3. **Nested model serialization** - `model_dump()` now shows `{"nested": {"field": None}}` instead of `{"nested": {}}` for incomplete nested models.

## Test Plan

- [x] All 45 partial tests pass
- [x] Manual verification of field constraints, model validators, nested models
- [x] Verified failure on main, success on this branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Introduces completeness-based validation for streaming JSON, validating only complete structures and deprecating `PartialLiteralMixin`.
> 
>   - **Behavior**:
>     - Introduces completeness-based validation for streaming JSON in `partial.py`, using `JsonCompleteness` from `json_tracker.py`.
>     - Validates only complete JSON structures, skipping validation for incomplete data.
>     - Deprecates `PartialLiteralMixin`, as completeness-based validation handles Literals and Enums automatically.
>   - **Implementation**:
>     - Adds `JsonCompleteness` class in `json_tracker.py` to track JSON completeness.
>     - Updates `process_potential_object()` in `partial.py` to use completeness-based logic.
>     - Modifies `_build_partial_object()` and `_build_partial_list()` in `partial.py` to handle partial data without validation.
>   - **Tests**:
>     - Updates tests in `test_partial.py` to verify completeness-based validation.
>     - Ensures tests cover scenarios for incomplete and complete JSON data, model validators, and recursive models.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=567-labs%2Finstructor&utm_source=github&utm_medium=referral)<sup> for 91cc3431a37408f6ed188d238569f197eb1eb6ca. You can [customize](https://app.ellipsis.dev/567-labs/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->