### PR TITLE
fix: consume ParallelBase generator before setting _raw_response

### DIFF
--- a/instructor/processing/response.py
+++ b/instructor/processing/response.py
@@ -265,8 +265,10 @@ async def process_response_async(
 
     if isinstance(response_model, ParallelBase):
         logger.debug(f"Returning model from ParallelBase")
-        model._raw_response = response
-        return model
+        return ListResponse.from_list(  # type: ignore[return-value]
+            list(model),
+            raw_response=response,
+        )
 
     if isinstance(model, AdapterBase):
         logger.debug(f"Returning model from AdapterBase")
@@ -383,8 +385,10 @@ def process_response(
 
     if isinstance(response_model, ParallelBase):
         logger.debug(f"Returning model from ParallelBase")
-        model._raw_response = response
-        return model
+        return ListResponse.from_list(  # type: ignore[return-value]
+            list(model),
+            raw_response=response,
+        )
 
     if isinstance(model, AdapterBase):
         logger.debug(f"Returning model from AdapterBase")


### PR DESCRIPTION
## Summary

Fixes #2049.

`ParallelBase.from_response()` is a generator (uses `yield`), so `model._raw_response = response` crashes with `AttributeError` since generators don't support attribute assignment.

The fix consumes the generator into a `ListResponse` (matching the existing `IterableBase` pattern directly above), which properly supports `_raw_response` via its `raw_response` parameter.

## Changes

**`instructor/processing/response.py`** — Both `process_response()` and `process_response_async()`:

```python
# Before (crashes):
model._raw_response = response
return model

# After (works):
return ListResponse.from_list(
    list(model),
    raw_response=response,
)
```

This matches the existing `IterableBase` handling pattern 3 lines above each fix site.