### PR TITLE
feat(security): add max_context_messages to prevent retry amplificati…

### DIFF
--- a/instructor/core/patch.py
+++ b/instructor/core/patch.py
@@ -150,6 +150,7 @@ def patch(  # type: ignore
         max_retries: int | AsyncRetrying = 1,
         strict: bool = True,
         hooks: Hooks | None = None,
+        max_context_messages: int | None = None,
         *args: T_ParamSpec.args,
         **kwargs: T_ParamSpec.kwargs,
     ) -> T_Model:
@@ -195,6 +196,7 @@ def patch(  # type: ignore
             strict=strict,
             mode=mode,
             hooks=hooks,
+            max_context_messages=max_context_messages,
         )
 
         # Store in cache *after* successful call
@@ -219,6 +221,7 @@ def patch(  # type: ignore
         max_retries: int | Retrying = 1,
         strict: bool = True,
         hooks: Hooks | None = None,
+        max_context_messages: int | None = None,
         *args: T_ParamSpec.args,
         **kwargs: T_ParamSpec.kwargs,
     ) -> T_Model:
@@ -265,6 +268,7 @@ def patch(  # type: ignore
             strict=strict,
             kwargs=new_kwargs,
             mode=mode,
+            max_context_messages=max_context_messages,
         )
 
         # Save to cache

--- a/instructor/core/retry.py
+++ b/instructor/core/retry.py
@@ -140,6 +140,77 @@ def extract_messages(kwargs: dict[str, Any]) -> Any:
     return []
 
 
