### PR TITLE
Pr formatting guidelines

### DIFF
--- a/AGENT.md
+++ b/AGENT.md
@@ -27,3 +27,53 @@
 - **Naming**: `snake_case` functions/variables, `PascalCase` classes
 - **No mocking**: Tests use real API calls
 - **Client creation**: Always use `instructor.from_provider("provider_name/model_name")` instead of provider-specific methods like `from_openai()`, `from_anthropic()`, etc.
+
+## Pull Request (PR) Formatting
+
+Use **Conventional Commits** formatting for PR titles. Treat the PR title as the message we would use for a squash merge commit.
+
+### PR Title Format
+
+Use:
+
+`<type>(<scope>): <short summary>`
+
+Rules:
+- Keep it under ~70 characters when you can.
+- Use the imperative mood (for example, “add”, “fix”, “update”).
+- Do not end with a period.
+- If it includes a breaking change, add `!` after the type or scope (for example, `feat(api)!:`).
+
+Good examples:
+- `fix(openai): handle empty tool_calls in streaming`
+- `feat(retry): add backoff for JSON parse failures`
+- `docs(agents): add conventional commit PR title guidelines`
+- `test(schema): cover nested union edge cases`
+- `ci(ruff): enforce formatting in pre-commit`
+
+Common types:
+- `feat`: new feature
+- `fix`: bug fix
+- `docs`: documentation-only changes
+- `refactor`: code change that is not a fix or feature
+- `perf`: performance improvement
+- `test`: add or update tests
+- `build`: build system or dependency changes
+- `ci`: CI pipeline changes
+- `chore`: maintenance work
+
+Suggested scopes (pick the closest match):
+- Providers: `openai`, `anthropic`, `gemini`, `vertexai`, `bedrock`, `mistral`, `groq`, `writer`
+- Core: `core`, `patch`, `process_response`, `function_calls`, `retry`, `dsl`
+- Repo: `docs`, `examples`, `tests`, `ci`, `build`
+
+### PR Description Guidelines
+
+Keep PR descriptions short and easy to review:
+- **What**: What changed, in 1–3 sentences.
+- **Why**: Why this change is needed (link issues when possible).
+- **Changes**: 3–7 bullet points with the main edits.
+- **Testing**: What you ran (or why you did not run anything).
+
+If the PR was authored by Cursor, include:
+- `This PR was written by [Cursor](https://cursor.com)`

--- a/docs/AGENT.md
+++ b/docs/AGENT.md
@@ -25,6 +25,51 @@ description: Internal guide for maintaining and improving Instructor documentati
 - **Provider docs**: Follow `templates/` patterns
 - **Navigation**: Update `mkdocs.yml` for new pages
 
+## Pull Request (PR) Formatting
+
+Use **Conventional Commits** formatting for PR titles so they are consistent and easy to scan. Treat the PR title as the message we would use for a squash merge commit.
+
+### PR Title Format
+
+Use:
+
+`<type>(<scope>): <short summary>`
+
+Rules:
+- Keep it under ~70 characters when you can.
+- Use the imperative mood (for example, “add”, “fix”, “update”).
+- Do not end with a period.
+- If it includes a breaking change, add `!` after the type or scope (for example, `feat(docs)!:`).
+
+Good examples:
+- `docs(agents): add conventional commit PR title guidelines`
+- `docs(mkdocs): fix broken link in validation tutorial`
+- `docs(examples): update youtube clips snippet`
+- `chore(docs): refresh docs build commands`
+
+Common types:
+- `docs`: documentation-only changes
+- `fix`: bug fix
+- `feat`: new feature
+- `test`: add or update tests
+- `chore`: maintenance work (build scripts, tooling, repo hygiene)
+- `ci`: CI pipeline changes
+
+Suggested docs scopes:
+- `docs`, `mkdocs`, `blog`, `examples`, `integrations`, `tutorials`, `agents`
+
+### PR Description Guidelines
+
+Keep PR descriptions short and actionable:
+- **What**: What changed, in 1–3 sentences.
+- **Why**: Why this change is needed (link issues when possible).
+- **Changes**: 3–7 bullet points with the main edits.
+- **Testing**: What you ran (or why you did not run anything).
+- **Docs impact**: Call out page moves, redirects, or nav updates.
+
+If the PR was authored by Cursor, include:
+- `This PR was written by [Cursor](https://cursor.com)`
+
 ## Key Files
 - `mkdocs.yml` - Site configuration and navigation
 - `hooks/` - Custom processing (hide_lines.py removes `# <%hide%>` markers)


### PR DESCRIPTION
docs(agents): add conventional commit PR formatting guidelines

## Describe your changes

This PR addresses Linear issue 567-273 by adding comprehensive Pull Request (PR) formatting guidelines to `AGENT.md` and `docs/AGENT.md`. The goal is to standardize PR titles using Conventional Commits and provide clear guidelines for PR descriptions, improving consistency and reviewability across agent-related contributions.

The guidelines include:
- Conventional Commits format, rules, examples, and common types for PR titles.
- Suggested scopes tailored to the respective `AGENT.md` file (general vs. docs-specific).
- A checklist for PR descriptions covering "What," "Why," "Changes," and "Testing."
- A specific convention for Cursor-authored PRs.

## Issue ticket number and link

567-273: Add PR formatting guidelines to agents.md using conventional commits

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
- [ ] If it is a core feature, I have added thorough tests.
- [ ] If it is a core feature, I have added documentation.

---
Linear Issue: [567-273](https://linear.app/fivesixseven/issue/567-273/add-pr-formatting-guidelines-to-agentsmd-using-conventional-commits)

<a href="https://cursor.com/background-agent?bcId=bc-7bcfbc35-c64a-4878-bc09-3bafee5170a2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-7bcfbc35-c64a-4878-bc09-3bafee5170a2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Standardizes PR structure across agent and docs guides.
> 
> - Adds **PR Formatting** section to `AGENT.md` and `docs/AGENT.md`
> - Defines Conventional Commits title format, rules, examples, common types, and suggested scopes
> - Introduces concise PR description checklist (What/Why/Changes/Testing) and Cursor-authored note
> - Tailors scopes/examples for general repo vs. docs
> - Documentation-only changes
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ad452ab67619fc927c5cac5cab483cc0bfcb635a. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->