### PR TITLE
Harden PDF.to_bedrock against SSRF and local file disclosure

### DIFF
--- a/instructor/processing/multimodal.py
+++ b/instructor/processing/multimodal.py
@@ -837,21 +837,11 @@ class PDF(BaseModel):
                 }
             }
 
-        # Handle bytes-based sources (URLs, paths, base64)
+        # Handle bytes-based sources (base64 only)
         if not self.data:
-            # Need to fetch/load the data
-            if isinstance(self.source, str) and self.source.startswith(
-                ("http://", "https://")
-            ):
-                response = requests.get(self.source)
-                response.raise_for_status()
-                pdf_bytes = response.content
-            elif isinstance(self.source, Path) or (
-                isinstance(self.source, str) and Path(self.source).exists()
-            ):
-                pdf_bytes = Path(self.source).read_bytes()
-            else:
-                raise ValueError("PDF data is missing and source cannot be loaded")
+            raise ValueError(
+                "PDF data is missing. Provide base64-encoded data or use an s3:// source."
+            )
         else:
             # Decode base64 data to bytes
             pdf_bytes = base64.b64decode(self.data)

--- a/tests/test_multimodal.py
+++ b/tests/test_multimodal.py
@@ -593,40 +593,33 @@ def test_pdf_to_bedrock_with_base64_data():
     assert bedrock_format["document"]["source"]["bytes"] == pdf_bytes
 
 
-def test_pdf_to_bedrock_with_path_source(tmp_path):
-    """Test PDF.to_bedrock with local file path."""
+def test_pdf_to_bedrock_rejects_path_source_without_data(tmp_path):
+    """Test PDF.to_bedrock rejects local file path when data is missing."""
     pdf_file = tmp_path / "test_document.pdf"
-    pdf_content = b"%PDF-1.4\ntest content"
-    pdf_file.write_bytes(pdf_content)
+    pdf_file.write_bytes(b"%PDF-1.4\ntest content")
 
-    pdf = PDF.from_path(pdf_file)
-    bedrock_format = pdf.to_bedrock()
+    pdf = PDF(source=pdf_file, media_type="application/pdf", data=None)
 
-    assert bedrock_format["document"]["format"] == "pdf"
-    assert bedrock_format["document"]["name"] == "test_documentpdf"
-    assert bedrock_format["document"]["source"]["bytes"] == pdf_content
+    with pytest.raises(
+        ValueError,
+        match="PDF data is missing. Provide base64-encoded data or use an s3:// source.",
+    ):
+        pdf.to_bedrock()
 
 
-def test_pdf_to_bedrock_with_url_source():
-    """Test PDF.to_bedrock with HTTP URL source."""
-    pdf_bytes = b"%PDF-1.4\nfetched content"
+def test_pdf_to_bedrock_rejects_url_source_without_data():
+    """Test PDF.to_bedrock rejects HTTP URL source when data is missing."""
+    pdf = PDF(
+        source="https://example.com/doc.pdf",
+        media_type="application/pdf",
+        data=None,
+    )
 
-    with patch("instructor.processing.multimodal.requests.get") as mock_get:
-        resp = MagicMock()
-        resp.content = pdf_bytes
-        resp.raise_for_status = MagicMock()
-        mock_get.return_value = resp
-
-        pdf = PDF(
-            source="https://example.com/doc.pdf",
-            media_type="application/pdf",
-            data=None,
-        )
-        bedrock_format = pdf.to_bedrock()
-
-    assert bedrock_format["document"]["format"] == "pdf"
-    assert bedrock_format["document"]["name"] == "docpdf"
-    assert bedrock_format["document"]["source"]["bytes"] == pdf_bytes
+    with pytest.raises(
+        ValueError,
+        match="PDF data is missing. Provide base64-encoded data or use an s3:// source.",
+    ):
+        pdf.to_bedrock()
 
 
 def test_pdf_to_bedrock_name_sanitization():
@@ -656,33 +649,36 @@ def test_pdf_to_bedrock_name_sanitization():
     assert bedrock_format["document"]["name"] == "my-doc (2024) [final]pdf"
 
 
