### PR TITLE
test(anthropic): assert full deprecation warning in routing test

### DIFF
--- a/tests/v2/test_routing.py
+++ b/tests/v2/test_routing.py
@@ -32,7 +32,6 @@ def test_from_provider_routes_to_v2(async_client: bool):
         assert isinstance(client, AsyncInstructor)
 
 
-@pytest.mark.skip(reason="Deprecation warning not yet implemented in v1 from_anthropic")
 @pytest.mark.parametrize(
     "client_class_name",
     ["Anthropic", "AsyncAnthropic"],
@@ -40,8 +39,6 @@ def test_from_provider_routes_to_v2(async_client: bool):
 )
 def test_old_from_anthropic_deprecation_warning(client_class_name: str):
     """Test that old from_anthropic() emits deprecation warning with correct v2 example.
-
-    Note: This test is skipped until deprecation warnings are added to v1 providers.
     """
     if importlib.util.find_spec("anthropic") is None:
         pytest.skip("anthropic package is not installed")
@@ -58,12 +55,16 @@ def test_old_from_anthropic_deprecation_warning(client_class_name: str):
         # Should emit deprecation warning
         assert len(w) == 1
         assert issubclass(w[0].category, DeprecationWarning)
-        assert "deprecated" in str(w[0].message).lower()
-        assert "v2" in str(w[0].message)
-        # Verify the warning shows correct v2 Mode enum (TOOLS not ANTHROPIC_TOOLS)
-        assert "Mode.TOOLS" in str(w[0].message)
-        # Verify it mentions the correct v2 import path
-        assert "instructor.v2.providers.anthropic" in str(w[0].message)
+        expected_warning = (
+            "from_anthropic() is deprecated and will be removed in v2.0. "
+            "Use instructor.v2.from_anthropic() with Mode instead:\n"
+            "  from instructor.v2.providers.anthropic import from_anthropic\n"
+            "  from instructor import Mode\n"
+            "  client = from_anthropic(anthropic_client, mode=Mode.TOOLS)\n"
+            "Or use from_provider() which automatically routes to v2:\n"
+            "  client = instructor.from_provider('anthropic/claude-3-sonnet')"
+        )
+        assert str(w[0].message) == expected_warning
 
 
 @pytest.mark.skip(reason="Requires Anthropic API key")


### PR DESCRIPTION
### Motivation
- Re-enable the v1 `from_anthropic()` deprecation test and make it assert the exact deprecation message emitted by the Anthropic provider so the test stays aligned with `instructor/providers/anthropic/client.py`.

### Description
- Updated `tests/v2/test_routing.py` to remove the unconditional skip and keep the conditional `pytest.skip` when the `anthropic` package is not installed.
- Replaced the loose warning substring checks with a single equality check against the full `expected_warning` string that matches the text produced by `from_anthropic()` in `instructor/providers/anthropic/client.py`.

### Testing
- No automated tests were run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697783948d308326bc4a160403d4999e)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Tightens deprecation warning assertions for the legacy `from_anthropic()` path and re-enables the test when `anthropic` is installed.
> 
> - Removes the unconditional skip and restores `test_old_from_anthropic_deprecation_warning` to run, keeping a conditional `pytest.skip` if `anthropic` is absent
> - Replaces loose substring checks with an exact match against the expected warning string produced by `from_anthropic()`
> - No production code changes; updates are confined to `tests/v2/test_routing.py`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e6daf4cd9a67ed5b9c1af0796e63ba23003f45be. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->