### PR TITLE
docs(examples): add canonical OpenAI starter example

### DIFF
--- a/examples/openai/README.md
+++ b/examples/openai/README.md
@@ -1,0 +1,28 @@
+# OpenAI Starter Example
+
+This directory contains a minimal example showing how to use Instructor with OpenAI.
+
+## Quick Start
+
+```bash
+pip install instructor openai
+export OPENAI_API_KEY="your-api-key"
+python run.py
+```
+
+## What This Example Shows
+
+1. **Patching the OpenAI client** with `instructor.from_openai()`
+2. **Defining a response model** using Pydantic's `BaseModel`
+3. **Extracting structured data** via `response_model` parameter
+
+## Output
+
+```
+User(name='John', age=25)
+```
+
+## Next Steps
+
+- See [instructor docs](https://python.useinstructor.com/) for advanced usage
+- Check other examples in this repository for more complex patterns

--- a/examples/openai/run.py
+++ b/examples/openai/run.py
@@ -1,0 +1,35 @@
+"""
+Minimal OpenAI example with Instructor.
+
+This example demonstrates the basic usage of Instructor with OpenAI's API
+to extract structured data from natural language.
+"""
+
+from pydantic import BaseModel
+from openai import OpenAI
+import instructor
+
+
+# Define a simple response model
+class User(BaseModel):
+    name: str
+    age: int
+
+
+# Patch the OpenAI client with Instructor
+client = instructor.from_openai(OpenAI())
+
+# Extract structured data from natural language
+user = client.chat.completions.create(
+    model="gpt-4o-mini",
+    messages=[
+        {
+            "role": "user",
+            "content": "Extract: John is 25 years old.",
+        }
+    ],
+    response_model=User,
+)
+
+print(user)
+# > User(name='John', age=25)


### PR DESCRIPTION
## Summary

Add a minimal OpenAI example under `examples/openai/` for first-time users.

## Changes

- `examples/openai/run.py`: Basic usage showing:
  - `instructor.from_openai()` client patching
  - Simple Pydantic `BaseModel` for structured output
  - One `chat.completions.create()` call with `response_model`

- `examples/openai/README.md`: Quick start guide with install instructions

## Motivation

OpenAI examples already exist across many topic folders, but there's no single canonical starter in a dedicated `examples/openai/` path. This makes first-time onboarding harder because users must search across multiple example directories.

Fixes #2082