### PR TITLE
fix: preserve field defaults in partial streaming instead of using None

### DIFF
--- a/instructor/dsl/partial.py
+++ b/instructor/dsl/partial.py
@@ -31,6 +31,7 @@ from typing import (  # noqa: UP035
 from jiter import from_json
 from pydantic import BaseModel, create_model
 from pydantic.fields import FieldInfo
+from pydantic_core import PydanticUndefined
 
 from instructor.mode import Mode
 from instructor.utils import extract_json_from_stream, extract_json_from_stream_async
@@ -171,7 +172,7 @@ def _build_partial_object(
         else:
             result[field_name] = field_value
 
-    # Set missing fields to None or empty nested models
+    # Set missing fields to their defaults (if any), None, or empty nested models
     for field_name, field_info in model.model_fields.items():
         if field_name not in result:
             field_type = field_info.annotation
@@ -179,6 +180,10 @@ def _build_partial_object(
                 result[field_name] = _build_partial_object(
                     {}, field_type, tracker, "", **kwargs
                 )
+            elif field_info.default is not PydanticUndefined:
+                result[field_name] = field_info.default
+            elif field_info.default_factory is not None:
+                result[field_name] = field_info.default_factory()
             else:
                 result[field_name] = None
 

--- a/tests/dsl/test_partial.py
+++ b/tests/dsl/test_partial.py
@@ -1129,3 +1129,111 @@ class TestRecursiveModels:
         assert result.content[0].text == "Introduction paragraph"
         assert result.content[1].title == "Section 1.1"
         assert result.content[1].content[1].title == "Subsection 1.1.1"
+
+
+class TestFieldDefaultsDuringStreaming:
+    """Tests that field defaults are preserved in partial objects during streaming.
+
+    When streaming incomplete JSON, fields not yet present in the data should
+    use their declared default values instead of being set to None.
+    Fixes: https://github.com/instructor-ai/instructor/issues/2054
+    """
+
+    def test_literal_default_preserved_in_partial_stream(self):
+        """Literal field with default should show default in partial responses."""
+        from instructor.dsl.partial import Partial, process_potential_object
+
+        class Person(BaseModel):
+            type: Literal["Person"] = "Person"
+            name: str
+            age: int
+
+        PartialModel = Partial[Person]
+        partial_model = PartialModel.get_partial_model()
+
+        # Simulate early streaming: only name has arrived, type not yet streamed
+        incomplete_json = '{"name": "Joh'
+        result = process_potential_object(
+            incomplete_json, partial_mode="trailing-strings", partial_model=partial_model
+        )
+        # type should use its default value "Person", not None
+        assert result.type == "Person"
+        assert result.name == "Joh"
+        assert result.age is None
+
+    def test_literal_default_preserved_with_complete_partial(self):
+        """Literal field default should be present even when other fields are complete."""
+        from instructor.dsl.partial import Partial, process_potential_object
+
+        class Person(BaseModel):
+            type: Literal["Person"] = "Person"
+            name: str
+            age: int
+
+        PartialModel = Partial[Person]
+        partial_model = PartialModel.get_partial_model()
+
+        # name and age are present but type hasn't been streamed yet
+        incomplete_json = '{"name": "John", "age": 31'
+        result = process_potential_object(
+            incomplete_json, partial_mode="trailing-strings", partial_model=partial_model
+        )
+        assert result.type == "Person"
+        assert result.name == "John"
+        assert result.age == 31
+
+    def test_default_factory_preserved_in_partial_stream(self):
+        """Fields with default_factory should use factory value in partial responses."""
+        from instructor.dsl.partial import Partial, process_potential_object
+
+        class TaggedItem(BaseModel):
+            name: str
+            tags: list[str] = Field(default_factory=list)
+
+        PartialModel = Partial[TaggedItem]
+        partial_model = PartialModel.get_partial_model()
+
+        incomplete_json = '{"name": "ite'
+        result = process_potential_object(
+            incomplete_json, partial_mode="trailing-strings", partial_model=partial_model
+        )
+        assert result.name == "ite"
+        assert result.tags == []
+
+    def test_simple_default_preserved_in_partial_stream(self):
+        """Fields with simple default values should use them in partial responses."""
+        from instructor.dsl.partial import Partial, process_potential_object
+
+        class Config(BaseModel):
+            name: str
+            enabled: bool = True
+            priority: int = 5
+
+        PartialModel = Partial[Config]
+        partial_model = PartialModel.get_partial_model()
+
+        incomplete_json = '{"name": "tes'
+        result = process_potential_object(
+            incomplete_json, partial_mode="trailing-strings", partial_model=partial_model
+        )
+        assert result.name == "tes"
+        assert result.enabled is True
+        assert result.priority == 5
+
+    def test_no_default_still_none_in_partial_stream(self):
+        """Fields without defaults should still be None in partial responses."""
+        from instructor.dsl.partial import Partial, process_potential_object
+
+        class Person(BaseModel):
+            name: str
+            age: int
+
+        PartialModel = Partial[Person]
+        partial_model = PartialModel.get_partial_model()
+
+        incomplete_json = '{"name": "Jo'
+        result = process_potential_object(
+            incomplete_json, partial_mode="trailing-strings", partial_model=partial_model
+        )
+        assert result.name == "Jo"
+        assert result.age is None


### PR DESCRIPTION
## Summary

Fixes #2054.

When streaming incomplete JSON via `Partial`, the `_build_partial_object()` function unconditionally set missing fields to `None`, ignoring any declared default values. This caused fields like `type: Literal["Person"] = "Person"` to appear as `None` in every partial response until the LLM happened to stream them — typically at the very end.

This is a problem for frontend rendering that relies on discriminator fields (e.g. `type`) to select components, since the field is `None` through most of the stream.

## Changes

**`instructor/dsl/partial.py`**:
- Import `PydanticUndefined` from `pydantic_core`
- In `_build_partial_object()`, check `field_info.default` and `field_info.default_factory` before falling back to `None` for missing fields

**`tests/dsl/test_partial.py`**:
- Add `TestFieldDefaultsDuringStreaming` class with 5 tests:
  - Literal field with default preserved in partial stream
  - Literal default preserved alongside complete fields
  - `default_factory` fields (e.g. `list`) use factory value
  - Simple defaults (`bool`, `int`) preserved
  - Fields without defaults still return `None` (no regression)

## Before



## After



## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] If it is a core feature, I have added thorough tests.