### PR TITLE
Library release preparation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,17 @@ All notable changes to this project will be documented in this file. The format 
 
 <!-- Add upcoming changes here -->
 
+## [1.14.4] - 2026-01-16
+
+### Changed
+- Refactored `JsonCompleteness` to simplify JSON completeness tracking using `jiter` and a sibling heuristic (#2000)
+
 ### Fixed
-- Fixed Google GenAI `safety_settings` causing `400 INVALID_ARGUMENT` when requests include image content by using image-specific harm categories when needed (#1773)
-- Fixed `create_with_completion()` crashing when using `list[T]` response models by preserving `_raw_response` on list outputs (#1303)
+- Fixed GenAI tools validation retries to preserve `thought_signature` metadata during reasks (#2001)
+- Fixed Responses API validation retries crashing when reasoning items are present in tool calls (#2002)
+- Fixed Google GenAI dict-style `config` merging to preserve `labels`, `cached_content`, and other config fields (#2005)
+- Fixed Google GenAI `safety_settings` causing `400 INVALID_ARGUMENT` when requests include image content by using image-specific harm categories when needed (#2007)
+- Fixed `create_with_completion()` crashing when using `list[T]` response models by preserving `_raw_response` on list outputs (#2011)
 
 ## [1.14.3] - 2026-01-13
 

--- a/instructor/__init__.py
+++ b/instructor/__init__.py
@@ -1,4 +1,5 @@
 import importlib.util
+from importlib.metadata import PackageNotFoundError, version as _pkg_version
 
 from .mode import Mode
 from .processing.multimodal import Image, Audio
@@ -34,7 +35,14 @@ from .distil import FinetuneFormat, Instructions
 from .processing.response import handle_response_model
 from .dsl.parallel import handle_parallel_model
 
+try:
+    __version__ = _pkg_version("instructor")
+except PackageNotFoundError:  # pragma: no cover
+    # Fallback for editable/checkouts where package metadata isn't available.
+    __version__ = "1.14.4"
+
 __all__ = [
+    "__version__",
     "Instructor",
     "Image",
     "Audio",

--- a/instructor/providers/gemini/utils.py
+++ b/instructor/providers/gemini/utils.py
@@ -776,24 +776,73 @@ def reask_genai_tools(
     Handle reask for Google GenAI tools mode when validation fails.
 
     Kwargs modifications:
-    - Adds: "contents" (tool response messages indicating validation errors)
+    - Adds: "contents" (model response preserved for thought_signature,
+                        tool response with validation errors)
     """
     from google.genai import types
 
     kwargs = kwargs.copy()
-    function_call = response.candidates[0].content.parts[0].function_call
+
+    existing_contents = kwargs.get("contents")
+    if isinstance(existing_contents, list):
+        kwargs["contents"] = existing_contents.copy()
+    elif existing_contents is None:
+        kwargs["contents"] = []
+    else:
+        kwargs["contents"] = list(existing_contents)
+
+    error_msg = (
+        f"Validation Error found:\n{exception}\n"
+        "Recall the function correctly, fix the errors"
+    )
+
+    model_content = None
+    function_call_content = None
+    function_call = None
+
+    candidates = getattr(response, "candidates", None) if response is not None else None
+    if isinstance(candidates, list):
+        for candidate in candidates:
+            content = getattr(candidate, "content", None)
+            if content is None:
+                continue
+
+            if model_content is None:
+                model_content = content
+
+            parts = getattr(content, "parts", None) or []
+            for part in parts:
+                function_call = getattr(part, "function_call", None)
+                if function_call is not None:
+                    function_call_content = content
+                    break
+
+            if function_call is not None:
+                break
+
+    if function_call is None:
+        if model_content is not None:
+            kwargs["contents"].append(model_content)
+
+        kwargs["contents"].append(
+            types.Content(
+                role="user",
+                parts=[types.Part.from_text(text=error_msg)],
+            )
+        )
+        return kwargs
+
+    kwargs["contents"].append(function_call_content)
     kwargs["contents"].append(
-        types.ModelContent(
+        types.Content(
+            role="tool",
             parts=[
-                types.Part.from_function_call(
+                types.Part.from_function_response(
                     name=function_call.name,
-                    args=function_call.args,
-                ),
-                types.Part.from_text(
-                    text=f"Validation Error found:\n{exception}\nRecall the function correctly, fix the errors"
-                ),
-            ]
-        ),
+                    response={"error": error_msg},
+                )
+            ],
+        )
     )
     return kwargs
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ dependencies = [
     "ty>=0.0.1a23",
 ]
 name = "instructor"
-version = "1.14.3"
+version = "1.14.4"
 description = "structured outputs for llm"
 readme = "README.md"
 

--- a/tests/test_genai_reask.py
+++ b/tests/test_genai_reask.py
@@ -1,0 +1,81 @@
+import pytest
+
+
+pytest.importorskip("google.genai")
+
+
+from google.genai import types
+
+from instructor.providers.gemini.utils import reask_genai_tools
+
+
+def _response_with_content(content: types.Content) -> types.GenerateContentResponse:
+    return types.GenerateContentResponse(candidates=[types.Candidate(content=content)])
+
+
+def test_reask_genai_tools_preserves_thought_signature() -> None:
+    function_call_part = types.Part.from_function_call(name="test_fn", args={"value": 1})
+    function_call_part.thought_signature = b"sig"
+    model_content = types.Content(role="model", parts=[function_call_part])
+
+    original_kwargs = {"contents": []}
+    result = reask_genai_tools(
+        kwargs=original_kwargs,
+        response=_response_with_content(model_content),
+        exception=Exception("boom"),
+    )
+
+    assert original_kwargs["contents"] == []
+    assert result["contents"][-2] is model_content
+    assert result["contents"][-2].parts[0].thought_signature == b"sig"
+
+    tool_content = result["contents"][-1]
+    assert tool_content.role == "tool"
+    assert tool_content.parts[0].function_response.name == "test_fn"
+
+
+def test_reask_genai_tools_finds_function_call_part_when_not_first() -> None:
+    function_call_part = types.Part.from_function_call(name="test_fn", args={"value": 1})
+    model_content = types.Content(
+        role="model",
+        parts=[
+            types.Part.from_text(text="some preface"),
+            function_call_part,
+        ],
+    )
+
+    result = reask_genai_tools(
+        kwargs={"contents": []},
+        response=_response_with_content(model_content),
+        exception=Exception("boom"),
+    )
+
+    assert result["contents"][-2] is model_content
+    assert result["contents"][-1].role == "tool"
+
+
+def test_reask_genai_tools_handles_none_response() -> None:
+    result = reask_genai_tools(
+        kwargs={},
+        response=None,
+        exception=Exception("boom"),
+    )
+
+    assert result["contents"][-1].role == "user"
+
+
+def test_reask_genai_tools_falls_back_when_no_function_call() -> None:
+    model_content = types.Content(
+        role="model",
+        parts=[types.Part.from_text(text="not a function call")],
+    )
+
+    result = reask_genai_tools(
+        kwargs={"contents": []},
+        response=_response_with_content(model_content),
+        exception=Exception("boom"),
+    )
+
+    assert result["contents"][0] is model_content
+    assert result["contents"][1].role == "user"
+

--- a/uv.lock
+++ b/uv.lock
@@ -1766,7 +1766,7 @@ wheels = [
 
 [[package]]
 name = "instructor"
-version = "1.14.3"
+version = "1.14.4"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
chore(release): bump to 1.14.4

## Describe your changes

Prepares the Instructor library for the `v1.14.4` release. This includes:

-   **Version Bump**: Updated version to `1.14.4` across `pyproject.toml`, `uv.lock`, and introduced `__version__` in `instructor/__init__.py`.
-   **Changelog Update**: Added a new `[1.14.4]` section to `CHANGELOG.md`, documenting all notable changes and fixes since `v1.14.3`.
-   **GenAI Metadata Preservation Fix**: Implemented the fix from #2001 to ensure `thought_signature` and original model content are preserved during GenAI tool validation retries.
-   **New Test Suite**: Added `tests/test_genai_reask.py` to cover the GenAI reask logic.

## Issue ticket number and link

567-272

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] If it is a core feature, I have added thorough tests.
- [x] If it is a core feature, I have added documentation.

---
Linear Issue: [567-272](https://linear.app/fivesixseven/issue/567-272/bump-version-number-and-update-changelog-for-new-release)

<a href="https://cursor.com/background-agent?bcId=bc-15d64e8a-d045-48ad-9459-82a41fdfc416"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-15d64e8a-d045-48ad-9459-82a41fdfc416"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

