### PR TITLE
fix: route GEMINI_TOOLS to parse_gemini_tools, not parse_vertexai_tools

### DIFF
--- a/instructor/processing/function_calls.py
+++ b/instructor/processing/function_calls.py
@@ -171,8 +171,11 @@ class OpenAISchema(BaseModel):
         if mode == Mode.BEDROCK_TOOLS:
             return cls.parse_bedrock_tools(completion, validation_context, strict)
 
-        if mode in {Mode.VERTEXAI_TOOLS, Mode.GEMINI_TOOLS}:
+        if mode == Mode.VERTEXAI_TOOLS:
             return cls.parse_vertexai_tools(completion, validation_context)
+
+        if mode == Mode.GEMINI_TOOLS:
+            return cls.parse_gemini_tools(completion, validation_context, strict)
 
         if mode == Mode.VERTEXAI_JSON:
             return cls.parse_vertexai_json(completion, validation_context, strict)
@@ -187,9 +190,6 @@ class OpenAISchema(BaseModel):
             return cls.parse_genai_structured_outputs(
                 completion, validation_context, strict
             )
-
-        if mode == Mode.GEMINI_TOOLS:
-            return cls.parse_gemini_tools(completion, validation_context, strict)
 
         if mode == Mode.GENAI_TOOLS:
             return cls.parse_genai_tools(completion, validation_context, strict)
@@ -518,6 +518,39 @@ class OpenAISchema(BaseModel):
             parsed = json.loads(extra_text, strict=False)
             # Pydantic non-strict: https://docs.pydantic.dev/latest/concepts/strict_mode/
             return cls.model_validate(parsed, context=validation_context, strict=False)
+
+    @classmethod
+    def parse_gemini_tools(
+        cls: type[BaseModel],
+        completion: Any,
+        validation_context: Optional[dict[str, Any]] = None,
+        strict: Optional[bool] = None,
+    ) -> BaseModel:
+        try:
+            function_call = completion.candidates[0].content.parts[0].function_call
+        except Exception as exc:
+            raise ResponseParsingError(
+                "No tool call found in Gemini response",
+                mode="GEMINI_TOOLS",
+                raw_response=completion,
+            ) from exc
+
+        args = getattr(function_call, "args", None)
+        if args is None and hasattr(type(function_call), "to_dict"):
+            try:
+                resp_dict = type(function_call).to_dict(function_call)
+            except Exception:
+                resp_dict = {}
+            args = resp_dict.get("args")
+
+        if args is None:
+            raise ResponseParsingError(
+                "No tool call args found in Gemini response",
+                mode="GEMINI_TOOLS",
+                raw_response=completion,
+            )
+
+        return cls.model_validate(args, context=validation_context, strict=strict)
 
     @classmethod
     def parse_vertexai_tools(


### PR DESCRIPTION
## Summary

Two related bugs in `OpenAISchema.from_response()` in `instructor/processing/function_calls.py`:

- **Bug 1 (wrong parser)**: `GEMINI_TOOLS` was grouped with `VERTEXAI_TOOLS` in a combined set (`{Mode.VERTEXAI_TOOLS, Mode.GEMINI_TOOLS}`) and dispatched to `parse_vertexai_tools`. This is incorrect — the legacy Gemini SDK (`google-generativeai`) and the VertexAI SDK have different response structures. Notably, `parse_vertexai_tools` iterates over protobuf-style `args` with a for-loop and forces `strict=False`, whereas Gemini SDK responses require different handling (with a `to_dict()` fallback and proper error reporting).

- **Bug 2 (dead code + missing method)**: A separate `if mode == Mode.GEMINI_TOOLS` branch further down in the same method referenced `cls.parse_gemini_tools(...)`. This branch was unreachable dead code (because `GEMINI_TOOLS` was already handled above), and the `parse_gemini_tools` method itself no longer existed in the class after a previous refactor — so if somehow reached, it would raise `AttributeError`.

## Fix

- Separate `VERTEXAI_TOOLS` and `GEMINI_TOOLS` into their own distinct dispatch branches.
- Restore the `parse_gemini_tools` classmethod (recovered from git history, pre-refactor) which correctly handles legacy Gemini SDK tool responses by extracting `function_call.args`, using a `to_dict()` fallback for protobuf-style objects, and raising `ResponseParsingError` with useful context on failure.
- Remove the now-redundant dead-code branch.

## Before / After

**Before**:
```python
# GEMINI_TOOLS incorrectly routed to VertexAI parser
if mode in {Mode.VERTEXAI_TOOLS, Mode.GEMINI_TOOLS}:
    return cls.parse_vertexai_tools(completion, validation_context)

# ... (unreachable dead code referencing a non-existent method)
if mode == Mode.GEMINI_TOOLS:
    return cls.parse_gemini_tools(completion, validation_context, strict)
```

**After**:
```python
if mode == Mode.VERTEXAI_TOOLS:
    return cls.parse_vertexai_tools(completion, validation_context)

if mode == Mode.GEMINI_TOOLS:
    return cls.parse_gemini_tools(completion, validation_context, strict)
```

## Test plan

- [ ] Call `from_response` with `mode=Mode.VERTEXAI_TOOLS` — still routes to `parse_vertexai_tools` as before.
- [ ] Call `from_response` with `mode=Mode.GEMINI_TOOLS` — now correctly routes to `parse_gemini_tools` with proper Gemini-SDK-specific response parsing.
- [ ] Verify `parse_gemini_tools` raises `ResponseParsingError` (not `AttributeError`) when tool call is missing from response.