### PR TITLE
refactor(providers): add missing providers, centralize URL detection, add tests

### DIFF
--- a/instructor/utils/providers.py
+++ b/instructor/utils/providers.py
@@ -12,6 +12,7 @@ class Provider(Enum):
     """Supported provider identifiers."""
 
     OPENAI = "openai"
+    AZURE_OPENAI = "azure_openai"
     VERTEXAI = "vertexai"
     ANTHROPIC = "anthropic"
     ANYSCALE = "anyscale"
@@ -27,6 +28,10 @@ class Provider(Enum):
     FIREWORKS = "fireworks"
     WRITER = "writer"
     XAI = "xai"
+    OLLAMA = "ollama"
+    LITELLM = "litellm"
+    GOOGLE = "google"
+    GENERATIVE_AI = "generative-ai"
     UNKNOWN = "unknown"
     BEDROCK = "bedrock"
     PERPLEXITY = "perplexity"
@@ -86,38 +91,34 @@ def get_provider(base_url: str) -> Provider:
     Returns:
         Provider: The detected provider enum value
     """
-    if "anyscale" in str(base_url):
-        return Provider.ANYSCALE
-    elif "together" in str(base_url):
-        return Provider.TOGETHER
-    elif "anthropic" in str(base_url):
-        return Provider.ANTHROPIC
-    elif "cerebras" in str(base_url):
-        return Provider.CEREBRAS
-    elif "fireworks" in str(base_url):
-        return Provider.FIREWORKS
-    elif "groq" in str(base_url):
-        return Provider.GROQ
-    elif "openai" in str(base_url):
-        return Provider.OPENAI
-    elif "mistral" in str(base_url):
-        return Provider.MISTRAL
-    elif "cohere" in str(base_url):
-        return Provider.COHERE
-    elif "gemini" in str(base_url):
-        return Provider.GEMINI
-    elif "databricks" in str(base_url):
-        return Provider.DATABRICKS
-    elif "deepseek" in str(base_url):
-        return Provider.DEEPSEEK
-    elif "vertexai" in str(base_url):
-        return Provider.VERTEXAI
-    elif "writer" in str(base_url):
-        return Provider.WRITER
-    elif "perplexity" in str(base_url):
-        return Provider.PERPLEXITY
-    elif "x.ai" in str(base_url) or "xai" in str(base_url):
-        return Provider.XAI
-    elif "openrouter" in str(base_url):
-        return Provider.OPENROUTER
+    normalized = str(base_url).lower()
+    providers = (
+        ("azure", Provider.AZURE_OPENAI),
+        ("anyscale", Provider.ANYSCALE),
+        ("together", Provider.TOGETHER),
+        ("anthropic", Provider.ANTHROPIC),
+        ("cerebras", Provider.CEREBRAS),
+        ("fireworks", Provider.FIREWORKS),
+        ("groq", Provider.GROQ),
+        ("openai", Provider.OPENAI),
+        ("mistral", Provider.MISTRAL),
+        ("cohere", Provider.COHERE),
+        ("gemini", Provider.GEMINI),
+        ("google", Provider.GOOGLE),
+        ("generative-ai", Provider.GENERATIVE_AI),
+        ("databricks", Provider.DATABRICKS),
+        ("deepseek", Provider.DEEPSEEK),
+        ("vertexai", Provider.VERTEXAI),
+        ("bedrock", Provider.BEDROCK),
+        ("writer", Provider.WRITER),
+        ("perplexity", Provider.PERPLEXITY),
+        ("ollama", Provider.OLLAMA),
+        ("litellm", Provider.LITELLM),
+        ("openrouter", Provider.OPENROUTER),
+        ("x.ai", Provider.XAI),
+        ("xai", Provider.XAI),
+    )
+    for token, provider in providers:
+        if token in normalized:
+            return provider
     return Provider.UNKNOWN

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,5 +1,6 @@
 import json
 import pytest
+from instructor.auto_client import supported_providers
 from instructor.utils import (
     classproperty,
     extract_json_from_codeblock,
@@ -8,6 +9,8 @@ from instructor.utils import (
     merge_consecutive_messages,
     extract_system_messages,
     combine_system_messages,
+    Provider,
+    get_provider,
 )
 
 
@@ -386,3 +389,61 @@ def test_combine_system_messages_preserve_cache_control():
         },
     ]
     assert result == expected
+
+
+def test_provider_enum_covers_supported_providers():
+    provider_values = {provider.value for provider in Provider}
+    missing = [provider for provider in supported_providers if provider not in provider_values]
+    assert not missing, f"Missing providers in Provider enum: {missing}"
+
+
+def test_get_provider_matches_supported_providers():
+    provider_mapping = {
+        "openai": Provider.OPENAI,
+        "azure_openai": Provider.AZURE_OPENAI,
+        "databricks": Provider.DATABRICKS,
+        "anthropic": Provider.ANTHROPIC,
+        "google": Provider.GOOGLE,
+        "generative-ai": Provider.GENERATIVE_AI,
+        "vertexai": Provider.VERTEXAI,
+        "mistral": Provider.MISTRAL,
+        "cohere": Provider.COHERE,
+        "perplexity": Provider.PERPLEXITY,
+        "groq": Provider.GROQ,
+        "writer": Provider.WRITER,
+        "bedrock": Provider.BEDROCK,
+        "cerebras": Provider.CEREBRAS,
+        "deepseek": Provider.DEEPSEEK,
+        "fireworks": Provider.FIREWORKS,
+        "ollama": Provider.OLLAMA,
+        "openrouter": Provider.OPENROUTER,
+        "xai": Provider.XAI,
+        "litellm": Provider.LITELLM,
+    }
+    provider_urls = {
+        "openai": "https://api.openai.com/v1",
+        "azure_openai": "https://example.openai.azure.com",
+        "databricks": "https://dbc-databricks.com",
+        "anthropic": "https://api.anthropic.com",
+        "google": "https://generativelanguage.googleapis.com",
+        "generative-ai": "https://generative-ai.googleapis.com",
+        "vertexai": "https://vertexai.googleapis.com",
+        "mistral": "https://api.mistral.ai",
+        "cohere": "https://api.cohere.ai",
+        "perplexity": "https://api.perplexity.ai",
+        "groq": "https://api.groq.com",
+        "writer": "https://api.writer.com",
+        "bedrock": "https://bedrock.aws.amazon.com",
+        "cerebras": "https://api.cerebras.ai",
+        "deepseek": "https://api.deepseek.com",
+        "fireworks": "https://api.fireworks.ai",
+        "ollama": "http://localhost:11434",
+        "openrouter": "https://openrouter.ai",
+        "xai": "https://api.x.ai",
+        "litellm": "https://litellm.ai",
+    }
+    assert set(supported_providers) == set(provider_mapping)
+    assert set(provider_mapping) == set(provider_urls)
+
+    for provider_name, base_url in provider_urls.items():
+        assert get_provider(base_url) == provider_mapping[provider_name]


### PR DESCRIPTION
### Motivation
- Prevent drift between the provider list used by `auto_client` and the local provider utilities by ensuring all supported identifiers are present. 
- Replace a long `if`/`elif` chain with a single mapping to make URL-based provider detection clearer and easier to maintain. 
- Add automated checks to catch future regressions where supported providers diverge across modules. 

### Description
- Updated `instructor/utils/providers.py` to add missing provider enum values: `AZURE_OPENAI`, `OLLAMA`, `LITELLM`, `GOOGLE`, and `GENERATIVE_AI`. 
- Replaced the `if`/`elif` chain in `get_provider()` with a normalized token-to-provider mapping and a single loop that returns the matched `Provider`. 
- Added tests in `tests/test_utils.py` (`test_provider_enum_covers_supported_providers` and `test_get_provider_matches_supported_providers`) that assert `Provider` enum values and `get_provider()` mapping stay in sync with `auto_client.supported_providers`. 

### Testing
- Added unit tests in `tests/test_utils.py` that validate the `Provider` enum covers `supported_providers` and that `get_provider()` detects each provider URL correctly. 
- No test suite was executed as part of this change (tests were added but `pytest` was not run).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69778d52de108326bcacb48795effe21)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Modernizes provider handling and prevents drift between modules.
> 
> - **Enums:** Add `AZURE_OPENAI`, `OLLAMA`, `LITELLM`, `GOOGLE`, `GENERATIVE_AI` to `Provider`
> - **Detection:** Replace `if/elif` chain in `get_provider()` with a normalized token→`Provider` mapping; extend detection to include tokens like `google`, `generative-ai`, `ollama`, `litellm`, and ensure existing providers (e.g., `bedrock`, `openrouter`, `x.ai`) are covered
> - **Tests:** Add `test_provider_enum_covers_supported_providers` and `test_get_provider_matches_supported_providers` to validate enum coverage and URL detection stay in sync with `auto_client.supported_providers`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f83738cb4d3be007764f8e97b82337a1a81f1831. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->