### PR TITLE
fix: Update Mistral import for compatibility with mistralai 2.0.0

### DIFF
--- a/instructor/providers/mistral/client.py
+++ b/instructor/providers/mistral/client.py
@@ -2,7 +2,13 @@
 from __future__ import annotations
 
 
-from mistralai import Mistral
+try:
+    # mistralai >= 2.0.0
+    from mistralai.client import Mistral
+except ImportError:
+    # mistralai < 2.0.0
+    from mistralai import Mistral
+
 import instructor
 from typing import overload, Any, Literal
 


### PR DESCRIPTION
## Problem

The mistralai Python SDK released version 2.0.0 on March 10, 2025, which contains breaking changes to the import paths.

In mistralai 2.0.0, the import path changed from:
- v1: `from mistralai import Mistral`
- v2: `from mistralai.client import Mistral`

This breaks the instructor library when users have mistralai >= 2.0.0 installed.

## Solution

This fix uses a try/except block to attempt the new import path first (for mistralai >= 2.0.0) and falls back to the old import path (for mistralai < 2.0.0). This ensures backward compatibility with both versions.

## Changes

- Updated `instructor/providers/mistral/client.py` to handle both import paths

## Testing

- Verified syntax with `python -m py_compile`
- The fix maintains backward compatibility with mistralai < 2.0.0

## References

- Fixes #2137
- mistralai/client-python MIGRATION.md: https://github.com/mistralai/client-python/blob/main/MIGRATION.md

---

I have read the CLA Document and I hereby sign the CLA.