### PR TITLE
fix(mode): add missing GENAI and Responses modes to tool_modes()

### DIFF
--- a/instructor/mode.py
+++ b/instructor/mode.py
@@ -95,6 +95,9 @@ class Mode(enum.Enum):
             cls.OPENROUTER_STRUCTURED_OUTPUTS,
             cls.MISTRAL_STRUCTURED_OUTPUTS,
             cls.XAI_TOOLS,
+            cls.GENAI_TOOLS,
+            cls.RESPONSES_TOOLS,
+            cls.RESPONSES_TOOLS_WITH_INBUILT_TOOLS,
         }
 
     @classmethod


### PR DESCRIPTION
- Add GENAI_TOOLS to tool_modes() classifier
- Add RESPONSES_TOOLS to tool_modes() classifier
- Add RESPONSES_TOOLS_WITH_INBUILT_TOOLS to tool_modes() classifier

These modes were defined but not included in the classifier method, which could cause issues for users checking mode types.