### PR TITLE
fix: return message unchanged for unrecognized formats in process_message

### DIFF
--- a/instructor/templating.py
+++ b/instructor/templating.py
@@ -80,6 +80,9 @@ def process_message(
         message["message"] = apply_template(message["message"], context)
         return message
 
+    # Unknown format: return message unchanged
+    return message
+
 
 def handle_templating(
     kwargs: dict[str, Any], mode: Mode, context: dict[str, Any] | None = None


### PR DESCRIPTION
## Summary

`process_message()` in `instructor/templating.py` returns `None` when a message doesn't match any recognized format (OpenAI, Anthropic, Gemini, Cohere, VertexAI, GENAI).

This causes `None` values to be inserted into the messages list via `handle_templating()`:
```python
new_kwargs["messages"] = [
    process_message(message, context, mode) for message in messages
]
# If any message has an unrecognized format, the list contains None
```

## Fix

Add a fallback `return message` at the end of `process_message()` so unrecognized message formats pass through unchanged instead of being silently dropped.

## Changes

**`instructor/templating.py`** — Add after the Cohere format block:

```python
    # Unknown format: return message unchanged
    return message
```