### PR TITLE
fix(process_response): use issubclass instead of isinstance for ParallelBase check

### DIFF
--- a/instructor/processing/response.py
+++ b/instructor/processing/response.py
@@ -263,7 +263,7 @@ async def process_response_async(
             raw_response=response,
         )
 
-    if isinstance(response_model, ParallelBase):
+    if inspect.isclass(response_model) and issubclass(response_model, ParallelBase):
         logger.debug(f"Returning model from ParallelBase")
         model._raw_response = response
         return model
@@ -381,7 +381,7 @@ def process_response(
             raw_response=response,
         )
 
-    if isinstance(response_model, ParallelBase):
+    if inspect.isclass(response_model) and issubclass(response_model, ParallelBase):
         logger.debug(f"Returning model from ParallelBase")
         model._raw_response = response
         return model


### PR DESCRIPTION
## Problem

When `response_model` is a `ParallelBase` subclass (e.g. `Parallel[ToolA, ToolB]`), the check `isinstance(response_model, ParallelBase)` always returns `False` because `response_model` is a **class object**, not an instance of `ParallelBase`.

This causes the function to fall through to `model._raw_response = response`, which crashes when `model` is a generator:

```
AttributeError: 'generator' object has no attribute '_raw_response'
and no __dict__ for setting new attributes
```

Fixes #2049

## Root Cause

In `instructor/processing/response.py`, there are two places with:

```python
if isinstance(response_model, ParallelBase):   # ← WRONG
```

`response_model` is always a **type** (class), not an instance. The correct check is:

```python
if inspect.isclass(response_model) and issubclass(response_model, ParallelBase):   # ✓
```

## Fix

Replace both `isinstance` checks with `inspect.isclass(...) and issubclass(...)` — `inspect` is already imported in the file.

This matches the pattern already used elsewhere in the codebase for checking `IterableBase`, `PartialBase`, etc.
