### PR TITLE
Token truncation handling

### DIFF
--- a/docs/concepts/error_handling.md
+++ b/docs/concepts/error_handling.md
@@ -56,6 +56,26 @@ except IncompleteOutputException as e:
     print(f"Last completion: {e.last_completion}")
 ```
 
+You can also control truncation retries directly:
+
+```python
+# Fail fast when output is truncated
+response = client.create(
+    response_model=DetailedReport,
+    messages=[{"role": "user", "content": "Write a very long report..."}],
+    max_tokens=200,
+    failfast_on_truncation=True,
+)
+
+# Auto-ramp max_tokens when truncation happens
+response = client.create(
+    response_model=DetailedReport,
+    messages=[{"role": "user", "content": "Write a very long report..."}],
+    max_tokens=200,
+    max_tokens_auto_ramp={"multiplier": 1.5, "cap": 2000, "max_attempts": 2},
+)
+```
+
 #### `InstructorRetryException`
 Raised when all retry attempts have been exhausted.
 
@@ -221,6 +241,12 @@ except IncompleteOutputException as e:
     # Handle truncated output - maybe increase max_tokens
     logger.warning(f"Output truncated, retrying with more tokens")
     response = client.create(..., max_tokens=2000)
+    # Or let Instructor handle it for you
+    response = client.create(
+        ...,
+        max_tokens=2000,
+        max_tokens_auto_ramp={"multiplier": 1.5, "cap": 4000, "max_attempts": 2},
+    )
 except InstructorRetryException as e:
     # Handle retry exhaustion - maybe fallback logic
     logger.error(f"Failed after {e.n_attempts} attempts")

--- a/docs/concepts/retrying.md
+++ b/docs/concepts/retrying.md
@@ -453,6 +453,27 @@ def double_retry_extraction(text: str) -> UserInfo:
     )
 ```
 
+## Truncation Handling
+
+When a response is cut off by max tokens, you can stop retries or auto-ramp the
+token limit.
+
+```python
+result = client.create(
+    response_model=UserInfo,
+    messages=[{"role": "user", "content": "Extract details"}],
+    max_tokens=300,
+    failfast_on_truncation=True,
+)
+
+result = client.create(
+    response_model=UserInfo,
+    messages=[{"role": "user", "content": "Extract details"}],
+    max_tokens=300,
+    max_tokens_auto_ramp={"multiplier": 1.5, "cap": 1200, "max_attempts": 2},
+)
+```
+
 ## Failed Attempts Tracking
 
 Instructor's retry system now tracks all failed attempts with detailed context for better debugging and error handling.

--- a/instructor/core/client.py
+++ b/instructor/core/client.py
@@ -25,6 +25,7 @@ from typing_extensions import Self
 from pydantic import BaseModel
 from ..dsl.partial import Partial
 from .hooks import Hooks, HookName
+from .retry import MaxTokensAutoRampConfig
 
 
 T = TypeVar("T", bound=Union[BaseModel, "Iterable[Any]", "Partial[Any]"])
@@ -45,6 +46,8 @@ class Response:
         validation_context: dict[str, Any] | None = None,
         context: dict[str, Any] | None = None,
         strict: bool = True,
+        failfast_on_truncation: bool = False,
+        max_tokens_auto_ramp: MaxTokensAutoRampConfig | bool | None = None,
         **kwargs,
     ) -> T | Any:
         if isinstance(input, str):
@@ -61,6 +64,8 @@ class Response:
             context=context,
             max_retries=max_retries,
             strict=strict,
+            failfast_on_truncation=failfast_on_truncation,
+            max_tokens_auto_ramp=max_tokens_auto_ramp,
             messages=input,
             **kwargs,
         )
@@ -70,6 +75,8 @@ class Response:
         input: str | list[ChatCompletionMessageParam],
         response_model: type[T],
         max_retries: int | Retrying = 3,
+        failfast_on_truncation: bool = False,
+        max_tokens_auto_ramp: MaxTokensAutoRampConfig | bool | None = None,
         **kwargs,
     ) -> tuple[T, Any]:
         if isinstance(input, str):
@@ -84,6 +91,8 @@ class Response:
             messages=input,
             response_model=response_model,
             max_retries=max_retries,
+            failfast_on_truncation=failfast_on_truncation,
+            max_tokens_auto_ramp=max_tokens_auto_ramp,
             **kwargs,
         )
 
@@ -92,6 +101,8 @@ class Response:
         input: str | list[ChatCompletionMessageParam],
         response_model: type[T],
         max_retries: int | Retrying = 3,
+        failfast_on_truncation: bool = False,
+        max_tokens_auto_ramp: MaxTokensAutoRampConfig | bool | None = None,
         **kwargs,
     ) -> Generator[T, None, None]:
         if isinstance(input, str):
@@ -106,6 +117,8 @@ class Response:
             messages=input,
             response_model=response_model,
             max_retries=max_retries,
+            failfast_on_truncation=failfast_on_truncation,
+            max_tokens_auto_ramp=max_tokens_auto_ramp,
             **kwargs,
         )
 
