### PR TITLE
refactor(providers): use v2 factories in auto client

### DIFF
--- a/instructor/auto_client.py
+++ b/instructor/auto_client.py
@@ -517,7 +517,7 @@ def from_provider(
     elif provider == "mistral":
         try:
             from mistralai import Mistral
-            from instructor import from_mistral  # type: ignore[attr-defined]
+            from instructor.v2 import from_mistral, normalize_mode
             import os
 
             api_key = api_key or os.environ.get("MISTRAL_API_KEY")
@@ -530,12 +530,17 @@ def from_provider(
                     "Set it with `export MISTRAL_API_KEY=<your-api-key>`."
                 )
 
-            if async_client:
-                result = from_mistral(
-                    client, model=model_name, use_async=True, **kwargs
-                )
-            else:
-                result = from_mistral(client, model=model_name, **kwargs)
+            normalized_mode = normalize_mode(
+                instructor.Provider.MISTRAL,
+                mode if mode else instructor.Mode.TOOLS,
+            )
+            result = from_mistral(
+                client,
+                model=model_name,
+                use_async=async_client,
+                mode=normalized_mode,
+                **kwargs,
+            )
             logger.info(
                 "Client initialized",
                 extra={**provider_info, "status": "success"},
@@ -645,14 +650,23 @@ def from_provider(
     elif provider == "groq":
         try:
             import groq
-            from instructor import from_groq  # type: ignore[attr-defined]
+            from instructor.v2 import from_groq, normalize_mode
 
             client = (
                 groq.AsyncGroq(api_key=api_key)
                 if async_client
                 else groq.Groq(api_key=api_key)
             )
-            result = from_groq(client, model=model_name, **kwargs)
+            normalized_mode = normalize_mode(
+                instructor.Provider.GROQ,
+                mode if mode else instructor.Mode.TOOLS,
+            )
+            result = from_groq(
+                client,
+                model=model_name,
+                mode=normalized_mode,
+                **kwargs,
+            )
             logger.info(
                 "Client initialized",
                 extra={**provider_info, "status": "success"},
@@ -678,14 +692,23 @@ def from_provider(
     elif provider == "writer":
         try:
             from writerai import AsyncWriter, Writer
-            from instructor import from_writer  # type: ignore[attr-defined]
+            from instructor.v2 import from_writer, normalize_mode
 
             client = (
                 AsyncWriter(api_key=api_key)
                 if async_client
                 else Writer(api_key=api_key)
             )
-            result = from_writer(client, model=model_name, **kwargs)
+            normalized_mode = normalize_mode(
+                instructor.Provider.WRITER,
+                mode if mode else instructor.Mode.TOOLS,
+            )
+            result = from_writer(
+                client,
+                model=model_name,
+                mode=normalized_mode,
+                **kwargs,
+            )
             logger.info(
                 "Client initialized",
                 extra={**provider_info, "status": "success"},
@@ -712,7 +735,7 @@ def from_provider(
         try:
             import os
             import boto3
-            from instructor import from_bedrock  # type: ignore[attr-defined]
+            from instructor.v2 import from_bedrock, normalize_mode
 
             # Get AWS configuration from environment or kwargs
             if "region" in kwargs:
@@ -749,17 +772,22 @@ def from_provider(
                 if model_name and (
                     "anthropic" in model_name.lower() or "claude" in model_name.lower()
                 ):
-                    default_mode = instructor.Mode.BEDROCK_TOOLS
+                    default_mode = instructor.Mode.TOOLS
                 else:
-                    default_mode = instructor.Mode.BEDROCK_JSON
+                    default_mode = instructor.Mode.MD_JSON
             else:
                 default_mode = mode
 
+            normalized_mode = normalize_mode(
+                instructor.Provider.BEDROCK,
+                default_mode,
+            )
             result = from_bedrock(
                 client,
-                mode=default_mode,
+                mode=normalized_mode,
                 async_client=async_client,
                 _async=async_client,  # for backward compatibility
+                model=model_name,
                 **kwargs,
             )
             logger.info(
@@ -787,14 +815,23 @@ def from_provider(
     elif provider == "cerebras":
         try:
             from cerebras.cloud.sdk import AsyncCerebras, Cerebras
-            from instructor import from_cerebras  # type: ignore[attr-defined]
+            from instructor.v2 import from_cerebras, normalize_mode
 
             client = (
                 AsyncCerebras(api_key=api_key)
                 if async_client
                 else Cerebras(api_key=api_key)
             )
-            result = from_cerebras(client, model=model_name, **kwargs)
+            normalized_mode = normalize_mode(
+                instructor.Provider.CEREBRAS,
+                mode if mode else instructor.Mode.TOOLS,
+            )
+            result = from_cerebras(
+                client,
+                model=model_name,
+                mode=normalized_mode,
+                **kwargs,
+            )
             logger.info(
                 "Client initialized",
                 extra={**provider_info, "status": "success"},
@@ -820,14 +857,23 @@ def from_provider(
     elif provider == "fireworks":
         try:
             from fireworks.client import AsyncFireworks, Fireworks
-            from instructor import from_fireworks  # type: ignore[attr-defined]
+            from instructor.v2 import from_fireworks, normalize_mode
 
             client = (
                 AsyncFireworks(api_key=api_key)
                 if async_client
                 else Fireworks(api_key=api_key)
             )
-            result = from_fireworks(client, model=model_name, **kwargs)
+            normalized_mode = normalize_mode(
+                instructor.Provider.FIREWORKS,
+                mode if mode else instructor.Mode.TOOLS,
+            )
+            result = from_fireworks(
+                client,
+                model=model_name,
+                mode=normalized_mode,
+                **kwargs,
+            )
             logger.info(
                 "Client initialized",
                 extra={**provider_info, "status": "success"},

--- a/tests/providers/test_auto_client.py
+++ b/tests/providers/test_auto_client.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from types import ModuleType
+
 import pytest
 from instructor.auto_client import from_provider
 from pydantic import BaseModel
@@ -319,6 +321,140 @@ def test_databricks_provider_requires_host():
             ):
                 with pytest.raises(ConfigurationError):
                     from_provider("databricks/dbrx-instruct")
+
+
+def _build_module_tree(module_path: str, **attributes: object) -> dict[str, ModuleType]:
+    modules: dict[str, ModuleType] = {}
+    parent_module: ModuleType | None = None
+    for idx in range(len(module_path.split("."))):
+        name = ".".join(module_path.split(".")[: idx + 1])
+        module = ModuleType(name)
+        modules[name] = module
+        if parent_module is not None:
+            setattr(parent_module, name.split(".")[-1], module)
+        parent_module = module
+    for key, value in attributes.items():
+        setattr(modules[module_path], key, value)
+    return modules
+
+
+def test_mistral_uses_v2_factory():
+    """Ensure Mistral provider uses v2 factory and normalized modes."""
+    from unittest.mock import MagicMock, patch
+    import sys
+    import instructor
+
+    mock_client = MagicMock()
+    mock_mistral_class = MagicMock(return_value=mock_client)
+    mistral_modules = _build_module_tree("mistralai", Mistral=mock_mistral_class)
+
+    with patch.dict(sys.modules, mistral_modules):
+        with patch("instructor.v2.from_mistral") as mock_from_mistral:
+            mock_from_mistral.return_value = MagicMock()
+
+            client = from_provider("mistral/ministral-8b-latest", api_key="key")
+
+            mock_from_mistral.assert_called_once()
+            _, kwargs = mock_from_mistral.call_args
+            assert kwargs["model"] == "ministral-8b-latest"
+            assert kwargs["mode"] == instructor.Mode.TOOLS
+            assert kwargs["use_async"] is False
+            assert client is mock_from_mistral.return_value
+
+
+@pytest.mark.parametrize(
+    "provider_string,module_path,sync_class,async_class,factory_name",
+    [
+        (
+            "groq/llama-3.1-8b-instant",
+            "groq",
+            "Groq",
+            "AsyncGroq",
+            "from_groq",
+        ),
+        (
+            "writer/palmyra-x5",
+            "writerai",
+            "Writer",
+            "AsyncWriter",
+            "from_writer",
+        ),
+        (
+            "cerebras/llama-4-scout-17b-16e-instruct",
+            "cerebras.cloud.sdk",
+            "Cerebras",
+            "AsyncCerebras",
+            "from_cerebras",
+        ),
+        (
+            "fireworks/accounts/fireworks/models/llama4-maverick-instruct-basic",
+            "fireworks.client",
+            "Fireworks",
+            "AsyncFireworks",
+            "from_fireworks",
+        ),
+    ],
+)
+def test_v2_factories_invoked_for_sdk_clients(
+    provider_string,
+    module_path,
+    sync_class,
+    async_class,
+    factory_name,
+):
+    """Ensure v2 provider factories are invoked for SDK-backed providers."""
+    from unittest.mock import MagicMock, patch
+    import sys
+    import instructor
+
+    mock_client = MagicMock()
+    sync_cls = MagicMock(return_value=mock_client)
+    async_cls = MagicMock(return_value=mock_client)
+    modules = _build_module_tree(
+        module_path, **{sync_class: sync_cls, async_class: async_cls}
+    )
+
+    with patch.dict(sys.modules, modules):
+        with patch(f"instructor.v2.{factory_name}") as mock_factory:
+            mock_factory.return_value = MagicMock()
+
+            client = from_provider(provider_string, api_key="key")
+
+            mock_factory.assert_called_once()
+            _, kwargs = mock_factory.call_args
+            assert kwargs["model"] == provider_string.split("/", 1)[1]
+            assert kwargs["mode"] == instructor.Mode.TOOLS
+            assert client is mock_factory.return_value
+
+
+@pytest.mark.parametrize(
+    "model_name,expected_mode",
+    [
+        ("anthropic.claude-3-haiku", "TOOLS"),
+        ("amazon.titan-text-lite", "MD_JSON"),
+    ],
+)
+def test_bedrock_uses_v2_factory_with_default_modes(model_name, expected_mode):
+    """Ensure Bedrock provider uses v2 factory with model-based defaults."""
+    from unittest.mock import MagicMock, patch
+    import instructor
+    import sys
+
+    mock_client = MagicMock()
+    boto3_modules = _build_module_tree("boto3", client=MagicMock())
+
+    with patch.dict(sys.modules, boto3_modules):
+        with patch("boto3.client", return_value=mock_client):
+            with patch("instructor.v2.from_bedrock") as mock_from_bedrock:
+                mock_from_bedrock.return_value = MagicMock()
+
+                client = from_provider(f"bedrock/{model_name}")
+
+                mock_from_bedrock.assert_called_once()
+                _, kwargs = mock_from_bedrock.call_args
+                assert kwargs["mode"] == getattr(instructor.Mode, expected_mode)
+                assert kwargs["model"] == model_name
+                assert client is mock_from_bedrock.return_value
 
 
 def test_genai_mode_parameter_passed_to_provider():


### PR DESCRIPTION
### Motivation
- Align the auto-client provider wiring with the v2 provider factories and generic mode handling to keep behavior consistent across SDK-backed providers.
- Normalize provider-specific legacy modes to the v2 generic modes so mode handling is centralized and deprecation-safe.

### Description
- Replace direct imports of provider factories with `from instructor.v2 import from_*` and import `normalize_mode` where applicable in `instructor/auto_client.py`.
- Normalize modes using `normalize_mode(...)` for Mistral, Groq, Writer, Cerebras, Fireworks, and Bedrock before calling the v2 factories.
- For Bedrock, map model-based defaults to generic v2 modes (`Mode.TOOLS` or `Mode.MD_JSON`) and pass the selected `model` into `from_bedrock`.
- Add and extend unit tests in `tests/providers/test_auto_client.py` that mock provider SDKs to assert the v2 factories are invoked and that Bedrock default mode selection and model injection behave as expected.

### Testing
- Added new unit tests in `tests/providers/test_auto_client.py` covering Mistral, Groq, Writer, Cerebras, Fireworks, and Bedrock factory invocations using mocks; these tests assert the `from_*` v2 factories are called with normalized modes and model values.
- No test run was executed as part of this change (automated test execution was not requested), so test results are not available here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697783880dc8832689fa163db4b0fd14)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Aligns `instructor/auto_client.py` with v2 provider factories and centralized mode handling.
> 
> - Replace legacy `from_*` imports with `instructor.v2` factories for `mistral`, `groq`, `writer`, `bedrock`, `cerebras`, and `fireworks`
> - Use `normalize_mode(...)` to map provider/legacy modes to generic `Mode` before invoking v2 factories; pass `use_async` where applicable (e.g., Mistral)
> - Update Bedrock defaults: Anthropic/Claude → `Mode.TOOLS`, others → `Mode.MD_JSON`; pass `model` into `from_bedrock`
> - Add unit tests asserting v2 factory invocation, normalized/default modes, and model propagation for the affected providers
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b13b625ba9289dced32678ca887e9309c3621955. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->