### PR TITLE
New release preparation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,16 @@ All notable changes to this project will be documented in this file. The format 
 
 <!-- Add upcoming changes here -->
 
+## [1.14.4] - 2026-01-16
+
+### Changed
+- Simplified `JsonCompleteness` by using `jiter` parsing and a sibling-based completeness heuristic (#2000)
+
 ### Fixed
-- Fixed Google GenAI `safety_settings` causing `400 INVALID_ARGUMENT` when requests include image content by using image-specific harm categories when needed (#1773)
-- Fixed `create_with_completion()` crashing when using `list[T]` response models by preserving `_raw_response` on list outputs (#1303)
+- Fixed Responses API retries crashing on reasoning items by skipping non-tool-call items in `reask_responses_tools` (#2002)
+- Fixed Google GenAI dict-style `config` handling to preserve `labels` and other settings like `cached_content` and `thinking_config` (#2005)
+- Fixed Google GenAI `safety_settings` causing `400 INVALID_ARGUMENT` when requests include image content by using image-specific harm categories when needed (#2007, #1773)
+- Fixed `create_with_completion()` crashing when using `list[T]` response models by preserving `_raw_response` on list outputs, and hardened optional `vertexai` imports (#2011, #1303)
 
 ## [1.14.3] - 2026-01-13
 

--- a/instructor/__init__.py
+++ b/instructor/__init__.py
@@ -1,5 +1,7 @@
 import importlib.util
 
+__version__ = "1.14.4"
+
 from .mode import Mode
 from .processing.multimodal import Image, Audio
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ dependencies = [
     "ty>=0.0.1a23",
 ]
 name = "instructor"
-version = "1.14.3"
+version = "1.14.4"
 description = "structured outputs for llm"
 readme = "README.md"
 

--- a/uv.lock
+++ b/uv.lock
@@ -1766,7 +1766,7 @@ wheels = [
 
 [[package]]
 name = "instructor"
-version = "1.14.3"
+version = "1.14.4"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
chore(release): bump version to 1.14.4

## Describe your changes

This PR prepares for a new release (`v1.14.4`) by:
- Bumping the version number to `1.14.4` in `pyproject.toml`, `instructor/__init__.py`, and `uv.lock`.
- Updating `CHANGELOG.md` with notable changes since `v1.14.3`, including fixes from PRs #2000, #2002, #2005, #2007, and #2011. This addresses the GenAI metadata preservation fix (covered by #2005).

## Issue ticket number and link
567-271

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
- [ ] If it is a core feature, I have added thorough tests.
- [ ] If it is a core feature, I have added documentation.

---
Linear Issue: [567-271](https://linear.app/fivesixseven/issue/567-271/bump-version-number-and-update-changelog-for-new-release)

<a href="https://cursor.com/background-agent?bcId=bc-98a70389-69d4-46b0-943d-759b56ebbb7d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-98a70389-69d4-46b0-943d-759b56ebbb7d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

