### PR TITLE
fix(mistral): handle breaking import change in mistralai v2.0.0

### DIFF
--- a/instructor/providers/mistral/client.py
+++ b/instructor/providers/mistral/client.py
@@ -2,7 +2,10 @@
 from __future__ import annotations
 
 
-from mistralai import Mistral
+try:
+    from mistralai.client import Mistral  # New v2 path
+except ImportError:
+    from mistralai import Mistral         # Old v1 path
 import instructor
 from typing import overload, Any, Literal
 

--- a/tests/llm/test_mistral/test_import.py
+++ b/tests/llm/test_mistral/test_import.py
@@ -1,0 +1,54 @@
+import os
+import pytest
+from pydantic import BaseModel
+import instructor
+
+try:
+    # mistralai v2.0.0+
+    from mistralai.client import Mistral
+except ImportError:
+    # mistralai v1.x
+    from mistralai import Mistral
+
+
+class UserDetail(BaseModel):
+    name: str
+    age: int
+
+
+def test_mistral_client_init():
+    """Test that we can initialize and patch the Mistral client successfully."""
+    # We use a dummy API key for instantiation test if one isn't provided
+    api_key = os.environ.get("MISTRAL_API_KEY", "dummy-key-for-test")
+
+    mistral_client = Mistral(api_key=api_key)
+
+    # We just want to ensure patching doesn't raise an exception
+    # due to strict type checks returning False for Mistral v2.0 clients
+    client = instructor.from_mistral(mistral_client)
+
+    assert client is not None
+    assert hasattr(client, "chat")
+
+
+@pytest.mark.skipif(
+    not os.environ.get("MISTRAL_API_KEY"), reason="MISTRAL_API_KEY must be set"
+)
+def test_mistral_extraction():
+    """Test a live extraction if the API key is provided."""
+    mistral_client = Mistral(api_key=os.environ.get("MISTRAL_API_KEY"))
+    client = instructor.from_mistral(mistral_client)
+
+    user = client.chat.completions.create(
+        model="mistral-large-latest",
+        response_model=UserDetail,
+        messages=[
+            {
+                "role": "user",
+                "content": "Kitan is a 18 year old engineer living in Alapere.",
+            }
+        ],
+    )
+
+    assert user.name == "Kitan"
+    assert user.age == 18


### PR DESCRIPTION
Title: fix: resolve ImportError by handling mistralai v2.0.0 package structure

Description:
The recent release of mistralai v2.0.0 (March 10, 2026) introduced breaking changes to the internal package structure, specifically moving the Mistral client from the root namespace to mistralai.client. This prevents the instructor Mistral provider from initializing, even for users who are not explicitly using Mistral models.
This PR implements a backward-compatible import strategy using a try-except block. This ensures that:

v2.x users are correctly routed to the new mistralai.client path.
v1.x users (legacy) can continue using the library without upgrading.
Changes:

Modified instructor/providers/mistral/client.py to handle both mistralai v1.x and v2.x import paths.
Validation:

Verified successful import on mistralai==2.0.0.
Verified successful import on mistralai==1.5.0 (Legacy).
Confirmed that the fix unblocks other providers when mistralai is present in the environment.
Fixes #2137
