### PR TITLE
fix(partial): handle PEP 604 union types in Partial streaming

### DIFF
--- a/instructor/dsl/partial.py
+++ b/instructor/dsl/partial.py
@@ -277,9 +277,12 @@ def _make_field_optional(
         )
 
         # Reconstruct the generic type with modified arguments
-        tmp_field.annotation = (
-            Optional[generic_base[modified_args]] if generic_base else None
-        )
+        if generic_base in UNION_ORIGINS:
+            tmp_field.annotation = Optional[Union[modified_args]]  # type: ignore
+        else:
+            tmp_field.annotation = (
+                Optional[generic_base[modified_args]] if generic_base else None
+            )
         tmp_field.default = None
         tmp_field.default_factory = None
     # If the field is a BaseModel, then recursively convert it's
@@ -1026,9 +1029,12 @@ class Partial(Generic[T_Model]):
                 modified_args = tuple(_process_generic_arg(arg) for arg in generic_args)
 
                 # Reconstruct the generic type with modified arguments
-                tmp_field.annotation = (
-                    generic_base[modified_args] if generic_base else None
-                )
+                if generic_base in UNION_ORIGINS:
+                    tmp_field.annotation = Union[modified_args]  # type: ignore
+                else:
+                    tmp_field.annotation = (
+                        generic_base[modified_args] if generic_base else None
+                    )
             # If the field is a BaseModel, then recursively convert it's
             # attributes to optionals.
             elif isinstance(annotation, type) and issubclass(annotation, BaseModel):

--- a/tests/dsl/test_partial.py
+++ b/tests/dsl/test_partial.py
@@ -1129,3 +1129,89 @@ class TestRecursiveModels:
         assert result.content[0].text == "Introduction paragraph"
         assert result.content[1].title == "Section 1.1"
         assert result.content[1].content[1].title == "Subsection 1.1.1"
+
+
+import sys
+
+if sys.version_info >= (3, 10):
+    from instructor.dsl.partial import MakeFieldsOptional
+
+    class TestPEP604UnionTypes:
+        """Tests for PEP 604 union syntax (str | int) in Partial models.
+
+        Regression tests for https://github.com/567-labs/instructor/issues/2088
+        """
+
+        def test_partial_with_pep604_union(self):
+            """Partial[Model] should not crash on `str | int` fields."""
+
+            class MyResponse(BaseModel):
+                value: str | int
+
+            partial = Partial[MyResponse]
+            assert partial is not None
+
+        def test_partial_with_pep604_union_validates(self):
+            """Partial model with PEP 604 union should validate data."""
+
+            class MyResponse(BaseModel):
+                value: str | int
+
+            PartialModel = Partial[MyResponse].get_partial_model()
+            result = PartialModel.model_validate({"value": "hello"})
+            assert result.value == "hello"
+
+            result = PartialModel.model_validate({"value": 42})
+            assert result.value == 42
+
+        def test_partial_with_pep604_union_in_list(self):
+            """Partial should handle list[str | int] fields."""
+
+            class MyResponse(BaseModel):
+                values: list[str | int]
+
+            partial = Partial[MyResponse]
+            PartialModel = partial.get_partial_model()
+            result = PartialModel.model_validate({"values": ["hello", 42]})
+            assert result.values == ["hello", 42]
+
+        def test_make_fields_optional_with_pep604_union(self):
+            """MakeFieldsOptional path should handle PEP 604 unions."""
+
+            class MyResponse(BaseModel):
+                value: str | int
+
+            partial = Partial[MyResponse, MakeFieldsOptional]
+            PartialModel = partial.get_partial_model()
+
+            # Should accept empty dict (all fields optional)
+            result = PartialModel.model_validate({})
+            assert result.value is None
+
+            # Should accept valid values
+            result = PartialModel.model_validate({"value": "hello"})
+            assert result.value == "hello"
+
+        def test_make_field_optional_with_pep604_union(self):
+            """_make_field_optional should handle PEP 604 union annotations."""
+
+            class MyResponse(BaseModel):
+                value: str | int
+
+            field = MyResponse.model_fields["value"]
+            annotation, new_field = _make_field_optional(field)
+            assert annotation is not None
+            assert new_field.default is None
+
+        def test_partial_with_nested_pep604_union(self):
+            """Partial should handle nested models with PEP 604 unions."""
+
+            class Inner(BaseModel):
+                x: str | int
+
+            class Outer(BaseModel):
+                inner: Inner
+                tag: str | None
+
+            partial = Partial[Outer]
+            assert partial is not None


### PR DESCRIPTION
## Summary

Fixes #2088. `Partial[Model]` crashes with `TypeError: type 'types.UnionType' is not subscriptable` when a model field uses PEP 604 union syntax (`str | int`) instead of `typing.Union[str, int]`.

## Root cause

`types.UnionType` (Python 3.10+ `X | Y` syntax) cannot be subscripted with `[]`. The codebase already handles this in `_process_generic_arg` (normalizing to `typing.Union`), but the same guard was missing from two other locations that reconstruct generic types:

1. `_wrap_models` (inner function in `Partial.__class_getitem__`) — the default `Partial[Model]` path
2. `_make_field_optional` — the `Partial[Model, MakeFieldsOptional]` path

Both tried `generic_base[modified_args]` where `generic_base` is `types.UnionType`, which raises `TypeError`.

## Changes

- `instructor/dsl/partial.py`: Add `UNION_ORIGINS` guard before subscripting `generic_base` in both `_wrap_models` and `_make_field_optional`. When the origin is a union type, use `Union[modified_args]` (which is subscriptable) instead.
- `tests/dsl/test_partial.py`: Add `TestPEP604UnionTypes` test class with 6 regression tests covering both code paths (basic union, union in list, nested models, MakeFieldsOptional path, `_make_field_optional` directly).

## Testing

- All 6 new tests pass
- All 49 existing tests in `test_partial.py` pass (2 skipped, requiring OpenAI API key)
- No regressions