### PR TITLE
feat: add Model Armor support for GenAI content blocking

### DIFF
--- a/instructor/core/exceptions.py
+++ b/instructor/core/exceptions.py
@@ -599,3 +599,15 @@ class MultimodalError(ValueError, InstructorError):
             context_parts.append(f"file: {file_path}")
         context = f" ({', '.join(context_parts)})" if context_parts else ""
         super().__init__(f"{message}{context}", *args, **kwargs)
+
+
+class ContentBlockedError(InstructorError):
+    """Raised when the response is blocked by safety filters or Model Armor."""
+
+    def __init__(self, block_reason=None, block_message=None):
+        self.block_reason = block_reason
+        self.block_message = block_message
+        msg = f"Response blocked: {block_reason or 'unknown reason'}"
+        if block_message:
+            msg += f" - {block_message}"
+        super().__init__(msg)

--- a/instructor/core/retry.py
+++ b/instructor/core/retry.py
@@ -249,6 +249,10 @@ def retry_sync(
                     )
                     raise e
                 except Exception as e:
+                    from .exceptions import ContentBlockedError
+
+                    if isinstance(e, ContentBlockedError):
+                        raise  # No retry in case of Content Blocked
                     # Emit completion:error for non-validation errors (API errors, network errors, etc.)
                     logger.debug(f"Completion error: {e}")
                     hooks.emit_completion_error(e)
@@ -406,6 +410,12 @@ async def retry_async(
                     )
                     raise e
                 except Exception as e:
+                    from .exceptions import ContentBlockedError
+
+                    if isinstance(
+                        e, ContentBlockedError
+                    ):  # No retry in case of blocked content
+                        raise
                     # Emit completion:error for non-validation errors (API errors, network errors, etc.)
                     logger.debug(f"Completion error: {e}")
                     hooks.emit_completion_error(e)

--- a/instructor/processing/function_calls.py
+++ b/instructor/processing/function_calls.py
@@ -269,6 +269,7 @@ class OpenAISchema(BaseModel):
         validation_context: Optional[dict[str, Any]] = None,
         strict: Optional[bool] = None,
     ) -> BaseModel:
+        _check_genai_blocked(completion)  # Check filtered content FIRST
         return cls.model_validate_json(
             completion.text, context=validation_context, strict=strict
         )
@@ -283,6 +284,9 @@ class OpenAISchema(BaseModel):
         from google.genai import types
 
         assert isinstance(completion, types.GenerateContentResponse)
+        _check_genai_blocked(
+            completion
+        )  # Check content filter BEFORE candidates for more specific error
         assert len(completion.candidates) == 1
 
         # Filter out thought parts (parts with thought: true)
@@ -493,6 +497,7 @@ class OpenAISchema(BaseModel):
         validation_context: Optional[dict[str, Any]] = None,
         strict: Optional[bool] = None,
     ) -> BaseModel:
+        _check_genai_blocked(completion)
         try:
             text = completion.text
         except ValueError:
@@ -808,3 +813,18 @@ def openai_schema(cls: type[BaseModel]) -> OpenAISchema:
     )
 
     return cast(OpenAISchema, schema)
+
+
+def _check_genai_blocked(completion):
+    from instructor.core.exceptions import ContentBlockedError
+
+    if hasattr(completion, "candidates") and not completion.candidates:
+        block_reason = None
+        block_message = None
+        if hasattr(completion, "prompt_feedback") and completion.prompt_feedback:
+            pf = completion.prompt_feedback
+            block_reason = getattr(pf, "block_reason", None)
+            block_message = getattr(pf, "block_reason_message", None)
+        raise ContentBlockedError(
+            block_reason=block_reason, block_message=block_message
+        )

--- a/instructor/providers/gemini/utils.py
+++ b/instructor/providers/gemini/utils.py
@@ -452,6 +452,7 @@ def update_genai_kwargs(
             "automatic_function_calling",
             "labels",
             "cached_content",
+            "model_armor_config",
         ]
         for field in config_fields_to_merge:
             if isinstance(user_config, dict):

--- a/tests/test_content_blocked.py
+++ b/tests/test_content_blocked.py
@@ -1,0 +1,84 @@
+"""Tests for Model Armor / content blocking support in GenAI parsers."""
+
+import pytest
+
+genai = pytest.importorskip("google.genai")
+
+from unittest.mock import MagicMock
+from pydantic import BaseModel
+from instructor.core.exceptions import ContentBlockedError
+from instructor.processing.function_calls import OpenAISchema, _check_genai_blocked
+
+
+class SimpleModel(OpenAISchema, BaseModel):
+    name: str
+
+
+def _make_blocked_response(
+    block_reason="MODEL_ARMOR", block_message="Blocked by policy"
+):
+    """Create a mock GenAI response that simulates a Model Armor block."""
+    response = MagicMock()
+    response.candidates = []  # empty when blocked
+    response.prompt_feedback = MagicMock()
+    response.prompt_feedback.block_reason = block_reason
+    response.prompt_feedback.block_reason_message = block_message
+    return response
+
+
+def _make_blocked_response_no_feedback():
+    """Create a mock blocked response without prompt_feedback."""
+    response = MagicMock()
+    response.candidates = []
+    response.prompt_feedback = None
+    return response
+
+
+# --- _check_genai_blocked tests ---
+
+
+def test_check_genai_blocked_raises_on_empty_candidates():
+    response = _make_blocked_response()
+    with pytest.raises(ContentBlockedError) as exc_info:
+        _check_genai_blocked(response)
+    assert exc_info.value.block_reason == "MODEL_ARMOR"
+    assert exc_info.value.block_message == "Blocked by policy"
+
+
+def test_check_genai_blocked_raises_without_feedback():
+    response = _make_blocked_response_no_feedback()
+    with pytest.raises(ContentBlockedError) as exc_info:
+        _check_genai_blocked(response)
+    assert exc_info.value.block_reason is None
+
+
+def test_check_genai_blocked_passes_valid_response():
+    response = MagicMock()
+    response.candidates = [MagicMock()]  # has candidates
+    # Should not raise
+    _check_genai_blocked(response)
+
+
+# --- Parser tests ---
+
+
+def test_parse_genai_tools_raises_content_blocked():
+    response = _make_blocked_response()
+    # Make it pass the isinstance check
+    from google.genai import types
+
+    response.__class__ = types.GenerateContentResponse
+    with pytest.raises(ContentBlockedError):
+        SimpleModel.parse_genai_tools(response)
+
+
+def test_parse_genai_structured_outputs_raises_content_blocked():
+    response = _make_blocked_response()
+    with pytest.raises(ContentBlockedError):
+        SimpleModel.parse_genai_structured_outputs(response)
+
+
+def test_parse_gemini_json_raises_content_blocked():
+    response = _make_blocked_response()
+    with pytest.raises(ContentBlockedError):
+        SimpleModel.parse_gemini_json(response)

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -12,6 +12,7 @@ from instructor.core.exceptions import (
     ModeError,
     ClientError,
     FailedAttempt,
+    ContentBlockedError,
 )
 
 