@@ -114,6 +127,8 @@ class Response:
         input: str | list[ChatCompletionMessageParam],
         response_model: type[T],
         max_retries: int | Retrying = 3,
+        failfast_on_truncation: bool = False,
+        max_tokens_auto_ramp: MaxTokensAutoRampConfig | bool | None = None,
         **kwargs,
     ) -> Generator[T, None, None]:
         if isinstance(input, str):
@@ -128,6 +143,8 @@ class Response:
             messages=input,
             response_model=response_model,
             max_retries=max_retries,
+            failfast_on_truncation=failfast_on_truncation,
+            max_tokens_auto_ramp=max_tokens_auto_ramp,
             **kwargs,
         )
 
@@ -144,6 +161,8 @@ class AsyncResponse(Response):
         validation_context: dict[str, Any] | None = None,
         context: dict[str, Any] | None = None,
         strict: bool = True,
+        failfast_on_truncation: bool = False,
+        max_tokens_auto_ramp: MaxTokensAutoRampConfig | bool | None = None,
         **kwargs,
     ) -> T | Any:
         if isinstance(input, str):
@@ -160,6 +179,8 @@ class AsyncResponse(Response):
             context=context,
             max_retries=max_retries,
             strict=strict,
+            failfast_on_truncation=failfast_on_truncation,
+            max_tokens_auto_ramp=max_tokens_auto_ramp,
             messages=input,
             **kwargs,
         )
@@ -169,6 +190,8 @@ class AsyncResponse(Response):
         input: str | list[ChatCompletionMessageParam],
         response_model: type[T],
         max_retries: int | AsyncRetrying = 3,
+        failfast_on_truncation: bool = False,
+        max_tokens_auto_ramp: MaxTokensAutoRampConfig | bool | None = None,
         **kwargs,
     ) -> tuple[T, Any]:
         if isinstance(input, str):
@@ -183,6 +206,8 @@ class AsyncResponse(Response):
             messages=input,
             response_model=response_model,
             max_retries=max_retries,
+            failfast_on_truncation=failfast_on_truncation,
+            max_tokens_auto_ramp=max_tokens_auto_ramp,
             **kwargs,
         )
 
@@ -191,6 +216,8 @@ class AsyncResponse(Response):
         input: str | list[ChatCompletionMessageParam],
         response_model: type[T],
         max_retries: int | AsyncRetrying = 3,
+        failfast_on_truncation: bool = False,
+        max_tokens_auto_ramp: MaxTokensAutoRampConfig | bool | None = None,
         **kwargs,
     ) -> AsyncGenerator[T, None]:
         if isinstance(input, str):
@@ -205,6 +232,8 @@ class AsyncResponse(Response):
             messages=input,
             response_model=response_model,
             max_retries=max_retries,
+            failfast_on_truncation=failfast_on_truncation,
+            max_tokens_auto_ramp=max_tokens_auto_ramp,
             **kwargs,
         )
 
@@ -313,6 +342,8 @@ class Instructor:
         context: dict[str, Any] | None = None,  # {{ edit_1 }}
         strict: bool = True,
         hooks: Hooks | None = None,
+        failfast_on_truncation: bool = False,
+        max_tokens_auto_ramp: MaxTokensAutoRampConfig | bool | None = None,
         **kwargs: Any,
     ) -> Awaitable[T]: ...
 
@@ -326,6 +357,8 @@ class Instructor:
         context: dict[str, Any] | None = None,  # {{ edit_1 }}
         strict: bool = True,
         hooks: Hooks | None = None,
+        failfast_on_truncation: bool = False,
+        max_tokens_auto_ramp: MaxTokensAutoRampConfig | bool | None = None,
         **kwargs: Any,
     ) -> T: ...
 
@@ -339,6 +372,8 @@ class Instructor:
         context: dict[str, Any] | None = None,  # {{ edit_1 }}
         strict: bool = True,
         hooks: Hooks | None = None,
+        failfast_on_truncation: bool = False,
+        max_tokens_auto_ramp: MaxTokensAutoRampConfig | bool | None = None,
         **kwargs: Any,
     ) -> Awaitable[Any]: ...
 
@@ -352,6 +387,8 @@ class Instructor:
         context: dict[str, Any] | None = None,  # {{ edit_1 }}
         strict: bool = True,
         hooks: Hooks | None = None,
+        failfast_on_truncation: bool = False,
+        max_tokens_auto_ramp: MaxTokensAutoRampConfig | bool | None = None,
         **kwargs: Any,
     ) -> Any: ...
 
@@ -364,6 +401,8 @@ class Instructor:
         context: dict[str, Any] | None = None,
         strict: bool = True,
         hooks: Hooks | None = None,
+        failfast_on_truncation: bool = False,
+        max_tokens_auto_ramp: MaxTokensAutoRampConfig | bool | None = None,
         **kwargs: Any,
     ) -> T | Any | Awaitable[T] | Awaitable[Any]:
         kwargs = self.handle_kwargs(kwargs)
@@ -381,6 +420,8 @@ class Instructor:
             context=context,
             strict=strict,
             hooks=combined_hooks,
+            failfast_on_truncation=failfast_on_truncation,
+            max_tokens_auto_ramp=max_tokens_auto_ramp,
             **kwargs,
         )
 
