### PR TITLE
fix(openai): allow JSON_SCHEMA mode for OpenAI provider in from_openai

### DIFF
--- a/instructor/core/client.py
+++ b/instructor/core/client.py
@@ -823,6 +823,7 @@ def from_openai(
         assert mode in {
             instructor.Mode.TOOLS,
             instructor.Mode.JSON,
+            instructor.Mode.JSON_SCHEMA,
             instructor.Mode.FUNCTIONS,
             instructor.Mode.PARALLEL_TOOLS,
             instructor.Mode.MD_JSON,


### PR DESCRIPTION
Allow JSON_SCHEMA mode for OpenAI provider when using `from_openai` to instantiate the client