### PR TITLE
Qwen3 VL tool_choice error

### DIFF
--- a/docs/integrations/openai.md
+++ b/docs/integrations/openai.md
@@ -464,3 +464,11 @@ Read more about how to use it [here](../examples/batch_job_oai.md)
 ## Updates and Compatibility
 
 Instructor maintains compatibility with the latest OpenAI API versions and models. Check the [changelog](https://github.com/jxnl/instructor/blob/main/CHANGELOG.md) for updates.
+
+## OpenAI-compatible servers (LM Studio, local models)
+
+Some OpenAI-compatible servers only accept string values for `tool_choice` (`"none"`, `"auto"`, `"required"`) and reject OpenAI’s newer object form (for example `{"type": "function", ...}`) with a 400 error like:
+
+`Invalid tool_choice type: 'object'. Supported string values: none, auto, required`
+
+If you see this error (common with local Qwen models served through LM Studio), Instructor will automatically retry with a string `tool_choice` as long as you allow at least 2 attempts (the default `max_retries` is already higher than this).

--- a/instructor/core/retry.py
+++ b/instructor/core/retry.py
@@ -45,6 +45,45 @@ T_ParamSpec = ParamSpec("T_ParamSpec")
 T = TypeVar("T")
 
 
+def _is_tool_choice_object_not_supported_error(exc: Exception) -> bool:
+    """Return True if provider rejects object tool_choice payloads.
+
+    Some OpenAI-compatible servers (for example, LM Studio) only accept string values for
+    `tool_choice` (e.g. "none", "auto", "required"). They reject OpenAI's newer object
+    form (e.g. {"type":"function", ...}) with a 400 error.
+    """
+    message = str(exc)
+    return (
+        "Invalid tool_choice type" in message
+        and "Supported string values" in message
+        and "'object'" in message
+    )
+
+
+def _coerce_tool_choice_to_string(tool_choice: Any) -> str | None:
+    """Coerce object tool_choice payloads to their string equivalent.
+
+    Returns None when no change is needed.
+    """
+    if isinstance(tool_choice, str) or tool_choice is None:
+        return None
+    if not isinstance(tool_choice, dict):
+        return None
+
+    tool_choice_type = tool_choice.get("type")
+    if isinstance(tool_choice_type, str) and tool_choice_type in {
+        "none",
+        "auto",
+        "required",
+    }:
+        return tool_choice_type
+
+    # Most object forms represent a forced tool/function call. If the server only supports
+    # string tool_choice, "required" is the closest behavior (and works well when only
+    # one tool is provided, which is the common Instructor structured output case).
+    return "required"
+
+
 def initialize_retrying(
     max_retries: int | Retrying | AsyncRetrying,
     is_async: bool,
@@ -262,6 +301,17 @@ def retry_sync(
                         )
                     )
 
+                    # Some OpenAI-compatible servers only accept string tool_choice values.
+                    # If we see that specific 400 error, coerce tool_choice and retry.
+                    if _is_tool_choice_object_not_supported_error(e):
+                        coerced = _coerce_tool_choice_to_string(kwargs.get("tool_choice"))
+                        if coerced is not None:
+                            logger.debug(
+                                "Coercing tool_choice object to string for compatibility: %s",
+                                coerced,
+                            )
+                            kwargs["tool_choice"] = coerced
+
                     # Check if this is the last attempt for completion errors
                     if isinstance(max_retries, Retrying) and hasattr(
                         max_retries, "stop"
@@ -418,6 +468,17 @@ async def retry_async(
                             completion=response,
                         )
                     )
+
+                    # Some OpenAI-compatible servers only accept string tool_choice values.
+                    # If we see that specific 400 error, coerce tool_choice and retry.
+                    if _is_tool_choice_object_not_supported_error(e):
+                        coerced = _coerce_tool_choice_to_string(kwargs.get("tool_choice"))
+                        if coerced is not None:
+                            logger.debug(
+                                "Coercing tool_choice object to string for compatibility: %s",
+                                coerced,
+                            )
+                            kwargs["tool_choice"] = coerced
 
                     # Check if this is the last attempt for completion errors
                     if isinstance(max_retries, AsyncRetrying) and hasattr(

--- a/tests/test_retry_tool_choice_compat.py
+++ b/tests/test_retry_tool_choice_compat.py
@@ -1,0 +1,92 @@
+"""
+Regression test for OpenAI-compatible servers that reject object tool_choice.
+
+Some OpenAI-compatible servers (for example, LM Studio) only accept string values for
+`tool_choice` and reject OpenAI's newer object form with an HTTP 400 error.
+
+This test ensures Instructor retries once with a string tool_choice when it sees the
+specific "Invalid tool_choice type: 'object'" error message.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import Mock
+
+import instructor
+from instructor.mode import Mode
+from openai.types.chat.chat_completion import ChatCompletion, Choice
+from openai.types.chat.chat_completion_message import ChatCompletionMessage
+from openai.types.chat.chat_completion_message_tool_call import (
+    ChatCompletionMessageToolCall,
+    Function,
+)
+from pydantic import BaseModel
+
+
+class User(BaseModel):
+    name: str
+    age: int
+
+
+def test_tool_choice_object_retried_as_string_required() -> None:
+    """Retries a 400 tool_choice object error by coercing to 'required'."""
+    completion = ChatCompletion(
+        id="test_id",
+        created=1234567890,
+        model="qwen3-vl-4b-instruct",
+        object="chat.completion",
+        choices=[
+            Choice(
+                index=0,
+                message=ChatCompletionMessage(
+                    role="assistant",
+                    content=None,
+                    refusal=None,
+                    tool_calls=[
+                        ChatCompletionMessageToolCall(
+                            id="call_1",
+                            type="function",
+                            function=Function(
+                                name="User",
+                                arguments='{"name":"Jason","age":25}',
+                            ),
+                        )
+                    ],
+                ),
+                finish_reason="stop",
+                logprobs=None,
+            )
+        ],
+    )
+
+    state = {"calls": 0}
+
+    def create_side_effect(*_args, **kwargs):
+        state["calls"] += 1
+        if state["calls"] == 1:
+            # The OpenAI tools handler uses an object tool_choice by default.
+            assert isinstance(kwargs.get("tool_choice"), dict)
+            raise Exception(
+                "Error code: 400 - {'error': \"Invalid tool_choice type: 'object'. Supported string values: none, auto, required\"}"
+            )
+        assert kwargs.get("tool_choice") == "required"
+        return completion
+
+    mock_client = Mock()
+    mock_client.chat = Mock()
+    mock_client.chat.completions = Mock()
+    mock_client.chat.completions.create = Mock(side_effect=create_side_effect)
+
+    client = instructor.patch(mock_client, mode=Mode.TOOLS)
+
+    user = client.chat.completions.create(
+        model="qwen3-vl-4b-instruct",
+        response_model=User,
+        messages=[{"role": "user", "content": "Extract: Jason is 25 years old"}],
+        max_retries=2,
+    )
+
+    assert user.name == "Jason"
+    assert user.age == 25
+    assert state["calls"] == 2
+


### PR DESCRIPTION
fix: improve compatibility with OpenAI-compatible servers for tool_choice

## Describe your changes

This PR addresses a compatibility issue where some OpenAI-compatible servers (e.g., LM Studio) reject `tool_choice` when it's provided as an object (the newer OpenAI schema), only accepting string values (`"none"`, `"auto"`, `"required"`).

Instructor's `Mode.TOOLS` uses the object form of `tool_choice` when a `response_model` is provided, leading to HTTP 400 errors on these servers.

This change introduces an automatic retry mechanism:
- If a request fails with an `Invalid tool_choice type: 'object'` error, Instructor will automatically coerce the object `tool_choice` to its string equivalent (e.g., `"required"`) and retry the request.
- A regression test has been added to `tests/test_retry_tool_choice_compat.py` to ensure this behavior.
- The `docs/integrations/openai.md` has been updated to document this compatibility feature.

## Issue ticket number and link

N/A

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] If it is a core feature, I have added thorough tests.
- [x] If it is a core feature, I have added documentation.

---
[Slack Thread](https://567-studio.slack.com/archives/C08U5CAP8KV/p1769891653731939?thread_ts=1769891653.731939&cid=C08U5CAP8KV)

<a href="https://cursor.com/background-agent?bcId=bc-cb302c13-a9c2-519a-ac65-0f41fe892416"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-cb302c13-a9c2-519a-ac65-0f41fe892416"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>

