### PR TITLE
docs: update GitHub organization name in README links

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ print(user)  # User(name='John', age=25)
 
 [![PyPI](https://img.shields.io/pypi/v/instructor?style=flat-square)](https://pypi.org/project/instructor/)
 [![Downloads](https://img.shields.io/pypi/dm/instructor?style=flat-square)](https://pypi.org/project/instructor/)
-[![GitHub Stars](https://img.shields.io/github/stars/instructor-ai/instructor?style=flat-square)](https://github.com/instructor-ai/instructor)
+[![GitHub Stars](https://img.shields.io/github/stars/567-labs/instructor?style=flat-square)](https://github.com/567-labs/instructor)
 [![Discord](https://img.shields.io/discord/1192334452110659664?style=flat-square)](https://discord.gg/bD9YE9JArw)
 [![Twitter](https://img.shields.io/twitter/follow/jxnlco?style=flat-square)](https://twitter.com/jxnlco)
 
@@ -283,14 +283,14 @@ Instructor's simple API is available in many languages:
 
 ## Contributing
 
-We welcome contributions! Check out our [good first issues](https://github.com/instructor-ai/instructor/labels/good%20first%20issue) to get started.
+We welcome contributions! Check out our [good first issues](https://github.com/567-labs/instructor/labels/good%20first%20issue) to get started.
 
 ## License
 
-MIT License - see [LICENSE](https://github.com/instructor-ai/instructor/blob/main/LICENSE) for details.
+MIT License - see [LICENSE](https://github.com/567-labs/instructor/blob/main/LICENSE) for details.
 
 ---
 
 <p align="center">
-Built by the Instructor community. Special thanks to <a href="https://twitter.com/jxnlco">Jason Liu</a> and all <a href="https://github.com/instructor-ai/instructor/graphs/contributors">contributors</a>.
+Built by the Instructor community. Special thanks to <a href="https://twitter.com/jxnlco">Jason Liu</a> and all <a href="https://github.com/567-labs/instructor/graphs/contributors">contributors</a>.
 </p>


### PR DESCRIPTION
## Description

Updated all GitHub links in README.md from `instructor-ai/instructor` to `567-labs/instructor` to reflect the repository move.

## Changes
- Updated GitHub stars badge link
- Updated "good first issues" link in Contributing section
- Updated LICENSE link
- Updated contributors graph link

## Motivation
The repository has moved from the `instructor-ai` organization to `567-labs`. While the old URLs still work via 301 redirects, it's better to use the canonical URLs to:
- Avoid unnecessary redirects
- Reflect the current project organization
- Keep documentation accurate

## Type of Change
- [x] Documentation fix
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change