### PR TITLE
fix(process_response): use issubclass instead of isinstance for ParallelBase check

### DIFF
--- a/instructor/processing/response.py
+++ b/instructor/processing/response.py
@@ -263,7 +263,7 @@ async def process_response_async(
             raw_response=response,
         )
 
-    if isinstance(response_model, ParallelBase):
+    if inspect.isclass(response_model) and issubclass(response_model, ParallelBase):
         logger.debug(f"Returning model from ParallelBase")
         model._raw_response = response
         return model
@@ -381,7 +381,7 @@ def process_response(
             raw_response=response,
         )
 
-    if isinstance(response_model, ParallelBase):
+    if inspect.isclass(response_model) and issubclass(response_model, ParallelBase):
         logger.debug(f"Returning model from ParallelBase")
         model._raw_response = response
         return model


### PR DESCRIPTION
## Summary

Fixes the bug where ParallelTools fails with:
```
'generator' object has no attribute '_raw_response'
```

## Root Cause

In `process_response.py`, the code uses `isinstance(response_model, ParallelBase)` but `response_model` is a **class (type)**, not an instance. Using `isinstance()` on a class type checks if that class object itself is an instance of a metaclass, which is not the intended behavior.

**Before (incorrect):**
```python
if isinstance(response_model, ParallelBase):
```

**After (correct):**
```python
if inspect.isclass(response_model) and issubclass(response_model, ParallelBase):
```

## Changes

- `instructor/processing/response.py`: Fixed both occurrences (line 266 and 384) of the incorrect `isinstance` check

## Test Plan

- [x] Syntax validation passes
- [x] Fix matches the root cause identified in issue #2049

This should resolve the error when using ParallelTools with models like Qwen3-VL.

Fixes #2049