@@ -394,6 +435,8 @@ class Instructor:
         context: dict[str, Any] | None = None,  # {{ edit_1 }}
         strict: bool = True,
         hooks: Hooks | None = None,
+        failfast_on_truncation: bool = False,
+        max_tokens_auto_ramp: MaxTokensAutoRampConfig | bool | None = None,
         **kwargs: Any,
     ) -> AsyncGenerator[T, None]: ...
 
@@ -407,6 +450,8 @@ class Instructor:
         context: dict[str, Any] | None = None,
         strict: bool = True,
         hooks: Hooks | None = None,
+        failfast_on_truncation: bool = False,
+        max_tokens_auto_ramp: MaxTokensAutoRampConfig | bool | None = None,
         **kwargs: Any,
     ) -> Generator[T, None, None]: ...
 
@@ -419,6 +464,8 @@ class Instructor:
         context: dict[str, Any] | None = None,
         strict: bool = True,
         hooks: Hooks | None = None,
+        failfast_on_truncation: bool = False,
+        max_tokens_auto_ramp: MaxTokensAutoRampConfig | bool | None = None,
         **kwargs: Any,
     ) -> Generator[T, None, None] | AsyncGenerator[T, None]:
         kwargs["stream"] = True
@@ -439,6 +486,8 @@ class Instructor:
             context=context,
             strict=strict,
             hooks=combined_hooks,
+            failfast_on_truncation=failfast_on_truncation,
+            max_tokens_auto_ramp=max_tokens_auto_ramp,
             **kwargs,
         )
 
@@ -452,6 +501,8 @@ class Instructor:
         context: dict[str, Any] | None = None,
         strict: bool = True,
         hooks: Hooks | None = None,
+        failfast_on_truncation: bool = False,
+        max_tokens_auto_ramp: MaxTokensAutoRampConfig | bool | None = None,
         **kwargs: Any,
     ) -> AsyncGenerator[T, None]: ...
 
@@ -465,6 +516,8 @@ class Instructor:
         context: dict[str, Any] | None = None,
         strict: bool = True,
         hooks: Hooks | None = None,
+        failfast_on_truncation: bool = False,
+        max_tokens_auto_ramp: MaxTokensAutoRampConfig | bool | None = None,
         **kwargs: Any,
     ) -> Generator[T, None, None]: ...
 
@@ -477,6 +530,8 @@ class Instructor:
         context: dict[str, Any] | None = None,
         strict: bool = True,
         hooks: Hooks | None = None,
+        failfast_on_truncation: bool = False,
+        max_tokens_auto_ramp: MaxTokensAutoRampConfig | bool | None = None,
         **kwargs: Any,
     ) -> Generator[T, None, None] | AsyncGenerator[T, None]:
         kwargs["stream"] = True
@@ -496,6 +551,8 @@ class Instructor:
             context=context,
             strict=strict,
             hooks=combined_hooks,
+            failfast_on_truncation=failfast_on_truncation,
+            max_tokens_auto_ramp=max_tokens_auto_ramp,
             **kwargs,
         )
 
@@ -509,6 +566,8 @@ class Instructor:
         context: dict[str, Any] | None = None,
         strict: bool = True,
         hooks: Hooks | None = None,
+        failfast_on_truncation: bool = False,
+        max_tokens_auto_ramp: MaxTokensAutoRampConfig | bool | None = None,
         **kwargs: Any,
     ) -> Awaitable[tuple[T, Any]]: ...
 
@@ -522,6 +581,8 @@ class Instructor:
         context: dict[str, Any] | None = None,
         strict: bool = True,
         hooks: Hooks | None = None,
+        failfast_on_truncation: bool = False,
+        max_tokens_auto_ramp: MaxTokensAutoRampConfig | bool | None = None,
         **kwargs: Any,
     ) -> tuple[T, Any]: ...
 
@@ -534,6 +595,8 @@ class Instructor:
         context: dict[str, Any] | None = None,
         strict: bool = True,
         hooks: Hooks | None = None,
+        failfast_on_truncation: bool = False,
+        max_tokens_auto_ramp: MaxTokensAutoRampConfig | bool | None = None,
         **kwargs: Any,
     ) -> tuple[T, Any] | Awaitable[tuple[T, Any]]:
         kwargs = self.handle_kwargs(kwargs)
@@ -551,6 +614,8 @@ class Instructor:
             context=context,
             strict=strict,
             hooks=combined_hooks,
+            failfast_on_truncation=failfast_on_truncation,
+            max_tokens_auto_ramp=max_tokens_auto_ramp,
             **kwargs,
         )
         return model, model._raw_response
@@ -614,6 +679,8 @@ class AsyncInstructor(Instructor):
         context: dict[str, Any] | None = None,
         strict: bool = True,
         hooks: Hooks | None = None,
+        failfast_on_truncation: bool = False,
+        max_tokens_auto_ramp: MaxTokensAutoRampConfig | bool | None = None,
         **kwargs: Any,
     ) -> T | Any:
         kwargs = self.handle_kwargs(kwargs)
