### PR TITLE
feat(providers): add deprecation warnings to v1 factory helpers

### DIFF
--- a/instructor/providers/bedrock/client.py
+++ b/instructor/providers/bedrock/client.py
@@ -48,6 +48,15 @@ def from_bedrock(
     """
     Accepts both 'async_client' (preferred) and '_async' (deprecated) for async mode.
     """
+    warnings.warn(
+        "from_bedrock() is deprecated and will be removed in v2. "
+        "Use the v2 factory instead:\n"
+        "  from instructor.v2.providers.bedrock import from_bedrock\n"
+        "Or use from_provider() which automatically routes to v2:\n"
+        "  client = instructor.from_provider('bedrock/model-name')",
+        DeprecationWarning,
+        stacklevel=2,
+    )
     valid_modes = {
         instructor.Mode.BEDROCK_TOOLS,
         instructor.Mode.BEDROCK_JSON,

--- a/instructor/providers/cerebras/client.py
+++ b/instructor/providers/cerebras/client.py
@@ -1,5 +1,6 @@
 from __future__ import annotations  # type: ignore
 
+import warnings
 from typing import Any, overload
 
 import instructor
@@ -30,6 +31,15 @@ def from_cerebras(
     mode: instructor.Mode = instructor.Mode.CEREBRAS_TOOLS,
     **kwargs: Any,
 ) -> Instructor | AsyncInstructor:
+    warnings.warn(
+        "from_cerebras() is deprecated and will be removed in v2. "
+        "Use the v2 factory instead:\n"
+        "  from instructor.v2.providers.cerebras import from_cerebras\n"
+        "Or use from_provider() which automatically routes to v2:\n"
+        "  client = instructor.from_provider('cerebras/model-name')",
+        DeprecationWarning,
+        stacklevel=2,
+    )
     valid_modes = {
         instructor.Mode.CEREBRAS_TOOLS,
         instructor.Mode.CEREBRAS_JSON,

--- a/instructor/providers/cohere/client.py
+++ b/instructor/providers/cohere/client.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import inspect
+import warnings
 from collections.abc import Awaitable
 from typing import Any, TypeVar, cast, overload
 
@@ -51,6 +52,15 @@ def from_cohere(
     mode: instructor.Mode = instructor.Mode.COHERE_TOOLS,
     **kwargs: Any,
 ):
+    warnings.warn(
+        "from_cohere() is deprecated and will be removed in v2. "
+        "Use the v2 factory instead:\n"
+        "  from instructor.v2.providers.cohere import from_cohere\n"
+        "Or use from_provider() which automatically routes to v2:\n"
+        "  client = instructor.from_provider('cohere/model-name')",
+        DeprecationWarning,
+        stacklevel=2,
+    )
     valid_modes = {
         instructor.Mode.COHERE_TOOLS,
         instructor.Mode.COHERE_JSON_SCHEMA,

--- a/instructor/providers/fireworks/client.py
+++ b/instructor/providers/fireworks/client.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import warnings
 from typing import TYPE_CHECKING, Any, overload
 
 import instructor
@@ -36,6 +37,15 @@ def from_fireworks(
     mode: instructor.Mode = instructor.Mode.FIREWORKS_JSON,
     **kwargs: Any,
 ) -> Instructor | AsyncInstructor:
+    warnings.warn(
+        "from_fireworks() is deprecated and will be removed in v2. "
+        "Use the v2 factory instead:\n"
+        "  from instructor.v2.providers.fireworks import from_fireworks\n"
+        "Or use from_provider() which automatically routes to v2:\n"
+        "  client = instructor.from_provider('fireworks/model-name')",
+        DeprecationWarning,
+        stacklevel=2,
+    )
     valid_modes = {
         instructor.Mode.FIREWORKS_TOOLS,
         instructor.Mode.FIREWORKS_JSON,

--- a/instructor/providers/groq/client.py
+++ b/instructor/providers/groq/client.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
-from typing import overload, Any
+import warnings
+from typing import Any, overload
 
 import groq
 import instructor
@@ -27,6 +28,15 @@ def from_groq(
     mode: instructor.Mode = instructor.Mode.TOOLS,
     **kwargs: Any,
 ) -> instructor.Instructor | instructor.AsyncInstructor:
+    warnings.warn(
+        "from_groq() is deprecated and will be removed in v2. "
+        "Use the v2 factory instead:\n"
+        "  from instructor.v2.providers.groq import from_groq\n"
+        "Or use from_provider() which automatically routes to v2:\n"
+        "  client = instructor.from_provider('groq/model-name')",
+        DeprecationWarning,
+        stacklevel=2,
+    )
     valid_modes = {
         instructor.Mode.JSON,
         instructor.Mode.TOOLS,

--- a/instructor/providers/mistral/client.py
+++ b/instructor/providers/mistral/client.py
@@ -2,9 +2,11 @@
 from __future__ import annotations
 
 
-from mistralai import Mistral
+import warnings
+from typing import Any, Literal, overload
+
 import instructor
-from typing import overload, Any, Literal
+from mistralai import Mistral
 
 
 @overload
@@ -31,6 +33,15 @@ def from_mistral(
     use_async: bool = False,
     **kwargs: Any,
 ) -> instructor.Instructor | instructor.AsyncInstructor:
+    warnings.warn(
+        "from_mistral() is deprecated and will be removed in v2. "
+        "Use the v2 factory instead:\n"
+        "  from instructor.v2.providers.mistral import from_mistral\n"
+        "Or use from_provider() which automatically routes to v2:\n"
+        "  client = instructor.from_provider('mistral/model-name')",
+        DeprecationWarning,
+        stacklevel=2,
+    )
     valid_modes = {
         instructor.Mode.MISTRAL_TOOLS,
         instructor.Mode.MISTRAL_STRUCTURED_OUTPUTS,

--- a/instructor/providers/writer/client.py
+++ b/instructor/providers/writer/client.py
@@ -2,9 +2,11 @@
 from __future__ import annotations
 
 
+import warnings
+from typing import Any, overload
+
 import instructor
 from writerai import AsyncWriter, Writer
-from typing import overload, Any
 
 
 @overload
@@ -28,6 +30,15 @@ def from_writer(
     mode: instructor.Mode = instructor.Mode.WRITER_TOOLS,
     **kwargs: Any,
 ) -> instructor.Instructor | instructor.AsyncInstructor:
+    warnings.warn(
+        "from_writer() is deprecated and will be removed in v2. "
+        "Use the v2 factory instead:\n"
+        "  from instructor.v2.providers.writer import from_writer\n"
+        "Or use from_provider() which automatically routes to v2:\n"
+        "  client = instructor.from_provider('writer/model-name')",
+        DeprecationWarning,
+        stacklevel=2,
+    )
     valid_modes = {instructor.Mode.WRITER_TOOLS, instructor.Mode.WRITER_JSON}
 
     if mode not in valid_modes:

--- a/instructor/providers/xai/client.py
+++ b/instructor/providers/xai/client.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import warnings
 from typing import Any, TYPE_CHECKING, cast, overload
 import json
 
@@ -94,6 +95,15 @@ def from_xai(
     mode: instructor.Mode = instructor.Mode.XAI_JSON,
     **kwargs: Any,
 ) -> instructor.Instructor | instructor.AsyncInstructor:
+    warnings.warn(
+        "from_xai() is deprecated and will be removed in v2. "
+        "Use the v2 factory instead:\n"
+        "  from instructor.v2.providers.xai import from_xai\n"
+        "Or use from_provider() which automatically routes to v2:\n"
+        "  client = instructor.from_provider('xai/model-name')",
+        DeprecationWarning,
+        stacklevel=2,
+    )
     valid_modes = {instructor.Mode.XAI_JSON, instructor.Mode.XAI_TOOLS}
 
     if mode not in valid_modes:

--- a/tests/v2/test_v1_deprecation_warnings.py
+++ b/tests/v2/test_v1_deprecation_warnings.py
@@ -1,0 +1,165 @@
+from __future__ import annotations
+
+import importlib.util
+import warnings
+from dataclasses import dataclass
+from typing import Any, Callable
+
+import pytest
+
+import instructor
+
+
+def _init_with_api_key(client_class: type[Any]) -> Any:
+    try:
+        return client_class(api_key="test")
+    except TypeError:
+        return client_class("test")
+
+
+def _make_mistral_client() -> Any:
+    import mistralai
+
+    return _init_with_api_key(mistralai.Mistral)
+
+
+def _make_groq_client() -> Any:
+    import groq
+
+    return _init_with_api_key(groq.Groq)
+
+
+def _make_cohere_client() -> Any:
+    import cohere
+
+    return _init_with_api_key(cohere.Client)
+
+
+def _make_writer_client() -> Any:
+    from writerai import Writer
+
+    return _init_with_api_key(Writer)
+
+
+def _make_bedrock_client() -> Any:
+    import botocore.session
+
+    session = botocore.session.get_session()
+    return session.create_client(
+        "bedrock-runtime",
+        region_name="us-east-1",
+        aws_access_key_id="test",
+        aws_secret_access_key="test",
+    )
+
+
+def _make_cerebras_client() -> Any:
+    from cerebras.cloud.sdk import Cerebras
+
+    return _init_with_api_key(Cerebras)
+
+
+def _make_fireworks_client() -> Any:
+    from fireworks.client import Fireworks
+
+    return _init_with_api_key(Fireworks)
+
+
+def _make_xai_client() -> Any:
+    from xai_sdk.sync.client import Client
+
+    return _init_with_api_key(Client)
+
+
+@dataclass(frozen=True)
+class WarningCase:
+    name: str
+    module_name: str
+    v2_import_path: str
+    make_client: Callable[[], Any]
+    call_factory: Callable[[Any], Any]
+
+
+CASES = [
+    WarningCase(
+        name="mistral",
+        module_name="mistralai",
+        v2_import_path="instructor.v2.providers.mistral",
+        make_client=_make_mistral_client,
+        call_factory=lambda client: instructor.from_mistral(client),
+    ),
+    WarningCase(
+        name="groq",
+        module_name="groq",
+        v2_import_path="instructor.v2.providers.groq",
+        make_client=_make_groq_client,
+        call_factory=lambda client: instructor.from_groq(client),
+    ),
+    WarningCase(
+        name="cohere",
+        module_name="cohere",
+        v2_import_path="instructor.v2.providers.cohere",
+        make_client=_make_cohere_client,
+        call_factory=lambda client: instructor.from_cohere(client),
+    ),
+    WarningCase(
+        name="writer",
+        module_name="writerai",
+        v2_import_path="instructor.v2.providers.writer",
+        make_client=_make_writer_client,
+        call_factory=lambda client: instructor.from_writer(client),
+    ),
+    WarningCase(
+        name="bedrock",
+        module_name="botocore",
+        v2_import_path="instructor.v2.providers.bedrock",
+        make_client=_make_bedrock_client,
+        call_factory=lambda client: instructor.from_bedrock(client),
+    ),
+    WarningCase(
+        name="cerebras",
+        module_name="cerebras",
+        v2_import_path="instructor.v2.providers.cerebras",
+        make_client=_make_cerebras_client,
+        call_factory=lambda client: instructor.from_cerebras(client),
+    ),
+    WarningCase(
+        name="fireworks",
+        module_name="fireworks",
+        v2_import_path="instructor.v2.providers.fireworks",
+        make_client=_make_fireworks_client,
+        call_factory=lambda client: instructor.from_fireworks(client),
+    ),
+    WarningCase(
+        name="xai",
+        module_name="xai_sdk",
+        v2_import_path="instructor.v2.providers.xai",
+        make_client=_make_xai_client,
+        call_factory=lambda client: instructor.from_xai(client),
+    ),
+]
+
+
+@pytest.mark.parametrize("case", CASES, ids=[case.name for case in CASES])
+def test_v1_factories_emit_deprecation_warning(case: WarningCase) -> None:
+    if importlib.util.find_spec(case.module_name) is None:
+        pytest.skip(f"{case.module_name} is not installed")
+
+    try:
+        client = case.make_client()
+    except Exception as exc:
+        pytest.skip(f"Unable to construct {case.name} client: {exc}")
+
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always", DeprecationWarning)
+        case.call_factory(client)
+
+    messages = [
+        str(w.message)
+        for w in caught
+        if issubclass(w.category, DeprecationWarning)
+    ]
+
+    assert messages, f"Expected DeprecationWarning for {case.name}"
+    assert any(case.v2_import_path in message for message in messages)
+    assert any("from_provider()" in message for message in messages)


### PR DESCRIPTION
### Motivation
- Mark several v1 provider factory helpers as deprecated and direct users to the v2 factories and `from_provider()` routing to encourage migration to the v2 API.
- Provide automated coverage to ensure the deprecation warnings include actionable v2 guidance.

### Description
- Emit a `DeprecationWarning` at the start of the v1 factory functions for the following providers: Mistral, Groq, Cohere, Writer, Bedrock, Cerebras, Fireworks, and xAI (`instructor/providers/*/client.py`).
- Use a consistent warning message that points to the v2 factory import (for example, `from instructor.v2.providers.<provider> import from_<provider>`) and mentions `from_provider()` as an alternative.
- Add a new parametrized pytest file `tests/v2/test_v1_deprecation_warnings.py` that constructs lightweight client instances (when available) and asserts `DeprecationWarning` messages include the v2 import path and `from_provider()` guidance.
- Small import additions (e.g., `import warnings`) and minor test updates to call the provider factories via `instructor.from_<provider>`.

### Testing
- Added `pytest` tests in `tests/v2/test_v1_deprecation_warnings.py` that are parametrized across the affected providers and assert warning presence and message contents.
- No test suite was executed in this change; the new tests were added but not run as part of this PR (skipped at runtime if provider packages are not installed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6977838a819c8326bc9a29a9325b7584)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Deprecates v1 provider factory helpers with clear guidance to v2 equivalents and `from_provider()`.
> 
> - Add `DeprecationWarning` at the start of `from_<provider>` in `instructor/providers/*/client.py` (Bedrock, Cerebras, Cohere, Fireworks, Groq, Mistral, Writer, xAI), pointing to `instructor.v2.providers.<provider>` and mentioning `from_provider()`
> - New pytest `tests/v2/test_v1_deprecation_warnings.py` parametrized across providers to assert warnings include the v2 import path and `from_provider()`
> - Minor import additions (`warnings`) and small refactors limited to warning emission
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 305159374865d8491898797d60f3bebaf44868f7. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->