### PR TITLE
fix(litellm): preserve Usage subclass type in update_total_usage

### DIFF
--- a/instructor/utils/core.py
+++ b/instructor/utils/core.py
@@ -347,7 +347,14 @@ def update_total_usage(
         ):
             tpd.audio_tokens = (tpd.audio_tokens or 0) + (rpd.audio_tokens or 0)
             tpd.cached_tokens = (tpd.cached_tokens or 0) + (rpd.cached_tokens or 0)
-        response.usage = total_usage  # type: ignore  # Replace each response usage with the total usage
+        # Copy accumulated totals back to the original usage object to preserve
+        # its type (e.g. litellm's Usage subclass). Replacing it with total_usage
+        # would lose provider-specific methods and break integrations like Langfuse.
+        response_usage.completion_tokens = total_usage.completion_tokens
+        response_usage.prompt_tokens = total_usage.prompt_tokens
+        response_usage.total_tokens = total_usage.total_tokens
+        response_usage.completion_tokens_details = total_usage.completion_tokens_details
+        response_usage.prompt_tokens_details = total_usage.prompt_tokens_details
         return response
 
     # Anthropic usage.
@@ -371,7 +378,16 @@ def update_total_usage(
             total_usage.cache_read_input_tokens += (
                 response_usage.cache_read_input_tokens or 0
             )
-            response.usage = total_usage  # type: ignore
+            # Copy accumulated totals back to the original usage object to
+            # preserve its type.
+            response_usage.input_tokens = total_usage.input_tokens
+            response_usage.output_tokens = total_usage.output_tokens
+            response_usage.cache_creation_input_tokens = (
+                total_usage.cache_creation_input_tokens
+            )
+            response_usage.cache_read_input_tokens = (
+                total_usage.cache_read_input_tokens
+            )
             return response
     except ImportError:
         pass

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,5 +1,8 @@
 import json
 import pytest
+from openai.types import CompletionUsage
+from openai.types.chat import ChatCompletion
+from openai.types.chat.chat_completion import Choice, ChatCompletionMessage
 from instructor.utils import (
     classproperty,
     extract_json_from_codeblock,
@@ -9,6 +12,7 @@ from instructor.utils import (
     extract_system_messages,
     combine_system_messages,
 )
+from instructor.utils.core import update_total_usage
 
 
 def test_extract_json_from_codeblock():
@@ -386,3 +390,88 @@ def test_combine_system_messages_preserve_cache_control():
         },
     ]
     assert result == expected
+
+
+class CustomUsage(CompletionUsage):
+    """Simulates a provider-specific Usage subclass (e.g. litellm's Usage)."""
+
+    def get(self, key: str, default=None):
+        """Provider-specific method that would be lost if type is replaced."""
+        return getattr(self, key, default)
+
+
+def _make_chat_completion(usage):
+    """Helper to create a ChatCompletion with given usage."""
+    return ChatCompletion(
+        id="chatcmpl-test",
+        choices=[
+            Choice(
+                finish_reason="stop",
+                index=0,
+                message=ChatCompletionMessage(role="assistant", content="test"),
+            )
+        ],
+        created=0,
+        model="test",
+        object="chat.completion",
+        usage=usage,
+    )
+
+
+def test_update_total_usage_preserves_usage_subclass_type():
+    """Test that update_total_usage preserves the original usage object type.
+
+    When response.usage is a subclass of CompletionUsage (e.g. litellm's Usage),
+    the function should copy accumulated totals back to the original object
+    instead of replacing it, preserving provider-specific methods. Fixes #2113.
+    """
+    custom_usage = CustomUsage(
+        completion_tokens=10,
+        prompt_tokens=20,
+        total_tokens=30,
+    )
+    response = _make_chat_completion(custom_usage)
+    total_usage = CompletionUsage(
+        completion_tokens=0,
+        prompt_tokens=0,
+        total_tokens=0,
+    )
+
+    result = update_total_usage(response, total_usage)
+
+    assert result is not None
+    # The usage type must be preserved (not replaced with plain CompletionUsage)
+    assert type(result.usage) is CustomUsage
+    # Provider-specific methods should still work
+    assert result.usage.get("completion_tokens") == 10
+    # Token counts should be accumulated correctly
+    assert result.usage.completion_tokens == 10
+    assert result.usage.prompt_tokens == 20
+    assert result.usage.total_tokens == 30
+
+
+def test_update_total_usage_accumulates_across_retries():
+    """Test that totals accumulate across multiple calls (simulating retries)."""
+    total_usage = CompletionUsage(
+        completion_tokens=0,
+        prompt_tokens=0,
+        total_tokens=0,
+    )
+
+    # First retry
+    r1 = _make_chat_completion(
+        CustomUsage(completion_tokens=5, prompt_tokens=10, total_tokens=15)
+    )
+    update_total_usage(r1, total_usage)
+
+    # Second retry
+    r2 = _make_chat_completion(
+        CustomUsage(completion_tokens=7, prompt_tokens=12, total_tokens=19)
+    )
+    result = update_total_usage(r2, total_usage)
+
+    assert result is not None
+    assert type(result.usage) is CustomUsage
+    assert result.usage.completion_tokens == 5 + 7
+    assert result.usage.prompt_tokens == 10 + 12
+    assert result.usage.total_tokens == 15 + 19


### PR DESCRIPTION
## Summary
- `update_total_usage()` now copies accumulated token totals back to the original `response.usage` object instead of replacing it with a plain `CompletionUsage`
- Preserves provider-specific Usage subclass types (e.g. litellm's `Usage`) and their methods
- Also applies the same fix to the Anthropic usage path for consistency

## Root Cause
When using instructor with litellm, `response.usage` is a litellm-specific `Usage` subclass that inherits from OpenAI's `CompletionUsage` but adds extra methods (e.g. `.get()`). The code at line 350 (`response.usage = total_usage`) replaces this subclass instance with a plain `CompletionUsage`, causing litellm's Langfuse integration to fail with `'CompletionUsage' object has no attribute 'get'`.

## Fix
Instead of:
```python
response.usage = total_usage  # replaces subclass with plain CompletionUsage
```

Now:
```python
response_usage.completion_tokens = total_usage.completion_tokens
response_usage.prompt_tokens = total_usage.prompt_tokens
response_usage.total_tokens = total_usage.total_tokens
# ... same for token details
```

This copies the accumulated values back to the original object, preserving its type.

## Test Plan
- [x] `test_update_total_usage_preserves_usage_subclass_type` - verifies `type(result.usage)` stays as the subclass
- [x] `test_update_total_usage_accumulates_across_retries` - verifies correct accumulation across multiple retries
- [x] All 24 tests in `tests/test_utils.py` pass
- [x] `ruff check` passes

Fixes #2113