@@ -643,6 +710,8 @@ class AsyncInstructor(Instructor):
                 context=context,
                 strict=strict,
                 hooks=hooks,  # Pass the per-call hooks to create_iterable
+                failfast_on_truncation=failfast_on_truncation,
+                max_tokens_auto_ramp=max_tokens_auto_ramp,
                 **kwargs,
             )
 
@@ -654,6 +723,8 @@ class AsyncInstructor(Instructor):
             messages=messages,
             strict=strict,
             hooks=combined_hooks,
+            failfast_on_truncation=failfast_on_truncation,
+            max_tokens_auto_ramp=max_tokens_auto_ramp,
             **kwargs,
         )
 
@@ -666,6 +737,8 @@ class AsyncInstructor(Instructor):
         context: dict[str, Any] | None = None,
         strict: bool = True,
         hooks: Hooks | None = None,
+        failfast_on_truncation: bool = False,
+        max_tokens_auto_ramp: MaxTokensAutoRampConfig | bool | None = None,
         **kwargs: Any,
     ) -> AsyncGenerator[T, None]:
         kwargs = self.handle_kwargs(kwargs)
@@ -684,6 +757,8 @@ class AsyncInstructor(Instructor):
             messages=messages,
             strict=strict,
             hooks=combined_hooks,
+            failfast_on_truncation=failfast_on_truncation,
+            max_tokens_auto_ramp=max_tokens_auto_ramp,
             **kwargs,
         ):
             yield item
@@ -697,6 +772,8 @@ class AsyncInstructor(Instructor):
         context: dict[str, Any] | None = None,
         strict: bool = True,
         hooks: Hooks | None = None,
+        failfast_on_truncation: bool = False,
+        max_tokens_auto_ramp: MaxTokensAutoRampConfig | bool | None = None,
         **kwargs: Any,
     ) -> AsyncGenerator[T, None]:
         kwargs = self.handle_kwargs(kwargs)
@@ -715,6 +792,8 @@ class AsyncInstructor(Instructor):
             messages=messages,
             strict=strict,
             hooks=combined_hooks,
+            failfast_on_truncation=failfast_on_truncation,
+            max_tokens_auto_ramp=max_tokens_auto_ramp,
             **kwargs,
         ):
             yield item
@@ -728,6 +807,8 @@ class AsyncInstructor(Instructor):
         context: dict[str, Any] | None = None,
         strict: bool = True,
         hooks: Hooks | None = None,
+        failfast_on_truncation: bool = False,
+        max_tokens_auto_ramp: MaxTokensAutoRampConfig | bool | None = None,
         **kwargs: Any,
     ) -> tuple[T, Any]:
         kwargs = self.handle_kwargs(kwargs)
@@ -745,6 +826,8 @@ class AsyncInstructor(Instructor):
             messages=messages,
             strict=strict,
             hooks=combined_hooks,
+            failfast_on_truncation=failfast_on_truncation,
+            max_tokens_auto_ramp=max_tokens_auto_ramp,
             **kwargs,
         )
         return response, response._raw_response

--- a/instructor/core/patch.py
+++ b/instructor/core/patch.py
@@ -14,7 +14,7 @@ from openai import AsyncOpenAI, OpenAI  # type: ignore[import-not-found]
 from pydantic import BaseModel  # type: ignore[import-not-found]
 
 from ..processing.response import handle_response_model
-from .retry import retry_async, retry_sync
+from .retry import MaxTokensAutoRampConfig, retry_async, retry_sync
 from ..utils import is_async
 from .hooks import Hooks
 from ..templating import handle_templating
@@ -41,6 +41,8 @@ class InstructorChatCompletionCreate(Protocol):
         validation_context: dict[str, Any] | None = None,  # Deprecate in 2.0
         context: dict[str, Any] | None = None,
         max_retries: int | Retrying = 1,
+        failfast_on_truncation: bool = False,
+        max_tokens_auto_ramp: MaxTokensAutoRampConfig | bool | None = None,
         *args: Any,
         **kwargs: Any,
     ) -> T_Model: ...
@@ -53,6 +55,8 @@ class AsyncInstructorChatCompletionCreate(Protocol):
         validation_context: dict[str, Any] | None = None,  # Deprecate in 2.0
         context: dict[str, Any] | None = None,
         max_retries: int | AsyncRetrying = 1,
+        failfast_on_truncation: bool = False,
+        max_tokens_auto_ramp: MaxTokensAutoRampConfig | bool | None = None,
         *args: Any,
         **kwargs: Any,
     ) -> T_Model: ...
