### PR TITLE
feat(bedrock): support MD_JSON mode with think-tag stripping

### DIFF
--- a/instructor/mode.py
+++ b/instructor/mode.py
@@ -68,6 +68,7 @@ class Mode(enum.Enum):
     WRITER_JSON = "writer_json"
     BEDROCK_TOOLS = "bedrock_tools"
     BEDROCK_JSON = "bedrock_json"
+    BEDROCK_MD_JSON = "bedrock_md_json"
     PERPLEXITY_JSON = "perplexity_json"
     OPENROUTER_STRUCTURED_OUTPUTS = "openrouter_structured_outputs"
 
@@ -116,6 +117,7 @@ class Mode(enum.Enum):
             cls.FIREWORKS_JSON,
             cls.WRITER_JSON,
             cls.BEDROCK_JSON,
+            cls.BEDROCK_MD_JSON,
             cls.PERPLEXITY_JSON,
             cls.OPENROUTER_STRUCTURED_OUTPUTS,
             cls.MISTRAL_STRUCTURED_OUTPUTS,

--- a/instructor/processing/function_calls.py
+++ b/instructor/processing/function_calls.py
@@ -168,6 +168,9 @@ class OpenAISchema(BaseModel):
         if mode == Mode.BEDROCK_JSON:
             return cls.parse_bedrock_json(completion, validation_context, strict)
 
+        if mode == Mode.BEDROCK_MD_JSON:
+            return cls.parse_bedrock_md_json(completion, validation_context, strict)
+
         if mode == Mode.BEDROCK_TOOLS:
             return cls.parse_bedrock_tools(completion, validation_context, strict)
 
@@ -448,6 +451,39 @@ class OpenAISchema(BaseModel):
             text = re.sub(r"```?json|\\n", "", text).strip()
         else:
             text = completion.text
+        return cls.model_validate_json(text, context=validation_context, strict=strict)
+
+    @classmethod
+    def parse_bedrock_md_json(
+        cls: type[BaseModel],
+        completion: Any,
+        validation_context: Optional[dict[str, Any]] = None,
+        strict: Optional[bool] = None,
+    ) -> BaseModel:
+        """Parse Bedrock MD_JSON responses, stripping <think>...</think> tags
+        and markdown codeblocks before extracting JSON.
+
+        This is useful for models like Kimi K2 Thinking that prepend
+        reasoning in <think> tags before the actual JSON output.
+        """
+        if isinstance(completion, dict):
+            content = completion["output"]["message"]["content"]
+            text_content = next((c for c in content if "text" in c), None)
+            if not text_content:
+                raise ResponseParsingError(
+                    "Unexpected format. No text content found in Bedrock response.",
+                    mode="BEDROCK_MD_JSON",
+                    raw_response=completion,
+                )
+            text = text_content["text"]
+            # Strip <think>...</think> tags (including multiline content)
+            text = re.sub(r"<think>.*?</think>", "", text, flags=re.DOTALL).strip()
+            # Extract JSON from markdown codeblock or raw text
+            text = extract_json_from_codeblock(text)
+        else:
+            text = completion.text
+            text = re.sub(r"<think>.*?</think>", "", text, flags=re.DOTALL).strip()
+            text = extract_json_from_codeblock(text)
         return cls.model_validate_json(text, context=validation_context, strict=strict)
 
     @classmethod

