### PR TITLE
Add OpenAI PARALLEL_TOOLS parse scenario and parallel-tool mock in handler tests

### DIFF
--- a/tests/v2/test_handlers_parametrized.py
+++ b/tests/v2/test_handlers_parametrized.py
@@ -508,7 +508,7 @@ def test_parse_response_validation_error(provider: Provider, mode: Mode) -> None
         raise ValueError(f"Unsupported scenario {scenario}")
 
     with pytest.raises(ValidationError):
-        handlers.response_parser(
+        result = handlers.response_parser(
             response=response,
             response_model=response_model,
             validation_context=None,
@@ -516,6 +516,8 @@ def test_parse_response_validation_error(provider: Provider, mode: Mode) -> None
             stream=False,
             is_async=False,
         )
+        if scenario == "parallel_tool_call":
+            list(result)
 
 
 @pytest.mark.parametrize("provider,mode", _provider_mode_params())


### PR DESCRIPTION
### Motivation
- Add coverage for the OpenAI PARALLEL_TOOLS mode to ensure handler parsing logic handles parallel tool-call wrappers correctly.
- Provide a mock parallel-tools response builder so tests can simulate multiple tool-call outputs and verify both successful parsing and validation failures.

### Description
- Extend `PARSE_SCENARIOS` for `Provider.OPENAI` to include `Mode.PARALLEL_TOOLS` mapped to `parallel_tool_call` in `tests/v2/test_handlers_parametrized.py`.
- Add `parallel_tool_response` to `MockResponseBuilder` to construct OpenAI-style responses containing multiple `tool_calls` with JSON-encoded arguments.
- Update `test_parse_response` to handle the new `parallel_tool_call` scenario by creating a response for `Iterable[Answer | User]`, asserting the returned value is an iterator, and validating the parsed list equals `[Answer(answer=4.0), User(name="Ada", age=37)]`.
- Update `test_parse_response_validation_error` to exercise a parallel-tool payload with an invalid `Answer` payload and assert a `ValidationError` is raised; also add the `collections.abc.Iterable` import.

### Testing
- No automated tests were executed as part of this change (tests were not run).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6977839f3db88326b6a27ba414c08d9f)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds coverage for OpenAI `Mode.PARALLEL_TOOLS` in v2 handler tests.
> 
> - Extends `PARSE_SCENARIOS` for `Provider.OPENAI` to map `Mode.PARALLEL_TOOLS` to `parallel_tool_call`; includes `Mode.PARALLEL_TOOLS` in `PROVIDER_HANDLER_MODES`
> - Introduces `MockResponseBuilder.parallel_tool_response` to build OpenAI-style `tool_calls` arrays
> - Updates `test_parse_response` to parse `Iterable[Answer | User]`, assert iterator semantics, and verify parsed outputs
> - Updates `test_parse_response_validation_error` to assert `ValidationError` for invalid parallel-tool payloads
> - Adds `collections.abc.Iterable` import and skips `prepare_request` tests for `PARALLEL_TOOLS`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit adf24a01474649061d2a712b735347f1da7f7021. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->