### PR TITLE
Responses API validation error

### DIFF
--- a/instructor/providers/openai/utils.py
+++ b/instructor/providers/openai/utils.py
@@ -28,6 +28,37 @@ def _is_stream_response(response: Any) -> bool:
     return response is None or not hasattr(response, "choices")
 
 
+def _filter_responses_tool_calls(output_items: list[Any]) -> list[Any]:
+    """Return response output items that represent tool calls."""
+    tool_calls: list[Any] = []
+    for item in output_items:
+        item_type = getattr(item, "type", None)
+        if item_type in {"function_call", "tool_call"}:
+            tool_calls.append(item)
+            continue
+        if item_type is None and hasattr(item, "arguments"):
+            tool_calls.append(item)
+    return tool_calls
+
+
+def _format_responses_tool_call_details(tool_call: Any) -> str:
+    """Format tool call name/id details for reask messages."""
+    tool_name = getattr(tool_call, "name", None)
+    tool_id = (
+        getattr(tool_call, "id", None)
+        or getattr(tool_call, "call_id", None)
+        or getattr(tool_call, "tool_call_id", None)
+    )
+    details: list[str] = []
+    if tool_name:
+        details.append(f"name={tool_name}")
+    if tool_id:
+        details.append(f"id={tool_id}")
+    if not details:
+        return ""
+    return f" (tool call {', '.join(details)})"
+
+
 def reask_tools(
     kwargs: dict[str, Any],
     response: Any,
@@ -100,14 +131,15 @@ def reask_responses_tools(
         return kwargs
 
     reask_messages = []
-    for tool_call in response.output:
-        if not hasattr(tool_call, "arguments"):
-            continue
+    for tool_call in _filter_responses_tool_calls(response.output):
+        details = _format_responses_tool_call_details(tool_call)
         reask_messages.append(
             {
                 "role": "user",  # type: ignore
                 "content": (
-                    f"Validation Error found:\n{exception}\nRecall the function correctly, fix the errors with {tool_call.arguments}"
+                    f"Validation Error found:\n{exception}\n"
+                    "Recall the function correctly, fix the errors with "
+                    f"{tool_call.arguments}{details}"
                 ),
             }
         )


### PR DESCRIPTION
fix: Prevent `reaskresponsestools` from crashing with reasoning items

## Describe your changes

Adds a check for `hasattr(tool_call, "arguments")` in the `reask_responses_tools` function. This prevents the function from attempting to access the `.arguments` attribute on `ResponseReasoningItem` objects, which do not have it, thus resolving a bug where validation errors were not properly sent back to the LLM during retry attempts when using reasoning models.

## Issue ticket number and link

567-251: [https://github.com/567-labs/instructor/issues/1957](https://github.com/567-labs/instructor/issues/1957)

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
- [ ] If it is a core feature, I have added thorough tests.
- [ ] If it is a core feature, I have added documentation.

---
Linear Issue: [567-251](https://linear.app/fivesixseven/issue/567-251/fix-validation-error-handling-in-responses-api-github-1957)

<a href="https://cursor.com/background-agent?bcId=bc-bab08456-7051-4bd5-b617-6beafadc25b9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-bab08456-7051-4bd5-b617-6beafadc25b9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>


<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes crash in `reask_responses_tools` by checking for `arguments` attribute, ensuring proper handling of reasoning items.
> 
>   - **Behavior**:
>     - Adds `hasattr(tool_call, "arguments")` check in `reask_responses_tools` to prevent crashes with `ResponseReasoningItem` objects.
>     - Ensures validation errors are sent back to LLM during retries.
>   - **Functions**:
>     - Adds `_filter_responses_tool_calls()` to filter tool calls in `utils.py`.
>     - Adds `_format_responses_tool_call_details()` to format tool call details in `utils.py`.
>   - **Tests**:
>     - Adds `test_reask_responses_tools_skips_reasoning_items_and_includes_details` in `test_streaming_reask_bug.py` to verify reasoning items are skipped and tool details are included.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=567-labs%2Finstructor&utm_source=github&utm_medium=referral)<sup> for 8ad4b0b35e7c12854dd158b4082c8a42b474615e. You can [customize](https://app.ellipsis.dev/567-labs/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->