+def truncate_context_messages(
+    kwargs: dict[str, Any],
+    max_context_messages: int | None = None,
+) -> dict[str, Any]:
+    """
+    Truncate context messages to prevent retry amplification attacks.
+
+    During retries, each failed attempt appends 2 messages (assistant response + error).
+    With 10 retries, this can cause 506x context growth, leading to token budget
+    exhaustion and cost amplification. This function limits the message count
+    by keeping the system message and most recent messages.
+
+    See: https://github.com/instructor-ai/instructor/issues/2056
+
+    Args:
+        kwargs: The request kwargs containing messages.
+        max_context_messages: Maximum number of messages to keep in context.
+            If None, no truncation is performed. The system message (if present)
+            is always preserved and doesn't count towards this limit.
+
+    Returns:
+        Modified kwargs with truncated messages.
+    """
+    if max_context_messages is None:
+        return kwargs
+
+    # Handle different message formats
+    messages_key = None
+    if "messages" in kwargs:
+        messages_key = "messages"
+    elif "contents" in kwargs:
+        messages_key = "contents"
+    elif "chat_history" in kwargs:
+        messages_key = "chat_history"
+
+    if messages_key is None:
+        return kwargs
+
+    messages = kwargs.get(messages_key, [])
+    if not messages or len(messages) <= max_context_messages:
+        return kwargs
+
+    new_kwargs = kwargs.copy()
+
+    # Preserve system message if present (OpenAI format)
+    system_message = None
+    other_messages = messages
+
+    if messages and isinstance(messages[0], dict):
+        if messages[0].get("role") == "system":
+            system_message = messages[0]
+            other_messages = messages[1:]
+
+    # Keep only the most recent messages up to the limit
+    if len(other_messages) > max_context_messages:
+        truncated = other_messages[-max_context_messages:]
+        logger.debug(
+            f"Truncated context from {len(other_messages)} to {len(truncated)} messages "
+            f"(max_context_messages={max_context_messages})"
+        )
+        other_messages = truncated
+
+    # Reconstruct messages with system message first
+    if system_message is not None:
+        new_kwargs[messages_key] = [system_message] + list(other_messages)
+    else:
+        new_kwargs[messages_key] = list(other_messages)
+
+    return new_kwargs
+
+
 def retry_sync(
     func: Callable[T_ParamSpec, T_Retval],
     response_model: type[T_Model] | None,
@@ -150,6 +221,7 @@ def retry_sync(
     strict: bool | None = None,
     mode: Mode = Mode.TOOLS,
     hooks: Hooks | None = None,
+    max_context_messages: int | None = None,
 ) -> T_Model | None:
     """
     Retry a synchronous function upon specified exceptions.
@@ -164,6 +236,10 @@ def retry_sync(
         strict (Optional[bool], optional): Strict mode flag. Defaults to None.
         mode (Mode, optional): The mode of operation. Defaults to Mode.TOOLS.
         hooks (Optional[Hooks], optional): Hooks for emitting events. Defaults to None.
+        max_context_messages (Optional[int], optional): Maximum number of messages to keep
+            in context during retries. Helps prevent context amplification attacks where
+            each retry adds messages, causing exponential growth. The system message is
+            always preserved. See: https://github.com/instructor-ai/instructor/issues/2056
 
     Returns:
         T_Model | None: The processed response model or None.
@@ -247,6 +323,8 @@ def retry_sync(
                         exception=e,
                         failed_attempts=failed_attempts,
                     )
+                    # Apply context truncation to prevent retry amplification
+                    kwargs = truncate_context_messages(kwargs, max_context_messages)
                     raise e
                 except Exception as e:
                     # Emit completion:error for non-validation errors (API errors, network errors, etc.)
@@ -306,6 +384,7 @@ async def retry_async(
     strict: bool | None = None,
     mode: Mode = Mode.TOOLS,
     hooks: Hooks | None = None,
+    max_context_messages: int | None = None,
 ) -> T_Model | None:
     """
     Retry an asynchronous function upon specified exceptions.
@@ -320,6 +399,10 @@ async def retry_async(
         strict (Optional[bool], optional): Strict mode flag. Defaults to None.
         mode (Mode, optional): The mode of operation. Defaults to Mode.TOOLS.
         hooks (Optional[Hooks], optional): Hooks for emitting events. Defaults to None.
+        max_context_messages (Optional[int], optional): Maximum number of messages to keep
+            in context during retries. Helps prevent context amplification attacks where
+            each retry adds messages, causing exponential growth. The system message is
+            always preserved. See: https://github.com/instructor-ai/instructor/issues/2056
 
     Returns:
         T_Model | None: The processed response model or None.
@@ -404,6 +487,8 @@ async def retry_async(
                         exception=e,
                         failed_attempts=failed_attempts,
                     )
+                    # Apply context truncation to prevent retry amplification
+                    kwargs = truncate_context_messages(kwargs, max_context_messages)
                     raise e
                 except Exception as e:
                     # Emit completion:error for non-validation errors (API errors, network errors, etc.)

--- a/tests/test_retry_context_limits.py
+++ b/tests/test_retry_context_limits.py
@@ -1,0 +1,157 @@
+"""Tests for retry context limits feature.
+
+This tests the max_context_messages parameter that prevents retry amplification
+attacks where context grows exponentially (506x with 10 retries).
+
+See: https://github.com/instructor-ai/instructor/issues/2056
+"""
+
+import pytest
+from instructor.core.retry import truncate_context_messages
+
+
+class TestTruncateContextMessages:
+    """Test suite for truncate_context_messages function."""
+
+    def test_no_truncation_when_none(self):
+        """Should return kwargs unchanged when max_context_messages is None."""
+        kwargs = {
+            "messages": [
+                {"role": "user", "content": "Hello"},
+                {"role": "assistant", "content": "Hi"},
+                {"role": "user", "content": "How are you?"},
+            ]
+        }
+        result = truncate_context_messages(kwargs, max_context_messages=None)
+        assert result == kwargs
+        assert len(result["messages"]) == 3
+
+    def test_no_truncation_when_under_limit(self):
+        """Should not truncate when message count is under limit."""
+        kwargs = {
+            "messages": [
+                {"role": "user", "content": "Hello"},
+                {"role": "assistant", "content": "Hi"},
+            ]
+        }
+        result = truncate_context_messages(kwargs, max_context_messages=5)
+        assert result == kwargs
+        assert len(result["messages"]) == 2
+
+    def test_truncates_to_limit(self):
+        """Should truncate messages to max_context_messages."""
+        kwargs = {
+            "messages": [
+                {"role": "user", "content": "msg1"},
+                {"role": "assistant", "content": "msg2"},
+                {"role": "user", "content": "msg3"},
+                {"role": "assistant", "content": "msg4"},
+                {"role": "user", "content": "msg5"},
+            ]
+        }
+        result = truncate_context_messages(kwargs, max_context_messages=3)
+        assert len(result["messages"]) == 3
+        # Should keep the most recent messages
+        assert result["messages"][0]["content"] == "msg3"
+        assert result["messages"][1]["content"] == "msg4"
+        assert result["messages"][2]["content"] == "msg5"
+
+    def test_preserves_system_message(self):
+        """Should always preserve system message and not count it towards limit."""
+        kwargs = {
+            "messages": [
+                {"role": "system", "content": "You are helpful."},
+                {"role": "user", "content": "msg1"},
+                {"role": "assistant", "content": "msg2"},
+                {"role": "user", "content": "msg3"},
+                {"role": "assistant", "content": "msg4"},
+                {"role": "user", "content": "msg5"},
+            ]
+        }
+        result = truncate_context_messages(kwargs, max_context_messages=3)
+        # Should have system + 3 most recent = 4 total
+        assert len(result["messages"]) == 4
+        assert result["messages"][0]["role"] == "system"
+        assert result["messages"][0]["content"] == "You are helpful."
+        assert result["messages"][1]["content"] == "msg3"
+        assert result["messages"][2]["content"] == "msg4"
+        assert result["messages"][3]["content"] == "msg5"
+
+    def test_handles_contents_key(self):
+        """Should handle Gemini/VertexAI 'contents' format."""
+        kwargs = {
+            "contents": [
+                {"role": "user", "parts": [{"text": "msg1"}]},
+                {"role": "model", "parts": [{"text": "msg2"}]},
+                {"role": "user", "parts": [{"text": "msg3"}]},
+            ]
+        }
+        result = truncate_context_messages(kwargs, max_context_messages=2)
+        assert len(result["contents"]) == 2
+
+    def test_handles_chat_history_key(self):
+        """Should handle Cohere 'chat_history' format."""
+        kwargs = {
+            "chat_history": [
+                {"role": "USER", "message": "msg1"},
+                {"role": "CHATBOT", "message": "msg2"},
+                {"role": "USER", "message": "msg3"},
+            ]
+        }
+        result = truncate_context_messages(kwargs, max_context_messages=2)
+        assert len(result["chat_history"]) == 2
+
+    def test_returns_unchanged_if_no_messages(self):
+        """Should return kwargs unchanged if no message key found."""
+        kwargs = {"model": "gpt-4", "temperature": 0.5}
+        result = truncate_context_messages(kwargs, max_context_messages=5)
+        assert result == kwargs
+
+    def test_handles_empty_messages(self):
+        """Should handle empty messages list."""
+        kwargs = {"messages": []}
+        result = truncate_context_messages(kwargs, max_context_messages=5)
+        assert result == kwargs
+
+    def test_does_not_mutate_original(self):
+        """Should not mutate the original kwargs."""
+        original_messages = [
+            {"role": "user", "content": "msg1"},
+            {"role": "assistant", "content": "msg2"},
+            {"role": "user", "content": "msg3"},
+        ]
+        kwargs = {"messages": original_messages}
+        result = truncate_context_messages(kwargs, max_context_messages=2)
+        # Original should be unchanged
+        assert len(kwargs["messages"]) == 3
+        # Result should be truncated
+        assert len(result["messages"]) == 2
+
+
+class TestRetryAmplificationPrevention:
+    """Test that max_context_messages prevents retry amplification attack."""
+
+    def test_simulated_retry_growth(self):
+        """Simulate retry amplification and verify truncation prevents growth."""
+        # Initial conversation
+        messages = [
+            {"role": "system", "content": "You are helpful."},
+            {"role": "user", "content": "Extract: John is 25"},
+        ]
+        
+        # Simulate 10 retries, each adding 2 messages
+        for i in range(10):
+            # Each retry adds assistant response + error message
+            messages.append({"role": "assistant", "content": f"error response {i}"})
+            messages.append({"role": "user", "content": f"Error: validation failed {i}"})
+        
+        # Without truncation: 2 + 20 = 22 messages
+        assert len(messages) == 22
+        
+        # With truncation to 10 messages
+        kwargs = {"messages": messages}
+        result = truncate_context_messages(kwargs, max_context_messages=10)
+        
+        # Should have system + 10 recent = 11 total
+        assert len(result["messages"]) == 11
+        assert result["messages"][0]["role"] == "system"  # System preserved


### PR DESCRIPTION
…on (#2056)

This PR addresses the retry amplification security issue described in #2056.

## Problem
During retries, each failed attempt appends 2 messages (assistant response + tool error). With 10 retries, this can cause 506x context growth, leading to:
- Token budget exhaustion
- Cost amplification
- Potential denial of service

## Solution
Added  parameter that limits the number of messages kept in context during retries. The system message is always preserved.

### Usage
```python
client = instructor.from_openai(OpenAI())

response = client.chat.completions.create(
    model='gpt-4',
    response_model=MyModel,
    max_retries=10,
    max_context_messages=20,  # Limit context to 20 messages
    messages=[...]
)
```

### Changes
- Added `truncate_context_messages()` function in `instructor/core/retry.py`
- Added `max_context_messages` parameter to `retry_sync()` and `retry_async()`
- Exposed parameter through `patch.py` for user access
- Added comprehensive unit tests (10 test cases)

### Testing
- All tests pass
- Backwards compatible (default is None = no truncation)