### PR TITLE
fix: make diskcache an optional dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,6 @@ dependencies = [
     "jiter>=0.6.1,<0.13",
     "jinja2<4.0.0,>=3.1.4",
     "requests<3.0.0,>=2.32.3",
-    "diskcache>=5.6.3",
 ]
 name = "instructor"
 version = "1.14.5"
@@ -83,6 +82,7 @@ test-docs = [
     "mistralai<2.0.0,>=1.5.1",
 ]
 anthropic = ["anthropic==0.76.0", "xmltodict>=0.13,<1.1"]
+diskcache = ["diskcache>=5.6.3"]
 groq = ["groq>=0.4.2,<1.1.0"]
 cohere = ["cohere<6.0.0,>=5.1.8"]
 vertexai = ["google-cloud-aiplatform<2.0.0,>=1.53.0", "jsonref<2.0.0,>=1.1.0"]


### PR DESCRIPTION
## Problem

`diskcache` is listed as a required dependency in `pyproject.toml`, but it is only used by the `DiskCache` class and is already lazily imported via `_import_diskcache()` which raises a clear `ImportError` when absent. This forces every `instructor` installation to pull `diskcache` (and its transitive dependencies) even when disk caching is not used.

As noted in #2101, `diskcache` also has a known CVE (CVE-2025-69872) in versions prior to 5.6.3+, making the unnecessary hard dependency a security concern for downstream users.

## Solution

- Remove `diskcache` from required dependencies
- Add a new `diskcache` optional extra: `pip install instructor[diskcache]`
- No code changes needed — `_import_diskcache()` already handles the missing import gracefully

## Testing

- Verified `instructor` imports and works without `diskcache` installed
- Verified `DiskCache` raises a clear `ImportError` when `diskcache` is not installed
- Verified `DiskCache` works correctly when `diskcache` IS installed
- All 5 cache tests pass across 2 consecutive runs

Fixes #2101