--- a/instructor/processing/response.py
+++ b/instructor/processing/response.py
@@ -71,8 +71,10 @@ from ..providers.anthropic.utils import (
 # Bedrock utils
 from ..providers.bedrock.utils import (
     handle_bedrock_json,
+    handle_bedrock_md_json,
     handle_bedrock_tools,
     reask_bedrock_json,
+    reask_bedrock_md_json,
     reask_bedrock_tools,
 )
 
@@ -484,6 +486,7 @@ def handle_response_model(
         Mode.WRITER_TOOLS: handle_writer_tools,
         Mode.WRITER_JSON: handle_writer_json,
         Mode.BEDROCK_JSON: handle_bedrock_json,
+        Mode.BEDROCK_MD_JSON: handle_bedrock_md_json,
         Mode.BEDROCK_TOOLS: handle_bedrock_tools,
         Mode.PERPLEXITY_JSON: handle_perplexity_json,
         Mode.OPENROUTER_STRUCTURED_OUTPUTS: handle_openrouter_structured_outputs,
@@ -682,6 +685,7 @@ def handle_reask_kwargs(
         # Bedrock modes
         Mode.BEDROCK_TOOLS: reask_bedrock_tools,
         Mode.BEDROCK_JSON: reask_bedrock_json,
+        Mode.BEDROCK_MD_JSON: reask_bedrock_md_json,
         # Perplexity modes
         Mode.PERPLEXITY_JSON: reask_perplexity_json,
         # OpenRouter modes

--- a/instructor/providers/bedrock/client.py
+++ b/instructor/providers/bedrock/client.py
@@ -51,6 +51,7 @@ def from_bedrock(
     valid_modes = {
         instructor.Mode.BEDROCK_TOOLS,
         instructor.Mode.BEDROCK_JSON,
+        instructor.Mode.BEDROCK_MD_JSON,
     }
 
     if mode not in valid_modes:

--- a/instructor/providers/bedrock/utils.py
+++ b/instructor/providers/bedrock/utils.py
@@ -453,6 +453,93 @@ def handle_bedrock_json(
     return response_model, new_kwargs
 
 
+def reask_bedrock_md_json(
+    kwargs: dict[str, Any],
+    response: Any,
+    exception: Exception,
+):
+    """
+    Handle reask for Bedrock MD_JSON mode when validation fails.
+
+    Kwargs modifications:
+    - Adds: "messages" (assistant message then user message requesting JSON correction)
+    """
+    kwargs = kwargs.copy()
+    reask_msgs = [response["output"]["message"]]
+    reask_msgs.append(
+        {
+            "role": "user",
+            "content": [
+                {
+                    "text": (
+                        "Correct your JSON ONLY RESPONSE, based on the following errors:\n"
+                        f"{exception}\n"
+                        "Return the correct JSON response within a ```json codeblock."
+                    )
+                },
+            ],
+        }
+    )
+    kwargs["messages"].extend(reask_msgs)
+    return kwargs
+
+
+def handle_bedrock_md_json(
+    response_model: type[Any], new_kwargs: dict[str, Any]
+) -> tuple[type[Any], dict[str, Any]]:
+    """
+    Handle Bedrock MD_JSON mode for models that produce <think>...</think> tags
+    or other non-JSON preamble before the actual JSON output (e.g. Kimi K2 Thinking).
+
+    This mode instructs the model to return JSON inside a markdown codeblock,
+    then strips any think tags and extracts the JSON during parsing.
+
+    Kwargs modifications:
+    - Adds/Modifies: "system" (prepends JSON instructions)
+    - Adds: user message requesting JSON in markdown codeblock
+    - Applies: _prepare_bedrock_converse_kwargs_internal transformations
+    """
+    new_kwargs = _prepare_bedrock_converse_kwargs_internal(new_kwargs)
+    json_message = dedent(
+        f"""
+        As a genius expert, your task is to understand the content and provide
+        the parsed objects in json that match the following json_schema:\n
+
+        {json.dumps(response_model.model_json_schema(), indent=2, ensure_ascii=False)}
+
+        Make sure to return an instance of the JSON, not the schema itself.
+        Return the correct JSON response within a ```json codeblock.
+        """
+    )
+    system_message = new_kwargs.pop("system", None)
+    if not system_message:
+        new_kwargs["system"] = [{"text": json_message}]
+    else:
+        if not isinstance(system_message, list):
+            raise ValueError(
+                """system must be a list of SystemMessage, refer to:
+                https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/bedrock-runtime/client/converse.html
+                """
+            )
+        system_message.append({"text": json_message})
+        new_kwargs["system"] = system_message
+
+    # Add user message requesting markdown codeblock response
+    if "messages" in new_kwargs:
+        new_kwargs["messages"].append(
+            {
+                "role": "user",
+                "content": [
+                    {
+                        "text": "Return the correct JSON response within a ```json codeblock. not the JSON_SCHEMA"
+                    }
+                ],
+            }
+        )
+
+    return response_model, new_kwargs
+
+
 def handle_bedrock_tools(
     response_model: type[Any] | None, new_kwargs: dict[str, Any]
 ) -> tuple[type[Any] | None, dict[str, Any]]:
@@ -487,6 +574,10 @@ BEDROCK_HANDLERS = {
     Mode.BEDROCK_JSON: {
         "reask": reask_bedrock_json,
         "response": handle_bedrock_json,
+    },
+    Mode.BEDROCK_MD_JSON: {
+        "reask": reask_bedrock_md_json,
+        "response": handle_bedrock_md_json,
     },
     Mode.BEDROCK_TOOLS: {
         "reask": reask_bedrock_tools,

--- a/instructor/utils/core.py
+++ b/instructor/utils/core.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 import inspect
 import json
 import logging
+import re
 from collections.abc import AsyncGenerator, Generator, Iterable
 from typing import (
     TYPE_CHECKING,
@@ -44,9 +45,10 @@ def extract_json_from_codeblock(content: str) -> str:
     """
     Extract JSON from a string that may contain extra text.
 
-    The function looks for the first '{' and the last '}' in the string and
-    returns the content between them, inclusive. If no braces are found,
-    the original string is returned.
+    Strips ``<think>...</think>`` blocks (e.g. from reasoning models like
+    Kimi K2 Thinking) before locating the JSON. Then looks for the first
+    ``{`` and the last ``}`` and returns the content between them, inclusive.
+    If no braces are found, the original string is returned.
 
     Args:
         content: The string that may contain JSON
@@ -54,6 +56,8 @@ def extract_json_from_codeblock(content: str) -> str:
     Returns:
         The extracted JSON string
     """
+    # Strip <think>...</think> blocks that some models prepend
+    content = re.sub(r"<think>.*?</think>", "", content, flags=re.DOTALL).strip()
 
     first_brace = content.find("{")
     last_brace = content.rfind("}")

--- a/tests/test_json_extraction.py
+++ b/tests/test_json_extraction.py
@@ -391,3 +391,167 @@ class TestBedrockJSONParsing:
         assert result.name == "First"
         assert result.age == 30
         assert result.skills == ["python"]
+
+
+class TestThinkTagStripping:
+    """Test that <think> tags are stripped from content before JSON extraction."""
+
+    def test_extract_json_strips_think_tags(self):
+        """Test extract_json_from_codeblock strips <think>...</think> blocks."""
+        content = (
+            '<think>Let me reason about this...</think>\n{"name": "Alice", "age": 30}'
+        )
+        result = extract_json_from_codeblock(content)
+        parsed = json.loads(result)
+        assert parsed["name"] == "Alice"
+        assert parsed["age"] == 30
+
+    def test_extract_json_strips_multiline_think_tags(self):
+        """Test stripping multiline think tags."""
+        content = (
+            "<think>\nStep 1: Analyze the request\n"
+            "Step 2: Build the response\n</think>\n"
+            '```json\n{"name": "Bob", "age": 25}\n```'
+        )
+        result = extract_json_from_codeblock(content)
+        parsed = json.loads(result)
+        assert parsed["name"] == "Bob"
+        assert parsed["age"] == 25
+
+    def test_extract_json_no_think_tags(self):
+        """Test that normal JSON without think tags still works."""
+        content = '{"name": "Charlie", "age": 35}'
+        result = extract_json_from_codeblock(content)
+        parsed = json.loads(result)
+        assert parsed["name"] == "Charlie"
+        assert parsed["age"] == 35
+
+
+class TestBedrockMdJsonParsing:
+    """Test the parse_bedrock_md_json functionality."""
+
+    def test_parse_bedrock_md_json_with_think_tags(self):
+        """Test parsing Bedrock MD_JSON response with think tags."""
+        completion = {
+            "output": {
+                "message": {
+                    "content": [
+                        {
+                            "text": (
+                                "<think>Let me analyze this request and determine "
+                                "the correct JSON output.</think>\n"
+                                '```json\n{"name": "Kimi", "age": 28, "skills": ["reasoning"]}\n```'
+                            )
+                        }
+                    ]
+                }
+            }
+        }
+
+        result = cast(PersonSchema, PersonSchema.parse_bedrock_md_json(completion))
+        assert result.name == "Kimi"
+        assert result.age == 28
+        assert result.skills == ["reasoning"]
+
+    def test_parse_bedrock_md_json_plain_json_after_think(self):
+        """Test parsing when model returns plain JSON after think tags (no codeblock)."""
+        completion = {
+            "output": {
+                "message": {
+                    "content": [
+                        {
+                            "text": (
+                                "<think>Reasoning about the response...</think>\n"
+                                '{"name": "Test", "age": 30, "skills": ["python"]}'
+                            )
+                        }
+                    ]
+                }
+            }
+        }
+
+        result = cast(PersonSchema, PersonSchema.parse_bedrock_md_json(completion))
+        assert result.name == "Test"
+        assert result.age == 30
+
+    def test_parse_bedrock_md_json_no_think_tags(self):
+        """Test parsing Bedrock MD_JSON without think tags (regular codeblock)."""
+        completion = {
+            "output": {
+                "message": {
+                    "content": [
+                        {
+                            "text": '```json\n{"name": "Regular", "age": 25, "skills": []}\n```'
+                        }
+                    ]
+                }
+            }
+        }
+
+        result = cast(PersonSchema, PersonSchema.parse_bedrock_md_json(completion))
+        assert result.name == "Regular"
+        assert result.age == 25
+
+    def test_parse_bedrock_md_json_multiline_think(self):
+        """Test parsing with extensive multiline think content."""
+        completion = {
+            "output": {
+                "message": {
+                    "content": [
+                        {
+                            "text": (
+                                "<think>\n"
+                                "Step 1: The user wants to extract a person.\n"
+                                "Step 2: I need to return JSON.\n"
+                                "Step 3: Let me format it properly.\n"
+                                "</think>\n"
+                                '{"name": "Deep Thinker", "age": 42, "skills": ["analysis", "logic"]}'
+                            )
+                        }
+                    ]
+                }
+            }
+        }
+
+        result = cast(PersonSchema, PersonSchema.parse_bedrock_md_json(completion))
+        assert result.name == "Deep Thinker"
+        assert result.age == 42
+        assert "analysis" in result.skills
+
+    def test_parse_bedrock_md_json_no_text_content(self):
+        """Test parsing Bedrock MD_JSON when no text content is found."""
+        completion = {
+            "output": {
+                "message": {
+                    "content": [
+                        {"reasoningText": "Only reasoning, no text response"},
+                    ]
+                }
+            }
+        }
+
+        with pytest.raises(ValueError) as excinfo:
+            PersonSchema.parse_bedrock_md_json(completion)
+        assert "No text content found" in str(excinfo.value)
+
+    def test_parse_bedrock_md_json_with_reasoning_and_think(self):
+        """Test parsing with both reasoningText blocks and think tags in text."""
+        completion = {
+            "output": {
+                "message": {
+                    "content": [
+                        {"reasoningText": "Internal reasoning content..."},
+                        {
+                            "text": (
+                                "<think>Additional visible reasoning</think>\n"
+                                '{"name": "Combined", "age": 33, "skills": ["mixed"]}'
+                            )
+                        },
+                    ]
+                }
+            }
+        }
+
+        result = cast(PersonSchema, PersonSchema.parse_bedrock_md_json(completion))
+        assert result.name == "Combined"
+        assert result.age == 33


### PR DESCRIPTION
Enables `MD_JSON` mode for Bedrock clients and adds `<think>...</think>` tag stripping so models like Kimi K2 Thinking work without spurious retries.\n\nFixes #2076