### PR TITLE
fix(function_calls): remove duplicate ANTHROPIC_TOOLS check in from_response

### DIFF
--- a/instructor/processing/function_calls.py
+++ b/instructor/processing/function_calls.py
@@ -156,10 +156,7 @@ class OpenAISchema(BaseModel):
             cls (OpenAISchema): An instance of the class
         """
 
-        if mode == Mode.ANTHROPIC_TOOLS:
-            return cls.parse_anthropic_tools(completion, validation_context, strict)
-
-        if mode == Mode.ANTHROPIC_TOOLS or mode == Mode.ANTHROPIC_REASONING_TOOLS:
+        if mode in {Mode.ANTHROPIC_TOOLS, Mode.ANTHROPIC_REASONING_TOOLS}:
             return cls.parse_anthropic_tools(completion, validation_context, strict)
 
         if mode == Mode.ANTHROPIC_JSON:


### PR DESCRIPTION
## Summary

- Removed a redundant duplicate check for `Mode.ANTHROPIC_TOOLS` in `OpenAISchema.from_response()` that made the `ANTHROPIC_REASONING_TOOLS` branch unreachable via the intended code path.
- Consolidated two separate checks into a single `mode in {Mode.ANTHROPIC_TOOLS, Mode.ANTHROPIC_REASONING_TOOLS}` set membership test.

## What was wrong

In `instructor/processing/function_calls.py`, the `from_response()` method had:

```python
if mode == Mode.ANTHROPIC_TOOLS:                              # line 159
    return cls.parse_anthropic_tools(...)

if mode == Mode.ANTHROPIC_TOOLS or mode == Mode.ANTHROPIC_REASONING_TOOLS:  # line 162
    return cls.parse_anthropic_tools(...)
```

The first check on line 159 always returned for `ANTHROPIC_TOOLS`, so the second check on line 162 could only ever match `ANTHROPIC_REASONING_TOOLS`. While `ANTHROPIC_REASONING_TOOLS` still worked (it matched the second condition), the code was misleading and fragile — if the first check were ever modified independently (e.g., to dispatch to a different parser), `ANTHROPIC_REASONING_TOOLS` would silently break.

## Test plan

- [x] Verified both `Mode.ANTHROPIC_TOOLS` and `Mode.ANTHROPIC_REASONING_TOOLS` still dispatch to `parse_anthropic_tools`
- [x] No behavioral change — only dead/redundant code removed

🤖 Generated with [Claude Code](https://claude.com/claude-code)