### PR TITLE
docs(v2): clarify v1 provider locations

### DIFF
--- a/instructor/v2/README.md
+++ b/instructor/v2/README.md
@@ -321,8 +321,17 @@ This guide walks through migrating a provider from v1 to v2 architecture.
 Before migrating, understand your current v1 provider:
 
 1. **Locate provider files**:
-   - `instructor/providers/your_provider/client.py` - Factory function
-   - `instructor/providers/your_provider/utils.py` - Helper functions (if exists)
+   - `instructor/core/client.py` - V1 factory functions like `from_openai()` / `from_litellm()`
+   - `instructor/auto_client.py` - `from_provider()` routing (v2-first, v1 fallback)
+   - `instructor/core/patch.py` - V1 patching helpers used by the factories
+   - `instructor/core/retry.py` - V1 retry + reask orchestration
+   - `instructor/client.py` / `instructor/patch.py` - Backwards-compatible re-exports (thin wrappers)
+
+   **Current V1 footprint (migration tracking)**: V1 logic still lives in
+   `instructor/core/*` (client, patch, retry), with routing in
+   `instructor/auto_client.py` and deprecated shims in `instructor/client.py`
+   and `instructor/patch.py`. These modules are the remaining V1 surface area
+   to migrate or deprecate as providers move to v2.
 
 2. **Identify key components**:
    - What modes does your provider support?
@@ -331,22 +340,23 @@ Before migrating, understand your current v1 provider:
    - How does response parsing work? (extracting structured data from raw response)
    - How does reask/retry work? (handling validation failures)
 
-3. **Example V1 structure** (from `instructor/providers/cohere/client.py`):
+3. **Example V1 structure** (from `instructor/core/client.py`):
 
 ```python
-# V1: Direct mode handling in factory function
-def from_cohere(client, mode=Mode.COHERE_TOOLS, **kwargs):
-    valid_modes = {Mode.COHERE_TOOLS, Mode.COHERE_JSON_SCHEMA}
-
-    if mode not in valid_modes:
-        raise ModeError(...)
+# V1: Factory normalizes mode + applies patching
+def from_openai(client, mode=Mode.TOOLS, **kwargs):
+    _ensure_registry_loaded()
+    normalized_mode = normalize_mode_for_provider(mode, Provider.OPENAI)
 
     # Uses instructor.patch() which delegates to the registry handlers
     return Instructor(
         client=client,
-        create=instructor.patch(create=client.chat, mode=mode),
-        provider=Provider.COHERE,
-        mode=mode,
+        create=instructor.patch(
+            create=client.chat.completions.create,
+            mode=normalized_mode,
+        ),
+        provider=Provider.OPENAI,
+        mode=normalized_mode,
         **kwargs,
     )
 ```
@@ -390,19 +400,19 @@ Identify the three handler methods needed:
    - Look for functions like `reask_cohere_tools()`, `reask_anthropic_json()`
    - Modify kwargs to include error context for retry
 
-**Example V1 handler functions** (from `instructor/providers/cohere/utils.py`):
+**Example V1 handler functions** (from `instructor/processing/function_calls.py`
+and `instructor/processing/response.py`):
 
 ```python
-# V1: Scattered handler functions
-def handle_cohere_json_schema(response_model, new_kwargs):
-    # Convert response_model to JSON schema format
-    new_kwargs["response_format"] = {"type": "json_schema", ...}
-    return response_model, new_kwargs
+# V1: Response parsing helpers on ResponseSchema
+@classmethod
+def parse_cohere_json_schema(cls, completion, validation_context=None, strict=None):
+    text = completion.text
+    return cls.model_validate_json(text, context=validation_context, strict=strict)
 
-def reask_cohere_tools(kwargs, response, exception):
-    # Add error message to messages for retry
-    kwargs["messages"].append({"role": "user", "content": f"Error: {exception}"})
-    return kwargs
+def handle_reask_kwargs(kwargs, mode, response, exception, provider=Provider.OPENAI):
+    # Dispatch to provider-specific reask handler for retries
+    return handlers.reask_handler(kwargs, response, exception)
 ```
 
 #### Step 5: Implement V2 Handlers
@@ -645,13 +655,13 @@ def test_basic_extraction():
 1. **Update `from_provider()` routing** (if applicable):
    - Ensure `instructor.from_provider("cohere/model")` routes to v2
 
-2. **Add deprecation warnings** to v1 factory:
+2. **Add deprecation warnings** to v1 entry points:
 
    ```python
-   # instructor/providers/cohere/client.py
-   def from_cohere(...):
+   # instructor/core/client.py
+   def from_openai(...):
        warnings.warn(
-           "from_cohere() is deprecated. Use instructor.v2.providers.cohere.from_cohere()",
+           "from_openai() is deprecated. Use instructor.v2.providers.openai.from_openai()",
            DeprecationWarning,
            stacklevel=2,
        )
@@ -1181,7 +1191,9 @@ This checklist tracks which providers have been migrated to v2:
 
 ### Pending Migrations
 
-All current providers in `instructor/providers/` now have v2 implementations.
+All current providers have v2 implementations in `instructor/v2/providers/`.
+The remaining V1 surface area is concentrated in `instructor/core/*` and
+`instructor/auto_client.py` (see the Step 1 note above).
 
 ### Migration Steps
 


### PR DESCRIPTION
### Motivation

- The v2 migration guide referenced nonexistent v1 provider paths which made locating the real v1 surface area confusing. 
- Clarify where legacy V1 entry points and helpers actually live to make migrations and deprecations easier to track.

### Description

- Update `instructor/v2/README.md` Step 1 to point to the actual V1 entry points such as `instructor/core/client.py`, `instructor/auto_client.py`, `instructor/core/patch.py`, and `instructor/core/retry.py` and the backwards-compatible shims `instructor/client.py` / `instructor/patch.py`.
- Replace the V1 factory example with a realistic snippet based on `instructor/core/client.py` (e.g., `from_openai()` normalization + `instructor.patch` usage) and adjust examples to use `normalized_mode` where appropriate.
- Replace scattered V1 handler references to point at existing parsing/reask helpers in `instructor/processing/` (e.g., `ResponseSchema` and `handle_reask_kwargs`) and show how to reuse them from v2 handlers.
- Add a concise “Current V1 footprint (migration tracking)” note and update the migration checklist to state that remaining V1 surface area is concentrated in `instructor/core/*` and `instructor/auto_client.py`.

### Testing

- No automated tests were run because this is a documentation-only change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69778d5e722c8326b5783508a9bdd00c)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Updates `instructor/v2/README.md` to accurately document V1 surface areas and improve migration guidance.
> 
> - Adds explicit references to V1 entry points (`instructor/core/client.py`, `instructor/auto_client.py`, `instructor/core/patch.py`, `instructor/core/retry.py`, `instructor/client.py`, `instructor/patch.py`) with a concise note on the remaining V1 footprint
> - Replaces the V1 factory example with a realistic snippet from `instructor/core/client.py` using `normalized_mode` and `instructor.patch`
> - Redirects V1 handler references to existing helpers in `instructor/processing/` (`ResponseSchema` parsing, `handle_reask_kwargs`) and shows reuse from v2 handlers
> - Adds guidance to add deprecation warnings to V1 entry points and updates the pending migrations section to reflect where V1 remains
> - Minor doc polish: clarified routing via `from_provider()` and updated migration steps/checklist
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 492de19ca29d670c8c41786683eba4cda7f89fe3. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->