### PR TITLE
fix(gemini): remove IMAGE_ harm categories for Gemini API

### DIFF
--- a/instructor/providers/gemini/utils.py
+++ b/instructor/providers/gemini/utils.py
@@ -304,66 +304,6 @@ def update_genai_kwargs(
             if val is not None:  # Only set if value is not None
                 base_config[gemini_key] = val
 
-    def _genai_kwargs_has_image_content(genai_kwargs: dict[str, Any]) -> bool:
-        """
-        Best-effort check for image content in a GenAI request.
-
-        We use this to decide whether to send text vs image harm categories in
-        `safety_settings`. The google-genai SDK has separate image categories
-        (e.g., `HARM_CATEGORY_IMAGE_HATE`) which are required for image content.
-        """
-        # Prefer typed GenAI contents if present (works with autodetect_images)
-        contents = genai_kwargs.get("contents")
-        if isinstance(contents, list):
-            for content in contents:
-                parts = getattr(content, "parts", None)
-                if not parts:
-                    continue
-                for part in parts:
-                    inline_data = getattr(part, "inline_data", None)
-                    if inline_data is not None:
-                        mime_type = getattr(inline_data, "mime_type", None)
-                        if isinstance(mime_type, str) and mime_type.startswith(
-                            "image/"
-                        ):
-                            return True
-
-                    file_data = getattr(part, "file_data", None)
-                    if file_data is not None:
-                        mime_type = getattr(file_data, "mime_type", None)
-                        if isinstance(mime_type, str) and mime_type.startswith(
-                            "image/"
-                        ):
-                            return True
-
-        # Fall back to OpenAI-style messages if present
-        messages = genai_kwargs.get("messages")
-        if isinstance(messages, list):
-            for message in messages:
-                if not isinstance(message, dict):
-                    continue
-                content = message.get("content")
-                if isinstance(content, Image):
-                    return True
-                if isinstance(content, list):
-                    for item in content:
-                        if isinstance(item, Image):
-                            return True
-                        if isinstance(item, dict) and item.get("type") in {
-                            "image",
-                            "image_url",
-                            "input_image",
-                        }:
-                            return True
-                if isinstance(content, dict) and content.get("type") in {
-                    "image",
-                    "image_url",
-                    "input_image",
-                }:
-                    return True
-
-        return False
-
     safety_settings = new_kwargs.pop("safety_settings", {})
     base_config["safety_settings"] = []
 
@@ -381,44 +321,20 @@ def update_genai_kwargs(
         excluded_categories.add(HarmCategory.HARM_CATEGORY_JAILBREAK)
 
     if safety_settings is not None:
-        # google-genai has separate categories for image content.
-        has_image = _genai_kwargs_has_image_content(new_kwargs)
-        image_categories = [
-            c
-            for c in HarmCategory
-            if c not in excluded_categories
-            and c.name.startswith("HARM_CATEGORY_IMAGE_")
-        ]
-        text_categories = [
+        # Use only text harm categories for the Gemini API.
+        # IMAGE_ harm categories are only supported by Vertex AI API, not the standard
+        # Gemini API. See: https://github.com/instructor-ai/instructor/issues/2146
+        supported_categories = [
             c
             for c in HarmCategory
             if c not in excluded_categories
             and not c.name.startswith("HARM_CATEGORY_IMAGE_")
         ]
 
-        supported_categories = (
-            image_categories if (has_image and image_categories) else text_categories
-        )
-
-        def _map_text_to_image_category_name(image_category_name: str) -> str | None:
-            suffix = image_category_name.removeprefix("HARM_CATEGORY_IMAGE_")
-            # google-genai uses IMAGE_HATE while text uses HATE_SPEECH
-            if suffix == "HATE":
-                return "HARM_CATEGORY_HATE_SPEECH"
-            return f"HARM_CATEGORY_{suffix}"
-
         for category in supported_categories:
             threshold = HarmBlockThreshold.OFF
-            if isinstance(safety_settings, dict):
-                if category in safety_settings:
-                    threshold = safety_settings[category]
-                # If we are using image categories, try to honor thresholds passed via text categories.
-                elif has_image and category.name.startswith("HARM_CATEGORY_IMAGE_"):
-                    mapped_name = _map_text_to_image_category_name(category.name)
-                    if mapped_name is not None and hasattr(HarmCategory, mapped_name):
-                        mapped_category = getattr(HarmCategory, mapped_name)
-                        if mapped_category in safety_settings:
-                            threshold = safety_settings[mapped_category]
+            if isinstance(safety_settings, dict) and category in safety_settings:
+                threshold = safety_settings[category]
 
             base_config["safety_settings"].append(
                 {

--- a/tests/genai/test_safety_settings.py
+++ b/tests/genai/test_safety_settings.py
@@ -1,8 +1,12 @@
 from instructor.providers.gemini.utils import update_genai_kwargs
 
 
-def test_update_genai_kwargs_safety_settings_with_image_content_uses_image_categories():
-    """Image inputs should use IMAGE_* harm categories when available."""
+def test_update_genai_kwargs_safety_settings_with_image_content_uses_text_categories():
+    """Image inputs should use text harm categories for Gemini API (not IMAGE_*).
+    
+    IMAGE_* harm categories are only supported by Vertex AI API, not the standard
+    Gemini API. See: https://github.com/instructor-ai/instructor/issues/2146
+    """
     from google.genai import types
     from google.genai.types import HarmCategory
 
@@ -10,15 +14,12 @@ def test_update_genai_kwargs_safety_settings_with_image_content_uses_image_categ
     if hasattr(HarmCategory, "HARM_CATEGORY_JAILBREAK"):
         excluded_categories.add(HarmCategory.HARM_CATEGORY_JAILBREAK)
 
-    image_categories = [
+    text_categories = [
         c
         for c in HarmCategory
-        if c not in excluded_categories and c.name.startswith("HARM_CATEGORY_IMAGE_")
+        if c not in excluded_categories
+        and not c.name.startswith("HARM_CATEGORY_IMAGE_")
     ]
-
-    # Older SDKs may not expose separate image categories.
-    if not image_categories:
-        return
 
     kwargs = {
         "contents": [
@@ -34,27 +35,37 @@ def test_update_genai_kwargs_safety_settings_with_image_content_uses_image_categ
 
     assert "safety_settings" in result
     assert isinstance(result["safety_settings"], list)
-    assert len(result["safety_settings"]) == len(image_categories)
-    assert {s["category"] for s in result["safety_settings"]} == set(image_categories)
+    # Should use text categories, not IMAGE_* categories
+    assert len(result["safety_settings"]) == len(text_categories)
+    assert {s["category"] for s in result["safety_settings"]} == set(text_categories)
 
 
-def test_update_genai_kwargs_maps_text_thresholds_to_image_categories():
-    """Text thresholds should carry over to equivalent IMAGE_* categories."""
+def test_update_genai_kwargs_safety_settings_does_not_use_image_categories():
+    """Gemini API should never use IMAGE_* harm categories."""
+    from google.genai import types
+    from google.genai.types import HarmCategory
+
+    kwargs = {
+        "contents": [
+            types.Content(
+                role="user",
+                parts=[types.Part.from_bytes(data=b"123", mime_type="image/png")],
+            )
+        ]
+    }
+    base_config = {}
+
+    result = update_genai_kwargs(kwargs, base_config)
+
+    # Ensure no IMAGE_* categories are used
+    for setting in result["safety_settings"]:
+        assert not setting["category"].name.startswith("HARM_CATEGORY_IMAGE_")
+
+
+def test_update_genai_kwargs_maps_custom_safety_settings():
+    """Custom safety settings should be applied to text categories."""
     from google.genai import types
     from google.genai.types import HarmBlockThreshold, HarmCategory
-
-    excluded_categories = {HarmCategory.HARM_CATEGORY_UNSPECIFIED}
-    if hasattr(HarmCategory, "HARM_CATEGORY_JAILBREAK"):
-        excluded_categories.add(HarmCategory.HARM_CATEGORY_JAILBREAK)
-
-    image_categories = [
-        c
-        for c in HarmCategory
-        if c not in excluded_categories and c.name.startswith("HARM_CATEGORY_IMAGE_")
-    ]
-
-    if not image_categories or not hasattr(HarmCategory, "HARM_CATEGORY_IMAGE_HATE"):
-        return
 
     custom_safety = {
         HarmCategory.HARM_CATEGORY_HATE_SPEECH: HarmBlockThreshold.BLOCK_LOW_AND_ABOVE
@@ -74,12 +85,15 @@ def test_update_genai_kwargs_maps_text_thresholds_to_image_categories():
     result = update_genai_kwargs(kwargs, base_config)
 
     for setting in result["safety_settings"]:
-        if setting["category"] == HarmCategory.HARM_CATEGORY_IMAGE_HATE:
+        if setting["category"] == HarmCategory.HARM_CATEGORY_HATE_SPEECH:
             assert setting["threshold"] == HarmBlockThreshold.BLOCK_LOW_AND_ABOVE
 
 
-def test_handle_genai_tools_autodetect_images_uses_image_categories():
-    """Autodetected image content should switch safety_settings to IMAGE_* categories."""
+def test_handle_genai_tools_autodetect_images_uses_text_categories():
+    """Autodetected image content should use text harm categories for Gemini API.
+    
+    IMAGE_* harm categories are only supported by Vertex AI API.
+    """
     from pydantic import BaseModel
 
     from instructor.providers.gemini.utils import handle_genai_tools
@@ -105,7 +119,8 @@ def test_handle_genai_tools_autodetect_images_uses_image_categories():
 
     assert "config" in out
     assert out["config"].safety_settings is not None
-    assert any(
-        s.category.name.startswith("HARM_CATEGORY_IMAGE_")
+    # Should use text categories, not IMAGE_* categories
+    assert all(
+        not s.category.name.startswith("HARM_CATEGORY_IMAGE_")
         for s in out["config"].safety_settings
     )

--- a/tests/llm/test_genai/test_utils.py
+++ b/tests/llm/test_genai/test_utils.py
@@ -108,8 +108,12 @@ def test_update_genai_kwargs_with_custom_safety_settings():
             assert setting["threshold"] == HarmBlockThreshold.OFF
 
 
-def test_update_genai_kwargs_safety_settings_with_image_content_uses_image_categories():
-    """Test that image content switches to IMAGE_* harm categories when available."""
+def test_update_genai_kwargs_safety_settings_with_image_content_uses_text_categories():
+    """Image content should use text harm categories for Gemini API (not IMAGE_*).
+
+    IMAGE_* harm categories are only supported by Vertex AI API, not the standard
+    Gemini API. See: https://github.com/instructor-ai/instructor/issues/2146
+    """
     from google.genai import types
     from google.genai.types import HarmCategory
 
@@ -117,15 +121,12 @@ def test_update_genai_kwargs_safety_settings_with_image_content_uses_image_categ
     if hasattr(HarmCategory, "HARM_CATEGORY_JAILBREAK"):
         excluded_categories.add(HarmCategory.HARM_CATEGORY_JAILBREAK)
 
-    image_categories = [
+    text_categories = [
         c
         for c in HarmCategory
-        if c not in excluded_categories and c.name.startswith("HARM_CATEGORY_IMAGE_")
+        if c not in excluded_categories
+        and not c.name.startswith("HARM_CATEGORY_IMAGE_")
     ]
-
-    # Older SDKs may not expose separate image categories.
-    if not image_categories:
-        return
 
     kwargs = {
         "contents": [
@@ -141,27 +142,15 @@ def test_update_genai_kwargs_safety_settings_with_image_content_uses_image_categ
 
     assert "safety_settings" in result
     assert isinstance(result["safety_settings"], list)
-    assert len(result["safety_settings"]) == len(image_categories)
-    assert {s["category"] for s in result["safety_settings"]} == set(image_categories)
+    # Should use text categories, not IMAGE_* categories
+    assert len(result["safety_settings"]) == len(text_categories)
+    assert {s["category"] for s in result["safety_settings"]} == set(text_categories)
 
 
-def test_update_genai_kwargs_maps_text_thresholds_to_image_categories():
-    """Test that text-based safety settings are applied to equivalent IMAGE_* categories."""
+def test_update_genai_kwargs_maps_safety_settings_for_image_content():
+    """Test that custom safety settings are applied for image content using text categories."""
     from google.genai import types
     from google.genai.types import HarmCategory, HarmBlockThreshold
-
-    excluded_categories = {HarmCategory.HARM_CATEGORY_UNSPECIFIED}
-    if hasattr(HarmCategory, "HARM_CATEGORY_JAILBREAK"):
-        excluded_categories.add(HarmCategory.HARM_CATEGORY_JAILBREAK)
-
-    image_categories = [
-        c
-        for c in HarmCategory
-        if c not in excluded_categories and c.name.startswith("HARM_CATEGORY_IMAGE_")
-    ]
-
-    if not image_categories or not hasattr(HarmCategory, "HARM_CATEGORY_IMAGE_HATE"):
-        return
 
     custom_safety = {
         HarmCategory.HARM_CATEGORY_HATE_SPEECH: HarmBlockThreshold.BLOCK_LOW_AND_ABOVE
@@ -180,8 +169,9 @@ def test_update_genai_kwargs_maps_text_thresholds_to_image_categories():
 
     result = update_genai_kwargs(kwargs, base_config)
 
+    # Should apply custom safety setting to HATE_SPEECH category (not IMAGE_HATE)
     for setting in result["safety_settings"]:
-        if setting["category"] == HarmCategory.HARM_CATEGORY_IMAGE_HATE:
+        if setting["category"] == HarmCategory.HARM_CATEGORY_HATE_SPEECH:
             assert setting["threshold"] == HarmBlockThreshold.BLOCK_LOW_AND_ABOVE
 
 


### PR DESCRIPTION
## Summary

Fixes #2146

The SafetySettings changes in PR #2007 incorrectly used IMAGE_ harm categories (e.g., HARM_CATEGORY_IMAGE_HATE) for image content when using the Gemini API. However, these categories are **only supported by Vertex AI API**, not the standard Gemini API.

## Root Cause

The `update_genai_kwargs` function was checking for image content and switching to IMAGE_ harm categories when detected. This worked in the SDK but fails when actually calling the Gemini API, which rejects these categories.

## Changes

- Removed the image content detection logic (`_genai_kwargs_has_image_content`)
- Removed the logic that switched between text and image harm categories
- Now always uses standard text harm categories for the Gemini API
- Updated tests to reflect the correct behavior

## Verification

- All existing unit tests pass
- New tests verify that IMAGE_ categories are never used
- Tested with both text and image content scenarios

## References

- Gemini API HarmCategory: https://ai.google.dev/api/generate-content#harmcategory (no IMAGE_ categories)
- Vertex AI HarmCategory: https://docs.cloud.google.com/vertex-ai/generative-ai/docs/reference/rest/v1/HarmCategory (has IMAGE_ categories)

---

I confirm that I have read and understood the CLA, and I agree to contribute this code under the terms of the repository license.