### PR TITLE
fix(utils): update usage in-place to preserve LiteLLM usage type

### DIFF
--- a/instructor/utils/core.py
+++ b/instructor/utils/core.py
@@ -347,7 +347,13 @@ def update_total_usage(
         ):
             tpd.audio_tokens = (tpd.audio_tokens or 0) + (rpd.audio_tokens or 0)
             tpd.cached_tokens = (tpd.cached_tokens or 0) + (rpd.cached_tokens or 0)
-        response.usage = total_usage  # type: ignore  # Replace each response usage with the total usage
+        # Update the existing usage object in-place to preserve the original type
+        # (e.g. LiteLLM subclasses with extra methods used by Langfuse)
+        response_usage.completion_tokens = total_usage.completion_tokens
+        response_usage.prompt_tokens = total_usage.prompt_tokens
+        response_usage.total_tokens = total_usage.total_tokens
+        response_usage.completion_tokens_details = total_usage.completion_tokens_details
+        response_usage.prompt_tokens_details = total_usage.prompt_tokens_details
         return response
 
     # Anthropic usage.
@@ -371,7 +377,11 @@ def update_total_usage(
             total_usage.cache_read_input_tokens += (
                 response_usage.cache_read_input_tokens or 0
             )
-            response.usage = total_usage  # type: ignore
+            # Update the existing usage object in-place to preserve the original type
+            response_usage.input_tokens = total_usage.input_tokens
+            response_usage.output_tokens = total_usage.output_tokens
+            response_usage.cache_creation_input_tokens = total_usage.cache_creation_input_tokens
+            response_usage.cache_read_input_tokens = total_usage.cache_read_input_tokens
             return response
     except ImportError:
         pass


### PR DESCRIPTION
Instead of replacing `response.usage` with a new object, update token fields in-place so LiteLLM's custom methods on the usage object are preserved.\n\nFixes #2113