### PR TITLE
Move diskcache from hard dependency to optional extra (CVE-2025-69872)

### DIFF
--- a/instructor/cache/__init__.py
+++ b/instructor/cache/__init__.py
@@ -115,7 +115,8 @@ def _import_diskcache():  # pragma: no cover – only executed when requested
 
     if importlib.util.find_spec("diskcache") is None:  # type: ignore[attr-defined]
         raise ImportError(
-            "diskcache is not installed.  Install it with `pip install diskcache`."
+            "diskcache is not installed. Install it with "
+            "`pip install 'instructor[diskcache]'` or `pip install diskcache`."
         )
     import diskcache  # type: ignore
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,6 @@ dependencies = [
     "jiter>=0.6.1,<0.13",
     "jinja2<4.0.0,>=3.1.4",
     "requests<3.0.0,>=2.32.3",
-    "diskcache>=5.6.3",
 ]
 name = "instructor"
 version = "1.14.5"
@@ -82,6 +81,7 @@ test-docs = [
     "litellm<2.0.0,>=1.35.31",
     "mistralai<2.0.0,>=1.5.1",
 ]
+diskcache = ["diskcache>=5.6.3"]
 anthropic = ["anthropic==0.76.0", "xmltodict>=0.13,<1.1"]
 groq = ["groq>=0.4.2,<1.1.0"]
 cohere = ["cohere<6.0.0,>=5.1.8"]

--- a/requirements.txt
+++ b/requirements.txt
@@ -23,8 +23,6 @@ charset-normalizer==3.4.4
     # via requests
 click==8.1.8
     # via typer
-diskcache==5.6.3
-    # via instructor (pyproject.toml)
 distro==1.9.0
     # via openai
 docstring-parser==0.17.0


### PR DESCRIPTION
Closes #2101

## What changes are proposed

`diskcache` uses `pickle.load()` internally and is affected by CVE-2025-69872 (no upstream patch available). Since instructor already lazy-imports diskcache via `_import_diskcache()` and only uses it when `DiskCache` is explicitly requested, it does not need to be a hard dependency.

This moves `diskcache` from `[project.dependencies]` to `[project.optional-dependencies]` so that `pip install instructor` no longer pulls it in unconditionally. Users who need `DiskCache` can install with:

```
pip install 'instructor[diskcache]'
```

## Changes

- `pyproject.toml`: Remove `diskcache` from hard deps, add `diskcache` optional extras group
- `requirements.txt`: Remove `diskcache` pin
- `instructor/cache/__init__.py`: Update error message to mention `instructor[diskcache]` install syntax

## How is this PR tested

No behavior change for users who have diskcache installed. The `_import_diskcache()` function already handles the missing case and raises a clear `ImportError` with install instructions. Existing tests in `test_cache_key.py` and `test_cache_integration.py` do not depend on diskcache.