@@ -26,6 +27,7 @@ def test_all_exceptions_can_be_imported():
     assert ConfigurationError is not None
     assert ModeError is not None
     assert ClientError is not None
+    assert ContentBlockedError is not None
 
 
 def test_exception_hierarchy():
@@ -37,6 +39,7 @@ def test_exception_hierarchy():
     assert issubclass(ConfigurationError, InstructorError)
     assert issubclass(ModeError, InstructorError)
     assert issubclass(ClientError, InstructorError)
+    assert issubclass(ContentBlockedError, InstructorError)
 
 
 def test_base_instructor_error_can_be_caught():
@@ -594,3 +597,28 @@ def test_failed_attempts_exception_chaining():
         assert chained_error.failed_attempts is not None
         assert len(chained_error.failed_attempts) == 1
         assert chained_error.failed_attempts[0].exception.args[0] == "Original failure"
+
+
+def test_content_blocked_error_attributes():
+    """Test ContentBlockedError stores block_reason and block_message."""
+    err = ContentBlockedError(
+        block_reason="MODEL_ARMOR", block_message="Blocked by Floor Setting"
+    )
+    assert err.block_reason == "MODEL_ARMOR"
+    assert err.block_message == "Blocked by Floor Setting"
+    assert "MODEL_ARMOR" in str(err)
+    assert "Blocked by Floor Setting" in str(err)
+
+
+def test_content_blocked_error_defaults():
+    """Test ContentBlockedError with no arguments."""
+    err = ContentBlockedError()
+    assert err.block_reason is None
+    assert err.block_message is None
+    assert "unknown reason" in str(err)
+
+
+def test_content_blocked_error_caught_by_base():
+    """Test that InstructorError catches ContentBlockedError."""
+    with pytest.raises(InstructorError):
+        raise ContentBlockedError(block_reason="SAFETY")

--- a/tests/test_genai_config_merging.py
+++ b/tests/test_genai_config_merging.py
@@ -518,3 +518,50 @@ def test_handle_genai_tools_skips_tools_and_system_instruction_with_cached_conte
     assert result_config.system_instruction is None
     assert result_config.tools is None
     assert result_config.tool_config is None
+
+
+def test_update_genai_kwargs_config_object_model_armor_config():
+    """Test that model_armor_config is extracted from config object."""
+
+    class MockModelArmorConfig:
+        def __init__(self):
+            self.prompt_template_name = (
+                "projects/123/locations/us-central1/templates/tmpl1"
+            )
+            self.response_template_name = (
+                "projects/123/locations/us-central1/templates/tmpl2"
+            )
+
+    class MockConfig:
+        def __init__(self):
+            self.thinking_config = None
+            self.automatic_function_calling = None
+            self.labels = None
+            self.cached_content = None
+            self.model_armor_config = MockModelArmorConfig()
+
+    mock_config = MockConfig()
+    kwargs = {"config": mock_config}
+    base_config = {}
+
+    result = update_genai_kwargs(kwargs, base_config)
+
+    assert "model_armor_config" in result
+    assert (
+        result["model_armor_config"].prompt_template_name
+        == "projects/123/locations/us-central1/templates/tmpl1"
+    )
+
+
+def test_update_genai_kwargs_config_dict_model_armor_config():
+    """Test that model_armor_config is merged when config is a dict."""
+    armor_config = {
+        "prompt_template_name": "projects/123/locations/us-central1/templates/tmpl1",
+        "response_template_name": "projects/123/locations/us-central1/templates/tmpl2",
+    }
+    kwargs = {"config": {"model_armor_config": armor_config}}
+    base_config = {}
+
+    result = update_genai_kwargs(kwargs, base_config)
+
+    assert result["model_armor_config"] == armor_config


### PR DESCRIPTION
- Add ContentBlockedError exception for blocked responses                                                                                                                                                                         
- Check empty candidates in parse_genai_tools, parse_genai_structured_outputs, parse_gemini_json                                                                                                                                  
- Skip retry on ContentBlockedError (safety blocks are not retriable)                                                                                                                                                             
- Propagate model_armor_config through GenerateContentConfig