### PR TITLE
fix(streaming): pre-fill single-value Literal defaults in partial responses

### DIFF
--- a/instructor/dsl/partial.py
+++ b/instructor/dsl/partial.py
@@ -20,6 +20,7 @@ from typing import (  # noqa: UP035
     Any,
     Generic,
     List,  # needed for runtime check against typing.List annotations from user code
+    Literal,
     NoReturn,
     Optional,
     TypeVar,
@@ -114,6 +115,33 @@ def process_potential_object(potential_object, partial_mode, partial_model, **kw
         return _build_partial_object(parsed, model_for_construct, tracker, "", **kwargs)
 
 
+def _has_deterministic_default(field_info: Any) -> bool:
+    """Check if a field has a deterministic default that should be pre-filled.
+
+    Returns True for single-value Literal fields with a matching default,
+    e.g. ``type: Literal["Person"] = "Person"``.
+    """
+    from pydantic.fields import FieldInfo
+
+    if not isinstance(field_info, FieldInfo):
+        return False
+    if field_info.default is None:
+        return False
+    annotation = field_info.annotation
+    # Unwrap Optional[Literal[...]] -> Literal[...]
+    origin = get_origin(annotation)
+    if origin is Union or origin is types.UnionType:
+        args = [a for a in get_args(annotation) if a is not type(None)]
+        if len(args) == 1:
+            annotation = args[0]
+            origin = get_origin(annotation)
+    if origin is Literal:
+        literal_args = get_args(annotation)
+        if len(literal_args) == 1 and literal_args[0] == field_info.default:
+            return True
+    return False
+
+
 def _build_partial_object(
     data: Any,
     model: type[BaseModel],
@@ -171,7 +199,7 @@ def _build_partial_object(
         else:
             result[field_name] = field_value
 
-    # Set missing fields to None or empty nested models
+    # Set missing fields to None, defaults, or empty nested models
     for field_name, field_info in model.model_fields.items():
         if field_name not in result:
             field_type = field_info.annotation
@@ -179,6 +207,8 @@ def _build_partial_object(
                 result[field_name] = _build_partial_object(
                     {}, field_type, tracker, "", **kwargs
                 )
+            elif _has_deterministic_default(field_info):
+                result[field_name] = field_info.default
             else:
                 result[field_name] = None
 

--- a/tests/test_streaming_literal_default.py
+++ b/tests/test_streaming_literal_default.py
@@ -1,0 +1,159 @@
+"""Tests for streaming Partial with Literal default values.
+
+Ensures that single-value Literal fields with matching defaults are
+pre-filled in partial responses during streaming, rather than being
+set to None until the LLM returns them. (fixes #2054)
+"""
+
+from __future__ import annotations
+
+from typing import Literal
+
+import pytest
+from pydantic import BaseModel
+
+from instructor.dsl.partial import (
+    _build_partial_object,
+    _has_deterministic_default,
+    JsonCompleteness,
+)
+
+
+# ---------------------------------------------------------------------------
+# Models
+# ---------------------------------------------------------------------------
+
+
+class Person(BaseModel):
+    type: Literal["Person"] = "Person"
+    name: str
+    age: int
+
+
+class MultiLiteral(BaseModel):
+    """Literal with multiple values should NOT be pre-filled."""
+
+    kind: Literal["cat", "dog"] = "cat"
+    name: str
+
+
+class NoDefault(BaseModel):
+    """Literal without default should NOT be pre-filled."""
+
+    kind: Literal["item"]
+    name: str
+
+
+class NestedModel(BaseModel):
+    type: Literal["wrapper"] = "wrapper"
+    person: Person
+
+
+# ---------------------------------------------------------------------------
+# _has_deterministic_default tests
+# ---------------------------------------------------------------------------
+
+
+class TestHasDeterministicDefault:
+    def test_single_literal_with_matching_default(self):
+        field_info = Person.model_fields["type"]
+        assert _has_deterministic_default(field_info) is True
+
+    def test_multi_literal_returns_false(self):
+        field_info = MultiLiteral.model_fields["kind"]
+        assert _has_deterministic_default(field_info) is False
+
+    def test_no_default_returns_false(self):
+        field_info = NoDefault.model_fields["kind"]
+        assert _has_deterministic_default(field_info) is False
+
+    def test_regular_str_field_returns_false(self):
+        field_info = Person.model_fields["name"]
+        assert _has_deterministic_default(field_info) is False
+
+    def test_int_field_returns_false(self):
+        field_info = Person.model_fields["age"]
+        assert _has_deterministic_default(field_info) is False
+
+
+# ---------------------------------------------------------------------------
+# _build_partial_object tests
+# ---------------------------------------------------------------------------
+
+
+class TestBuildPartialObjectLiteralDefault:
+    def test_missing_literal_field_uses_default(self):
+        """When 'type' is not in the parsed JSON, it should use the default."""
+        tracker = JsonCompleteness()
+        result = _build_partial_object(
+            {"name": "Alice"},
+            Person,
+            tracker,
+            "",
+        )
+        assert result.type == "Person"
+        assert result.name == "Alice"
+        assert result.age is None
+
+    def test_present_literal_field_not_overridden(self):
+        """When 'type' IS in the parsed JSON, use the parsed value."""
+        tracker = JsonCompleteness()
+        result = _build_partial_object(
+            {"type": "Person", "name": "Bob", "age": 30},
+            Person,
+            tracker,
+            "",
+        )
+        assert result.type == "Person"
+        assert result.name == "Bob"
+        assert result.age == 30
+
+    def test_multi_literal_field_stays_none(self):
+        """Multi-value Literal should NOT be pre-filled."""
+        tracker = JsonCompleteness()
+        result = _build_partial_object(
+            {"name": "Whiskers"},
+            MultiLiteral,
+            tracker,
+            "",
+        )
+        assert result.kind is None
+        assert result.name == "Whiskers"
+
+    def test_empty_data_fills_literal_default(self):
+        """Even with no data, Literal default should appear."""
+        tracker = JsonCompleteness()
+        result = _build_partial_object(
+            {},
+            Person,
+            tracker,
+            "",
+        )
+        assert result.type == "Person"
+        assert result.name is None
+        assert result.age is None
+
+    def test_nested_model_literal_defaults(self):
+        """Literal defaults should work in nested models too."""
+        tracker = JsonCompleteness()
+        result = _build_partial_object(
+            {"person": {"name": "Carol"}},
+            NestedModel,
+            tracker,
+            "",
+        )
+        assert result.type == "wrapper"
+        assert result.person.type == "Person"
+        assert result.person.name == "Carol"
+
+    def test_no_default_literal_stays_none(self):
+        """Literal without default should remain None when missing."""
+        tracker = JsonCompleteness()
+        result = _build_partial_object(
+            {"name": "Dave"},
+            NoDefault,
+            tracker,
+            "",
+        )
+        assert result.kind is None
+        assert result.name == "Dave"


### PR DESCRIPTION
## Summary

When streaming with `Partial`, fields typed as `Literal["Value"] = "Value"` (single possible value with matching default) are set to `None` until the LLM happens to return them. Since these values are deterministic, they should be pre-filled immediately in every partial response.

Example model:
```python
class Person(BaseModel):
    type: Literal["Person"] = "Person"
    name: str
    age: int
```

Before this fix, streaming `Partial[Person]` would show `type=None` until the LLM returned the `type` field. After this fix, `type="Person"` appears from the first partial response.

fixes #2054

## Changes

- `instructor/dsl/partial.py`: Added `_has_deterministic_default()` helper that detects single-value `Literal` fields with matching defaults, and uses it in `_build_partial_object()` to pre-fill these fields instead of setting them to `None`
- Added `tests/test_streaming_literal_default.py` with 11 unit tests covering detection logic, partial object building, nested models, and edge cases

## Test plan

- [x] All 11 new tests pass locally
- [x] Existing related tests pass (test_list_response_wrapper, test_list_response)
- [ ] CI passes

AI-assisted review, AI-assisted testing

🤖 Generated with [Claude Code](https://claude.com/claude-code)