### PR TITLE
fix: support mistralai 2.0.0 import change

### DIFF
--- a/instructor/auto_client.py
+++ b/instructor/auto_client.py
@@ -519,7 +519,10 @@ def from_provider(
 
     elif provider == "mistral":
         try:
-            from mistralai import Mistral
+            try:
+                from mistralai import Mistral
+            except ImportError:
+                from mistralai.client import Mistral
             from instructor import from_mistral  # type: ignore[attr-defined]
             import os
 

--- a/instructor/providers/__init__.py
+++ b/instructor/providers/__init__.py
@@ -52,9 +52,12 @@ if importlib.util.find_spec("groq") is not None:
     __all__.append("from_groq")
 
 if importlib.util.find_spec("mistralai") is not None:
-    from .mistral.client import from_mistral  # noqa: F401
-
-    __all__.append("from_mistral")
+    try:
+        from .mistral.client import from_mistral  # noqa: F401
+    except ImportError:
+        pass
+    else:
+        __all__.append("from_mistral")
 
 if importlib.util.find_spec("openai") is not None:
     from .perplexity.client import from_perplexity  # noqa: F401

--- a/instructor/providers/mistral/client.py
+++ b/instructor/providers/mistral/client.py
@@ -2,7 +2,10 @@
 from __future__ import annotations
 
 
-from mistralai import Mistral
+try:
+    from mistralai import Mistral
+except ImportError:
+    from mistralai.client import Mistral
 import instructor
 from typing import overload, Any, Literal
 


### PR DESCRIPTION
## Summary

Fixes #2137

`mistralai` 2.0.0 (released 2 days ago) moved the `Mistral` class from `mistralai.Mistral` to `mistralai.client.Mistral`, causing an `ImportError` that breaks `instructor` — even for users not using Mistral — because the import runs at module load time.

## Changes

| File | Change |
|---|---|
| `instructor/providers/mistral/client.py` | Try `from mistralai import Mistral`, fall back to `from mistralai.client import Mistral` |
| `instructor/auto_client.py` | Same try/except pattern for the auto-client Mistral import |
| `instructor/providers/__init__.py` | Wrap mistral import in try/except to prevent entire providers module from breaking |

## Testing

- Verified import works with **mistralai 2.0.0** (new import path)
- Verified backward compatibility with **mistralai 1.10.0** (old import path)
- All existing tests pass (no regressions)