### PR TITLE
fix(usage): update usage counts in-place to preserve litellm subclass type

### DIFF
--- a/instructor/utils/core.py
+++ b/instructor/utils/core.py
@@ -347,7 +347,25 @@ def update_total_usage(
         ):
             tpd.audio_tokens = (tpd.audio_tokens or 0) + (rpd.audio_tokens or 0)
             tpd.cached_tokens = (tpd.cached_tokens or 0) + (rpd.cached_tokens or 0)
-        response.usage = total_usage  # type: ignore  # Replace each response usage with the total usage
+        # Update usage counts in-place when possible to preserve the runtime type of
+        # response.usage.  Replacing it wholesale with `total_usage` (an OpenAIUsage
+        # instance) would discard any subclass-specific methods added by integrations
+        # such as litellm, which adds a `.get()` method that its Langfuse logger
+        # depends on.  Updating in-place keeps the subclass intact while still
+        # reflecting the accumulated token counts.
+        try:
+            response_usage.completion_tokens = total_usage.completion_tokens
+            response_usage.prompt_tokens = total_usage.prompt_tokens
+            response_usage.total_tokens = total_usage.total_tokens
+            if total_usage.completion_tokens_details is not None:
+                response_usage.completion_tokens_details = (
+                    total_usage.completion_tokens_details
+                )
+            if total_usage.prompt_tokens_details is not None:
+                response_usage.prompt_tokens_details = total_usage.prompt_tokens_details
+        except Exception:
+            # Fall back to the old behaviour for types that don't support mutation.
+            response.usage = total_usage  # type: ignore
         return response
 
     # Anthropic usage.


### PR DESCRIPTION
## Summary

Fixes #2113 — when instructor is used with litellm, replacing `response.usage` with a plain `OpenAIUsage` instance discards litellm's extended `CompletionUsage` subclass, breaking the Langfuse / OpenTelemetry integration.

## Root Cause

`update_total_usage()` in `instructor/utils/core.py` accumulates token counts into a plain `OpenAIUsage` (`total_usage`), then sets:

```python
response.usage = total_usage  # Replaces subclass with plain OpenAIUsage
```

When using litellm, `response.usage` is an instance of litellm's `CompletionUsage` subclass that adds methods like `.get()` (used by litellm's Langfuse/OTEL loggers). Replacing it with a plain `OpenAIUsage` discards those methods, causing:

```
'CompletionUsage' object has no attribute 'get'
```

## Fix

Update the token count fields on the existing `response.usage` object **in-place**, preserving its runtime type:

```python
try:
    response_usage.completion_tokens = total_usage.completion_tokens
    response_usage.prompt_tokens = total_usage.prompt_tokens
    response_usage.total_tokens = total_usage.total_tokens
    # ... details
except Exception:
    response.usage = total_usage  # fallback for immutable types
```

This keeps the accumulated counts while preserving the subclass. The `except` fallback maintains backward compatibility for types that don't support field mutation.

## Test plan

- [ ] Use instructor with litellm + Langfuse enabled
- [ ] Make multiple requests (to trigger retry accumulation)
- [ ] Confirm no `'CompletionUsage' object has no attribute 'get'` errors in litellm logs
- [ ] Confirm `response.usage` still reflects accumulated token counts after retries
- [ ] Confirm existing usage tests still pass