### PR TITLE
fix: handle create_with_completion when model lacks _raw_response (fixes #1303)

### DIFF
--- a/instructor/core/client.py
+++ b/instructor/core/client.py
@@ -553,7 +553,7 @@ class Instructor:
             hooks=combined_hooks,
             **kwargs,
         )
-        return model, model._raw_response
+        return model, getattr(model, "_raw_response", None)
 
     def handle_kwargs(self, kwargs: dict[str, Any]) -> dict[str, Any]:
         """
@@ -747,7 +747,7 @@ class AsyncInstructor(Instructor):
             hooks=combined_hooks,
             **kwargs,
         )
-        return response, response._raw_response
+        return response, getattr(response, "_raw_response", None)
 
 
 @overload


### PR DESCRIPTION
## Summary
Fixes #1303

When `response_model` is `List[Object]` (e.g. `List[ExtractedListing]`), `create_with_completion` could crash with:
```
AttributeError: 'list' object has no attribute '_raw_response'
```

## Root Cause
In edge cases where the returned model does not have `_raw_response` attached (e.g. when the result is a plain list or from providers that return list-like structures), accessing `model._raw_response` raises.

## Fix
Use `getattr(model, '_raw_response', None)` to safely retrieve the raw response, returning `None` when absent instead of raising. This applies to both sync and async `create_with_completion` paths.

## Files Changed
- `instructor/core/client.py`: Two lines (sync and async return statements)

Made with [Cursor](https://cursor.com)