@@ -129,6 +133,8 @@ def patch(  # type: ignore
     - `validation_context` parameter to validate the response using the pydantic model
     - `strict` parameter to use strict json parsing
     - `hooks` parameter to hook into the completion process
+    - `failfast_on_truncation` parameter to stop retries on truncation
+    - `max_tokens_auto_ramp` parameter to increase max tokens on truncation
     """
 
     logger.debug(f"Patching `client.chat.completions.create` with {mode=}")
@@ -150,6 +156,8 @@ def patch(  # type: ignore
         max_retries: int | AsyncRetrying = 1,
         strict: bool = True,
         hooks: Hooks | None = None,
+        failfast_on_truncation: bool = False,
+        max_tokens_auto_ramp: MaxTokensAutoRampConfig | bool | None = None,
         *args: T_ParamSpec.args,
         **kwargs: T_ParamSpec.kwargs,
     ) -> T_Model:
@@ -190,6 +198,8 @@ def patch(  # type: ignore
             response_model=response_model,
             context=context,
             max_retries=max_retries,
+            failfast_on_truncation=failfast_on_truncation,
+            max_tokens_auto_ramp=max_tokens_auto_ramp,
             args=args,
             kwargs=new_kwargs,
             strict=strict,
@@ -219,6 +229,8 @@ def patch(  # type: ignore
         max_retries: int | Retrying = 1,
         strict: bool = True,
         hooks: Hooks | None = None,
+        failfast_on_truncation: bool = False,
+        max_tokens_auto_ramp: MaxTokensAutoRampConfig | bool | None = None,
         *args: T_ParamSpec.args,
         **kwargs: T_ParamSpec.kwargs,
     ) -> T_Model:
@@ -265,6 +277,8 @@ def patch(  # type: ignore
             strict=strict,
             kwargs=new_kwargs,
             mode=mode,
+            failfast_on_truncation=failfast_on_truncation,
+            max_tokens_auto_ramp=max_tokens_auto_ramp,
         )
 
         # Save to cache

--- a/instructor/core/retry.py
+++ b/instructor/core/retry.py
@@ -3,13 +3,16 @@
 from __future__ import annotations
 
 import logging
+import math
 from json import JSONDecodeError
-from typing import Any, Callable, TypeVar
+from typing import Any, Callable, NamedTuple, TypeVar, TypedDict
 
 from .exceptions import (
-    InstructorRetryException,
     AsyncValidationError,
+    ConfigurationError,
     FailedAttempt,
+    IncompleteOutputException,
+    InstructorRetryException,
     ValidationError as InstructorValidationError,
 )
 from .hooks import Hooks
@@ -31,6 +34,7 @@ from tenacity import (
     AsyncRetrying,
     RetryError,
     Retrying,
+    retry_if_exception,
     stop_after_attempt,
     stop_after_delay,
 )
@@ -45,10 +49,196 @@ T_ParamSpec = ParamSpec("T_ParamSpec")
 T = TypeVar("T")
 
 
+class MaxTokensAutoRampConfig(TypedDict, total=False):
+    """Configuration for auto-ramping max tokens on truncation."""
+
+    multiplier: float
+    cap: int | None
+    max_attempts: int
+
+
+class _ResolvedMaxTokensAutoRamp(NamedTuple):
+    multiplier: float
+    cap: int | None
+    max_attempts: int
+
+
+def _is_positive_int(value: Any) -> bool:
+    return isinstance(value, int) and not isinstance(value, bool) and value > 0
+
+
+def _resolve_max_tokens_auto_ramp(
+    config: MaxTokensAutoRampConfig | bool | None,
+) -> _ResolvedMaxTokensAutoRamp | None:
+    if config is None or config is False:
+        return None
+    if config is True:
+        config = {}
+    if not isinstance(config, dict):
+        raise ConfigurationError(
+            "max_tokens_auto_ramp must be a dict, True, or None."
+        )
+
+    multiplier = config.get("multiplier", 1.5)
+    cap = config.get("cap")
+    max_attempts = config.get("max_attempts", 1)
+
+    if isinstance(multiplier, bool) or not isinstance(multiplier, (int, float)):
+        raise ConfigurationError(
+            "max_tokens_auto_ramp.multiplier must be a number greater than 1."
+        )
+    if multiplier <= 1:
+        raise ConfigurationError(
+            "max_tokens_auto_ramp.multiplier must be greater than 1."
+        )
+    if not _is_positive_int(max_attempts):
+        raise ConfigurationError(
+            "max_tokens_auto_ramp.max_attempts must be a positive integer."
+        )
+    if cap is not None and not _is_positive_int(cap):
+        raise ConfigurationError("max_tokens_auto_ramp.cap must be a positive integer.")
+
+    return _ResolvedMaxTokensAutoRamp(
+        multiplier=float(multiplier),
+        cap=cap,
+        max_attempts=max_attempts,
+    )
+
+
+def _calculate_ramped_max_tokens(
+    current: int, ramp: _ResolvedMaxTokensAutoRamp
+) -> int | None:
+    if current <= 0:
+        return None
+    new_value = max(current + 1, int(math.ceil(current * ramp.multiplier)))
+    if ramp.cap is not None:
+        if ramp.cap <= current:
+            return None
+        new_value = min(new_value, ramp.cap)
+    if new_value <= current:
+        return None
+    return new_value
+
+
+def _find_max_tokens_target(
+    kwargs: dict[str, Any],
+) -> tuple[str, int, Callable[[int], None]] | None:
+    if _is_positive_int(kwargs.get("max_tokens")):
+        return (
+            "max_tokens",
+            kwargs["max_tokens"],
+            lambda value: kwargs.__setitem__("max_tokens", value),
+        )
+    if _is_positive_int(kwargs.get("max_output_tokens")):
+        return (
+            "max_output_tokens",
+            kwargs["max_output_tokens"],
+            lambda value: kwargs.__setitem__("max_output_tokens", value),
+        )
+
+    generation_config = kwargs.get("generation_config")
+    if isinstance(generation_config, dict) and _is_positive_int(
+        generation_config.get("max_output_tokens")
+    ):
+        return (
+            "generation_config.max_output_tokens",
+            generation_config["max_output_tokens"],
+            lambda value: generation_config.__setitem__("max_output_tokens", value),
+        )
+
+    inference_config = kwargs.get("inferenceConfig")
+    if isinstance(inference_config, dict) and _is_positive_int(
+        inference_config.get("maxTokens")
+    ):
+        return (
+            "inferenceConfig.maxTokens",
+            inference_config["maxTokens"],
+            lambda value: inference_config.__setitem__("maxTokens", value),
+        )
+
+    if _is_positive_int(kwargs.get("maxTokens")):
+        return (
+            "maxTokens",
+            kwargs["maxTokens"],
+            lambda value: kwargs.__setitem__("maxTokens", value),
+        )
+
+    config = kwargs.get("config")
+    if isinstance(config, dict) and _is_positive_int(config.get("max_output_tokens")):
+        return (
+            "config.max_output_tokens",
+            config["max_output_tokens"],
+            lambda value: config.__setitem__("max_output_tokens", value),
+        )
+    if config is not None and hasattr(config, "max_output_tokens"):
+        current = getattr(config, "max_output_tokens", None)
+        if _is_positive_int(current):
+            return (
+                "config.max_output_tokens",
+                current,
+                lambda value: setattr(config, "max_output_tokens", value),
+            )
+
+    return None
+
+
+def _apply_max_tokens_ramp(
+    kwargs: dict[str, Any], ramp: _ResolvedMaxTokensAutoRamp
+) -> bool:
+    target = _find_max_tokens_target(kwargs)
+    if target is None:
+        logger.debug("Auto-ramp skipped: no max token setting found.")
+        return False
+
+    target_name, current, setter = target
+    new_value = _calculate_ramped_max_tokens(current, ramp)
+    if new_value is None:
+        logger.debug(
+            "Auto-ramp skipped: token cap prevents increase (%s=%s).",
+            target_name,
+            current,
+        )
+        return False
+
+    try:
+        setter(new_value)
+    except Exception as exc:
+        logger.debug(
+            "Auto-ramp failed to set %s: %s", target_name, exc, exc_info=True
+        )
+        return False
+
+    logger.debug(
+        "Auto-ramped %s from %s to %s.", target_name, current, new_value
+    )
+    return True
+
+
+def _build_retry_predicate(
+    *,
+    failfast_on_truncation: bool,
+    auto_ramp: _ResolvedMaxTokensAutoRamp | None,
+    truncation_state: dict[str, Any],
+):
+    if not failfast_on_truncation and auto_ramp is None:
+        return None
+
+    def _should_retry(exception: Exception) -> bool:
+        if isinstance(exception, IncompleteOutputException):
+            if failfast_on_truncation:
+                return False
+            if truncation_state.get("stop", False):
+                return False
+        return True
+
+    return retry_if_exception(_should_retry)
+
+
 def initialize_retrying(
     max_retries: int | Retrying | AsyncRetrying,
     is_async: bool,
     timeout: float | None = None,
+    retry: Any | None = None,
 ):
     """
     Initialize the retrying mechanism based on the type (synchronous or asynchronous).
@@ -75,16 +265,26 @@ def initialize_retrying(
         for condition in stop_conditions[1:]:
             stop_condition = stop_condition | condition
 
+        retry_kwargs = {"stop": stop_condition}
+        if retry is not None:
+            retry_kwargs["retry"] = retry
         if is_async:
-            max_retries = AsyncRetrying(stop=stop_condition)
+            max_retries = AsyncRetrying(**retry_kwargs)
         else:
-            max_retries = Retrying(stop=stop_condition)
+            max_retries = Retrying(**retry_kwargs)
     elif not isinstance(max_retries, (Retrying, AsyncRetrying)):
         from .exceptions import ConfigurationError
 
         raise ConfigurationError(
             "max_retries must be an int or a `tenacity.Retrying`/`tenacity.AsyncRetrying` object"
         )
+    elif retry is not None:
+        try:
+            max_retries.retry = max_retries.retry & retry  # type: ignore[assignment]
+        except Exception as exc:  # pragma: no cover - defensive fallback
+            logger.debug(
+                "Failed to combine retry predicates: %s", exc, exc_info=True
+            )
     return max_retries
 
 
@@ -150,6 +350,8 @@ def retry_sync(
     strict: bool | None = None,
     mode: Mode = Mode.TOOLS,
     hooks: Hooks | None = None,
+    failfast_on_truncation: bool = False,
+    max_tokens_auto_ramp: MaxTokensAutoRampConfig | bool | None = None,
 ) -> T_Model | None:
     """
     Retry a synchronous function upon specified exceptions.
@@ -164,6 +366,9 @@ def retry_sync(
         strict (Optional[bool], optional): Strict mode flag. Defaults to None.
         mode (Mode, optional): The mode of operation. Defaults to Mode.TOOLS.
         hooks (Optional[Hooks], optional): Hooks for emitting events. Defaults to None.
+        failfast_on_truncation (bool, optional): Stop retries on truncation. Defaults to False.
+        max_tokens_auto_ramp (MaxTokensAutoRampConfig | bool | None, optional):
+            Auto-increase max tokens on truncation. Defaults to None.
 
     Returns:
         T_Model | None: The processed response model or None.
@@ -175,7 +380,16 @@ def retry_sync(
     total_usage = initialize_usage(mode)
     # Extract timeout from kwargs if available (for global timeout across retries)
     timeout = kwargs.get("timeout")
-    max_retries = initialize_retrying(max_retries, is_async=False, timeout=timeout)
+    truncation_state = {"attempts": 0, "stop": False}
+    auto_ramp = _resolve_max_tokens_auto_ramp(max_tokens_auto_ramp)
+    retry_predicate = _build_retry_predicate(
+        failfast_on_truncation=failfast_on_truncation,
+        auto_ramp=auto_ramp,
+        truncation_state=truncation_state,
+    )
+    max_retries = initialize_retrying(
+        max_retries, is_async=False, timeout=timeout, retry=retry_predicate
+    )
 
     # Pre-extract stream flag to avoid repeated lookup
     stream = kwargs.get("stream", False)
@@ -204,6 +418,32 @@ def retry_sync(
                         mode=mode,
                         stream=stream,
                     )
+                except IncompleteOutputException as e:
+                    logger.debug(f"Truncated output: {e}")
+                    hooks.emit_parse_error(e)
+
+                    failed_attempts.append(
+                        FailedAttempt(
+                            attempt_number=attempt.retry_state.attempt_number,
+                            exception=e,
+                            completion=response,
+                        )
+                    )
+
+                    truncation_state["attempts"] += 1
+                    stop_retry = False
+                    if failfast_on_truncation:
+                        stop_retry = True
+                    elif auto_ramp is not None:
+                        if truncation_state["attempts"] > auto_ramp.max_attempts:
+                            stop_retry = True
+                        elif not _apply_max_tokens_ramp(kwargs, auto_ramp):
+                            stop_retry = True
+
+                    truncation_state["stop"] = stop_retry
+                    if stop_retry:
+                        hooks.emit_completion_last_attempt(e)
+                    raise e
                 except (
                     ValidationError,
                     JSONDecodeError,
@@ -306,6 +546,8 @@ async def retry_async(
     strict: bool | None = None,
     mode: Mode = Mode.TOOLS,
     hooks: Hooks | None = None,
+    failfast_on_truncation: bool = False,
+    max_tokens_auto_ramp: MaxTokensAutoRampConfig | bool | None = None,
 ) -> T_Model | None:
     """
     Retry an asynchronous function upon specified exceptions.
@@ -320,6 +562,9 @@ async def retry_async(
         strict (Optional[bool], optional): Strict mode flag. Defaults to None.
         mode (Mode, optional): The mode of operation. Defaults to Mode.TOOLS.
         hooks (Optional[Hooks], optional): Hooks for emitting events. Defaults to None.
+        failfast_on_truncation (bool, optional): Stop retries on truncation. Defaults to False.
+        max_tokens_auto_ramp (MaxTokensAutoRampConfig | bool | None, optional):
+            Auto-increase max tokens on truncation. Defaults to None.
 
     Returns:
         T_Model | None: The processed response model or None.
@@ -331,7 +576,16 @@ async def retry_async(
     total_usage = initialize_usage(mode)
     # Extract timeout from kwargs if available (for global timeout across retries)
     timeout = kwargs.get("timeout")
-    max_retries = initialize_retrying(max_retries, is_async=True, timeout=timeout)
+    truncation_state = {"attempts": 0, "stop": False}
+    auto_ramp = _resolve_max_tokens_auto_ramp(max_tokens_auto_ramp)
+    retry_predicate = _build_retry_predicate(
+        failfast_on_truncation=failfast_on_truncation,
+        auto_ramp=auto_ramp,
+        truncation_state=truncation_state,
+    )
+    max_retries = initialize_retrying(
+        max_retries, is_async=True, timeout=timeout, retry=retry_predicate
+    )
 
     # Pre-extract stream flag to avoid repeated lookup
     stream = kwargs.get("stream", False)
@@ -360,6 +614,32 @@ async def retry_async(
                         mode=mode,
                         stream=stream,
                     )
+                except IncompleteOutputException as e:
+                    logger.debug(f"Truncated output: {e}")
+                    hooks.emit_parse_error(e)
+
+                    failed_attempts.append(
+                        FailedAttempt(
+                            attempt_number=attempt.retry_state.attempt_number,
+                            exception=e,
+                            completion=response,
+                        )
+                    )
+
+                    truncation_state["attempts"] += 1
+                    stop_retry = False
+                    if failfast_on_truncation:
+                        stop_retry = True
+                    elif auto_ramp is not None:
+                        if truncation_state["attempts"] > auto_ramp.max_attempts:
+                            stop_retry = True
+                        elif not _apply_max_tokens_ramp(kwargs, auto_ramp):
+                            stop_retry = True
+
+                    truncation_state["stop"] = stop_retry
+                    if stop_retry:
+                        hooks.emit_completion_last_attempt(e)
+                    raise e
                 except (
                     ValidationError,
                     JSONDecodeError,

--- a/tests/test_retry_json_mode.py
+++ b/tests/test_retry_json_mode.py
@@ -11,7 +11,10 @@ from unittest.mock import Mock
 from pydantic import BaseModel, ValidationError
 
 import instructor
-from instructor.core.exceptions import InstructorRetryException
+from instructor.core.exceptions import (
+    IncompleteOutputException,
+    InstructorRetryException,
+)
 from instructor.mode import Mode
 from typing import cast
 
@@ -96,3 +99,75 @@ def test_validation_error_caught_by_retry():
 
     for attempt in exception.failed_attempts:
         assert isinstance(attempt.exception, ValidationError)
+
+
+def test_truncation_failfast_stops_retries():
+    """Failfast should stop retries on truncation."""
+    mock_response = Mock()
+    mock_response.choices = [Mock()]
+    mock_response.choices[0].message = Mock()
+    mock_response.choices[0].message.content = '{"name": "John", "age": 30'
+    mock_response.choices[0].finish_reason = "length"
+    mock_response.usage = None
+
+    create_mock = Mock(return_value=mock_response)
+
+    mock_client = Mock()
+    mock_client.chat = Mock()
+    mock_client.chat.completions = Mock()
+    mock_client.chat.completions.create = create_mock
+
+    client = instructor.patch(mock_client, mode=Mode.JSON)
+
+    with pytest.raises(IncompleteOutputException):
+        client.chat.completions.create(
+            model="gpt-4o-mini",
+            response_model=User,
+            messages=[{"role": "user", "content": "test"}],
+            max_retries=3,
+            failfast_on_truncation=True,
+        )
+
+    assert create_mock.call_count == 1
+
+
+def test_truncation_auto_ramp_increases_max_tokens():
+    """Auto-ramp should increase max_tokens and retry."""
+    truncated_response = Mock()
+    truncated_response.choices = [Mock()]
+    truncated_response.choices[0].message = Mock()
+    truncated_response.choices[0].message.content = '{"name": "John", "age": 30'
+    truncated_response.choices[0].finish_reason = "length"
+    truncated_response.usage = None
+
+    complete_response = Mock()
+    complete_response.choices = [Mock()]
+    complete_response.choices[0].message = Mock()
+    complete_response.choices[0].message.content = '{"name": "John", "age": 30}'
+    complete_response.choices[0].finish_reason = "stop"
+    complete_response.usage = None
+
+    create_mock = Mock(side_effect=[truncated_response, complete_response])
+
+    mock_client = Mock()
+    mock_client.chat = Mock()
+    mock_client.chat.completions = Mock()
+    mock_client.chat.completions.create = create_mock
+
+    client = instructor.patch(mock_client, mode=Mode.JSON)
+
+    result = client.chat.completions.create(
+        model="gpt-4o-mini",
+        response_model=User,
+        messages=[{"role": "user", "content": "test"}],
+        max_retries=2,
+        max_tokens=10,
+        max_tokens_auto_ramp={"multiplier": 2, "max_attempts": 1},
+    )
+
+    assert result.name == "John"
+    assert create_mock.call_count == 2
+    first_call = create_mock.call_args_list[0].kwargs["max_tokens"]
+    second_call = create_mock.call_args_list[1].kwargs["max_tokens"]
+    assert first_call == 10
+    assert second_call == 20


### PR DESCRIPTION
feat: add truncation-aware retry handling with failfast and auto-ramp

## Describe your changes

This enhancement introduces two new parameters to improve how Instructor handles model response truncation:

1.  **`failfast_on_truncation=True`**: When enabled, Instructor will immediately raise an `IncompleteOutputException` if a model's response is truncated due to `max_tokens` limits. This prevents wasted validation retries when the issue is insufficient output length, not malformed JSON.
2.  **`max_tokens_auto_ramp`**: This option allows Instructor to automatically increase the `max_tokens` (or equivalent model-specific token limits like `max_output_tokens`, `maxTokens`) for subsequent retries when truncation is detected. It's configurable with a `multiplier`, an optional `cap`, and `max_attempts` to control the ramping behavior. This addresses truncation by increasing the token budget only when needed, optimizing rate limits and concurrency.

These features are integrated into the `instructor.patch` function and the `Instructor` client's `create` methods, and are supported by updated documentation and new unit tests.

## Issue ticket number and link

567-252, https://github.com/567-labs/instructor/issues/1962

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] If it is a core feature, I have added thorough tests.
- [x] If it is a core feature, I have added documentation.

---
Linear Issue: [567-252](https://linear.app/fivesixseven/issue/567-252/handle-token-truncation-better-to-avoid-wasted-validation-retries)

<a href="https://cursor.com/background-agent?bcId=bc-57a68a21-ccfa-4955-ac11-ddc7aaf6875f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-57a68a21-ccfa-4955-ac11-ddc7aaf6875f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

