### PR TITLE
Xai-sdk optional dependency

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -36,6 +36,7 @@ pip install "instructor[vertexai]"             # For Vertex AI
 pip install "instructor[cohere]"               # For Cohere
 pip install "instructor[litellm]"              # For LiteLLM (multiple providers)
 pip install "instructor[mistralai]"            # For Mistral
+pip install "instructor[xai]"                  # For xAI
 ```
 
 ## Setting Up Environment

--- a/docs/integrations/index.md
+++ b/docs/integrations/index.md
@@ -20,7 +20,8 @@ Learn how to integrate Instructor with various AI model providers. These compreh
     [:octicons-arrow-right-16: Google.GenerativeAI](./google.md)          ·
     [:octicons-arrow-right-16: Vertex AI](./vertex.md)       ·
     [:octicons-arrow-right-16: AWS Bedrock](./bedrock.md)    ·
-    [:octicons-arrow-right-16: Google.GenAI](./genai.md)
+    [:octicons-arrow-right-16: Google.GenAI](./genai.md)     ·
+    [:octicons-arrow-right-16: xAI](./xai.md)
 
 - :material-cloud-outline: **Additional Cloud Providers**
 

--- a/instructor/auto_client.py
+++ b/instructor/auto_client.py
@@ -1121,8 +1121,9 @@ def from_provider(
             from .core.exceptions import ConfigurationError
 
             raise ConfigurationError(
-                "The xai-sdk package is required to use the xAI provider. "
-                "Install it with `pip install xai-sdk`."
+                "The xAI provider needs the optional dependency `xai-sdk`. "
+                'Install it with `uv pip install "instructor[xai]"` (or `pip install "instructor[xai]"`). '
+                "Note: xai-sdk requires Python 3.10+."
             ) from None
         except Exception as e:
             logger.error(

--- a/instructor/providers/xai/client.py
+++ b/instructor/providers/xai/client.py
@@ -14,6 +14,16 @@ import instructor
 from .utils import _convert_messages
 
 
+def _raise_xai_sdk_missing() -> None:
+    from ...core.exceptions import ConfigurationError
+
+    raise ConfigurationError(
+        "The xAI provider needs the optional dependency `xai-sdk`. "
+        'Install it with `uv pip install "instructor[xai]"` (or `pip install "instructor[xai]"`). '
+        "Note: xai-sdk requires Python 3.10+."
+    ) from None
+
+
 def _get_model_schema(response_model: Any) -> dict[str, Any]:
     """
     Safely get JSON schema from a response model.
@@ -94,6 +104,9 @@ def from_xai(
     mode: instructor.Mode = instructor.Mode.XAI_JSON,
     **kwargs: Any,
 ) -> instructor.Instructor | instructor.AsyncInstructor:
+    if SyncClient is None or AsyncClient is None or xchat is None:
+        _raise_xai_sdk_missing()
+
     valid_modes = {instructor.Mode.XAI_JSON, instructor.Mode.XAI_TOOLS}
 
     if mode not in valid_modes:

--- a/instructor/providers/xai/utils.py
+++ b/instructor/providers/xai/utils.py
@@ -22,7 +22,13 @@ else:
 def _convert_messages(messages: list[dict[str, Any]]):
     """Convert OpenAI-style messages to xAI format."""
     if xchat is None:
-        raise ImportError("xai_sdk is required for xAI provider")
+        from ...core.exceptions import ConfigurationError
+
+        raise ConfigurationError(
+            "The xAI provider needs the optional dependency `xai-sdk`. "
+            'Install it with `uv pip install "instructor[xai]"` (or `pip install "instructor[xai]"`). '
+            "Note: xai-sdk requires Python 3.10+."
+        ) from None
 
     converted = []
     for m in messages:

--- a/tests/test_xai_optional_dependency.py
+++ b/tests/test_xai_optional_dependency.py
@@ -1,0 +1,26 @@
+import pytest
+
+
+def test_from_provider_xai_requires_optional_extra():
+    import instructor
+    from instructor.core.exceptions import ConfigurationError
+
+    with pytest.raises(ConfigurationError) as excinfo:
+        instructor.from_provider("xai/grok-3-mini", api_key="test-key")
+
+    msg = str(excinfo.value)
+    assert "instructor[xai]" in msg
+    assert "uv pip install" in msg
+
+
+def test_direct_from_xai_has_clear_error_when_sdk_missing():
+    from instructor.core.exceptions import ConfigurationError
+    from instructor.providers.xai.client import from_xai
+
+    with pytest.raises(ConfigurationError) as excinfo:
+        from_xai(object())  # type: ignore[arg-type]
+
+    msg = str(excinfo.value)
+    assert "instructor[xai]" in msg
+    assert "xai-sdk" in msg
+


### PR DESCRIPTION
feat: make xai-sdk an optional dependency

## Describe your changes

This PR makes `xai-sdk` an optional dependency, addressing user feedback to reduce unnecessary installations for users not requiring xAI functionality.

Key changes include:
- **Optional Dependency**: `xai-sdk` is now installed via the `instructor[xai]` extra.
- **Improved Error Handling**: Attempting to use xAI functionality without `xai-sdk` installed now raises a `ConfigurationError` with clear instructions on how to install the optional extra.
- **Documentation Updates**: `docs/getting-started.md` and `docs/integrations/index.md` have been updated to reflect the new optional installation method.
- **New Tests**: Added `tests/test_xai_optional_dependency.py` to verify the correct behavior of the optional dependency and error handling.

## Issue ticket number and link

567-316 (Make xai-sdk an optional dependency for instructor library)

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] If it is a core feature, I have added thorough tests.
- [x] If it is a core feature, I have added documentation.

---
Linear Issue: [567-316](https://linear.app/fivesixseven/issue/567-316/make-xai-sdk-an-optional-dependency-for-instructor-library)

<a href="https://cursor.com/background-agent?bcId=bc-42ad8eb6-2d80-4a22-9f13-377d67fcd914"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-42ad8eb6-2d80-4a22-9f13-377d67fcd914"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to xAI provider dependency gating, error messaging, and docs/tests; no core request/response logic is altered.
> 
> **Overview**
> Makes the xAI integration truly optional by standardizing the missing-`xai-sdk` behavior: xAI entrypoints (`from_provider`, `from_xai`, and `_convert_messages`) now raise a `ConfigurationError` with explicit install instructions for `instructor[xai]` (and note the Python 3.10+ requirement).
> 
> Updates docs to advertise `pip install "instructor[xai]"` and adds `tests/test_xai_optional_dependency.py` to ensure the new error messaging is raised when the SDK is not installed.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0bf0937f71482397a39517742499729d76eac325. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->