### PR TITLE
fix(bedrock): pass through cachePoint dicts in content items

### DIFF
--- a/instructor/providers/bedrock/utils.py
+++ b/instructor/providers/bedrock/utils.py
@@ -268,6 +268,10 @@ def _to_bedrock_content_items(content: Any) -> list[dict[str, Any]]:
                 if "document" in p and isinstance(p["document"], dict):
                     items.append(p)
                     continue
+                # Pass-through Bedrock cache point marker
+                if "cachePoint" in p and isinstance(p["cachePoint"], dict):
+                    items.append(p)
+                    continue
 
                 raise ValueError(f"Unsupported dict content for Bedrock: {p}")
 


### PR DESCRIPTION
## Problem

Since v1.13.0, `_to_bedrock_content_items` raises `ValueError: Unsupported dict content for Bedrock` when message content includes Bedrock cache point markers:

```python
user_message_content = [
    {"text": "Say hello"},
    {"cachePoint": {"type": "default"}},  # ← Raises ValueError
    {"text": "This is a test."}
]
```

This is a regression from v1.12.0 where caching worked correctly. The function handles `text`, `image`, and `document` dicts as pass-throughs, but `cachePoint` was not included.

## Fix

Add a pass-through for `cachePoint` dicts, following the same pattern as the existing pass-throughs:

```python
if "cachePoint" in p and isinstance(p["cachePoint"], dict):
    items.append(p)
    continue
```

## Test

24 Bedrock tests pass, 2 consecutive clean runs.

Fixes #1954