-def test_pdf_to_bedrock_name_from_path_source(tmp_path):
-    """Test that PDF.to_bedrock extracts name from Path source."""
-    pdf_file = tmp_path / "my-report.pdf"
-    pdf_file.write_bytes(b"%PDF-1.4\ntest")
+def test_pdf_to_bedrock_name_from_path_source_with_data(tmp_path):
+    """Test that PDF.to_bedrock extracts name from Path source when data is provided."""
+    import base64
 
-    pdf = PDF.from_path(pdf_file)
+    pdf_file = tmp_path / "my-report.pdf"
+    pdf_bytes = b"%PDF-1.4\ntest"
+    pdf_file.write_bytes(pdf_bytes)
+
+    pdf = PDF(
+        source=pdf_file,
+        media_type="application/pdf",
+        data=base64.b64encode(pdf_bytes).decode("utf-8"),
+    )
     bedrock_format = pdf.to_bedrock()
 
     assert bedrock_format["document"]["name"] == "my-reportpdf"
 
 
-def test_pdf_to_bedrock_name_from_url():
-    """Test that PDF.to_bedrock extracts name from URL."""
+def test_pdf_to_bedrock_name_from_url_with_data():
+    """Test that PDF.to_bedrock extracts name from URL when data is provided."""
+    import base64
+
     pdf_bytes = b"%PDF-1.4\ntest"
 
-    with patch("instructor.processing.multimodal.requests.get") as mock_get:
-        resp = MagicMock()
-        resp.content = pdf_bytes
-        resp.raise_for_status = MagicMock()
-        mock_get.return_value = resp
-
-        pdf = PDF(
-            source="https://example.com/reports/annual-report-2024.pdf",
-            media_type="application/pdf",
-            data=None,
-        )
-        bedrock_format = pdf.to_bedrock()
+    pdf = PDF(
+        source="https://example.com/reports/annual-report-2024.pdf",
+        media_type="application/pdf",
+        data=base64.b64encode(pdf_bytes).decode("utf-8"),
+    )
+    bedrock_format = pdf.to_bedrock()
 
     assert bedrock_format["document"]["name"] == "annual-report-2024pdf"
 
@@ -730,6 +726,7 @@ def test_pdf_to_bedrock_missing_data_no_source():
     )
 
     with pytest.raises(
-        ValueError, match="PDF data is missing and source cannot be loaded"
+        ValueError,
+        match="PDF data is missing. Provide base64-encoded data or use an s3:// source.",
     ):
         pdf.to_bedrock()


### PR DESCRIPTION
### Motivation
- Prevent server-side request forgery (SSRF) and arbitrary local file reads introduced by `PDF.to_bedrock` implicitly fetching `http(s)` URLs or reading local filesystem paths when `data` was missing.

### Description
- Stop implicit network and filesystem loading inside `PDF.to_bedrock` by removing `requests.get(...)` and `Path(...).read_bytes()` fallbacks and requiring explicit data for non-S3 sources.
- Preserve S3 passthrough behavior for `s3://` sources and preserve base64 decoding when `data` is provided, returning bytes in the existing Bedrock format.
- Replace the previous ambiguous fallback with a clear validation error: `"PDF data is missing. Provide base64-encoded data or use an s3:// source."`.
- Update `tests/test_multimodal.py` to assert that URL/path sources without `data` are rejected and to validate name extraction still works when base64 `data` is explicitly supplied.

### Testing
- Ran the focused Bedrock PDF conversion tests with `pytest -q tests/test_multimodal.py -k 'pdf_to_bedrock'` after installing test dependencies and the package in editable mode.
- The targeted test run completed successfully with the Bedrock PDF cases passing (`12 passed, 49 deselected`).
- No other automated tests were modified or intentionally changed for this patch.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699cef843a888326ad662fcbfb09960b)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Behavior change can break callers relying on `to_bedrock` to auto-fetch URLs or read local paths, but it reduces SSRF/local file disclosure risk and is well-covered by updated tests.
> 
> **Overview**
> Hardens `PDF.to_bedrock` by **removing implicit HTTP fetching and local file reads** when `data` is missing; non-`s3://` sources now require explicitly provided base64 `data` and otherwise raise a clearer validation error.
> 
> Updates the test suite to assert URL/path sources without `data` are rejected, while preserving name extraction behavior when base64 `data` is supplied and keeping `s3://` passthrough unchanged.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c4258b557d5f17868c2b5c22ab73daec5f3ee158. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->