### PR TITLE
fix(multimodal): add missing continue in convert_messages for typed messages

### DIFF
--- a/instructor/processing/multimodal.py
+++ b/instructor/processing/multimodal.py
@@ -1049,6 +1049,7 @@ def convert_messages(
         if "type" in message:
             if message["type"] in {"audio", "image"}:
                 converted_messages.append(message)  # type: ignore
+                continue
             else:
                 raise ValueError(f"Unsupported message type: {message['type']}")
         role = message["role"]


### PR DESCRIPTION
## Summary

- `convert_messages()` in `instructor/processing/multimodal.py` appends typed messages (audio/image with a `"type"` key) to the result list but then falls through to access `message["role"]` on the next line, raising a `KeyError` when the typed message dict lacks a `"role"` key.
- Added a `continue` statement after appending typed messages so execution skips the role/content processing path that doesn't apply to them.

## What was wrong

In the message processing loop (line ~1048-1054), when a message has `"type"` in `{"audio", "image"}`, it is correctly appended to `converted_messages`, but execution continues past that block and hits `role = message["role"]`, which fails with a `KeyError` if the message doesn't have a `"role"` key.

The `else` branch (unsupported type) raises `ValueError`, which implicitly stops processing — but the happy path (valid typed message) was missing the `continue` to skip the rest of the loop body.

## Test plan

- [x] Verified that messages with `{"type": "audio", ...}` or `{"type": "image", ...}` that lack a `"role"` key no longer raise `KeyError`
- [x] Verified that messages with both `"type"` and `"role"` keys still work correctly
- [x] Verified that unsupported message types still raise `ValueError`

🤖 Generated with [Claude Code](https://claude.com/claude-code)