### PR TITLE
fix: add missing Anthropic modes to initialize_usage

### DIFF
--- a/instructor/core/retry.py
+++ b/instructor/core/retry.py
@@ -107,7 +107,7 @@ def initialize_usage(mode: Mode) -> CompletionUsage | Any:
         ),
         prompt_tokens_details=PromptTokensDetails(audio_tokens=0, cached_tokens=0),
     )
-    if mode in {Mode.ANTHROPIC_TOOLS, Mode.ANTHROPIC_JSON}:
+    if mode in {Mode.ANTHROPIC_TOOLS, Mode.ANTHROPIC_JSON, Mode.ANTHROPIC_REASONING_TOOLS, Mode.ANTHROPIC_PARALLEL_TOOLS}:
         from anthropic.types import Usage as AnthropicUsage
 
         total_usage = AnthropicUsage(


### PR DESCRIPTION
## Summary

`initialize_usage` in `instructor/core/retry.py` only checks for `Mode.ANTHROPIC_TOOLS` and `Mode.ANTHROPIC_JSON` when deciding whether to create an Anthropic `Usage` accumulator. This misses `Mode.ANTHROPIC_REASONING_TOOLS` and `Mode.ANTHROPIC_PARALLEL_TOOLS`.

When either of those modes is used, the function falls through to returning an OpenAI `CompletionUsage` object. The retry loop then tries to accumulate Anthropic usage fields (`input_tokens`, `output_tokens`) into OpenAI fields (`prompt_tokens`, `completion_tokens`), silently breaking token usage tracking across retries.

## Fix

Add `Mode.ANTHROPIC_REASONING_TOOLS` and `Mode.ANTHROPIC_PARALLEL_TOOLS` to the mode check set on line 110:

```python
# Before
if mode in {Mode.ANTHROPIC_TOOLS, Mode.ANTHROPIC_JSON}:

# After
if mode in {Mode.ANTHROPIC_TOOLS, Mode.ANTHROPIC_JSON, Mode.ANTHROPIC_REASONING_TOOLS, Mode.ANTHROPIC_PARALLEL_TOOLS}:
```

This is the only place in `retry.py` that checks Anthropic modes, so no other changes are needed.

---

*This PR was written by Claude Opus 4.6 (an AI). See [more context](https://maxcalkin.com).*