### PR TITLE
fix: correct typos 'seperate' to 'separate' in examples and tests

### DIFF
--- a/examples/citation_with_extraction/citation_fuzzy_match.py
+++ b/examples/citation_with_extraction/citation_fuzzy_match.py
@@ -66,7 +66,7 @@ class QuestionAnswer(instructor.ResponseSchema):
     question: str = Field(..., description="Question that was asked")
     answer: list[Fact] = Field(
         ...,
-        description="Body of the answer, each fact should be its seperate object with a body and a list of sources",
+        description="Body of the answer, each fact should be its separate object with a body and a list of sources",
     )
 
     @model_validator(mode="after")

--- a/examples/extract-table/run_vision.py
+++ b/examples/extract-table/run_vision.py
@@ -44,7 +44,7 @@ MarkdownDataFrame = Annotated[
             "description": """
                 The markdown representation of the table, 
                 each one should be tidy, do not try to join tables
-                that should be seperate""",
+                that should be separate""",
         }
     ),
 ]

--- a/examples/extract-table/run_vision_langsmith.py
+++ b/examples/extract-table/run_vision_langsmith.py
@@ -45,7 +45,7 @@ MarkdownDataFrame = Annotated[
             "description": """
                 The markdown representation of the table, 
                 each one should be tidy, do not try to join tables
-                that should be seperate""",
+                that should be separate""",
         }
     ),
 ]

--- a/examples/extract-table/run_vision_org_table.py
+++ b/examples/extract-table/run_vision_org_table.py
@@ -44,7 +44,7 @@ MarkdownDataFrame = Annotated[
             "description": """
                 The markdown representation of the table, 
                 each one should be tidy, do not try to join tables
-                that should be seperate""",
+                that should be separate""",
         }
     ),
 ]

--- a/examples/logfire/image.py
+++ b/examples/logfire/image.py
@@ -40,7 +40,7 @@ MarkdownDataFrame = Annotated[
     WithJsonSchema(
         {
             "type": "string",
-            "description": "The markdown representation of the table, each one should be tidy, do not try to join tables that should be seperate",
+            "description": "The markdown representation of the table, each one should be tidy, do not try to join tables that should be separate",
         }
     ),
 ]

--- a/examples/resolving-complex-entities/run.py
+++ b/examples/resolving-complex-entities/run.py
@@ -39,7 +39,7 @@ class Entity(BaseModel):
 class DocumentExtraction(BaseModel):
     entities: list[Entity] = Field(
         ...,
-        description="Body of the answer, each fact should be its seperate object with a body and a list of sources",
+        description="Body of the answer, each fact should be its separate object with a body and a list of sources",
     )
 
 

--- a/examples/vision/run_table.py
+++ b/examples/vision/run_table.py
@@ -44,7 +44,7 @@ MarkdownDataFrame = Annotated[
             "description": """
                 The markdown representation of the table, 
                 each one should be tidy, do not try to join tables
-                that should be seperate""",
+                that should be separate""",
         }
     ),
 ]
@@ -68,7 +68,7 @@ def extract_table(url: str):
                         "type": "text",
                         "text": """Extract the table from the image, and describe it. 
                         Each table should be tidy, do not try to join tables that 
-                        should be seperately described.""",
+                        should be separately described.""",
                     },
                     {
                         "type": "image_url",

--- a/tests/llm/test_writer/evals/test_entities.py
+++ b/tests/llm/test_writer/evals/test_entities.py
@@ -38,7 +38,7 @@ class Entity(BaseModel):
 class DocumentExtraction(BaseModel):
     entities: list[Entity] = Field(
         ...,
-        description="Body of the answer, each fact should be its seperate object with a body and a list of sources",
+        description="Body of the answer, each fact should be its separate object with a body and a list of sources",
     )
 
 


### PR DESCRIPTION
Fix spelling errors across 8 files (9 occurrences):
- 'its seperate object' → 'its separate object'
- 'should be seperate' → 'should be separate'
- 'seperately described' → 'separately described'