### PR TITLE
Fix GenAI SafeSettings regression: always use text harm categories

### DIFF
--- a/instructor/providers/gemini/utils.py
+++ b/instructor/providers/gemini/utils.py
@@ -304,66 +304,6 @@ def update_genai_kwargs(
             if val is not None:  # Only set if value is not None
                 base_config[gemini_key] = val
 
-    def _genai_kwargs_has_image_content(genai_kwargs: dict[str, Any]) -> bool:
-        """
-        Best-effort check for image content in a GenAI request.
-
-        We use this to decide whether to send text vs image harm categories in
-        `safety_settings`. The google-genai SDK has separate image categories
-        (e.g., `HARM_CATEGORY_IMAGE_HATE`) which are required for image content.
-        """
-        # Prefer typed GenAI contents if present (works with autodetect_images)
-        contents = genai_kwargs.get("contents")
-        if isinstance(contents, list):
-            for content in contents:
-                parts = getattr(content, "parts", None)
-                if not parts:
-                    continue
-                for part in parts:
-                    inline_data = getattr(part, "inline_data", None)
-                    if inline_data is not None:
-                        mime_type = getattr(inline_data, "mime_type", None)
-                        if isinstance(mime_type, str) and mime_type.startswith(
-                            "image/"
-                        ):
-                            return True
-
-                    file_data = getattr(part, "file_data", None)
-                    if file_data is not None:
-                        mime_type = getattr(file_data, "mime_type", None)
-                        if isinstance(mime_type, str) and mime_type.startswith(
-                            "image/"
-                        ):
-                            return True
-
-        # Fall back to OpenAI-style messages if present
-        messages = genai_kwargs.get("messages")
-        if isinstance(messages, list):
-            for message in messages:
-                if not isinstance(message, dict):
-                    continue
-                content = message.get("content")
-                if isinstance(content, Image):
-                    return True
-                if isinstance(content, list):
-                    for item in content:
-                        if isinstance(item, Image):
-                            return True
-                        if isinstance(item, dict) and item.get("type") in {
-                            "image",
-                            "image_url",
-                            "input_image",
-                        }:
-                            return True
-                if isinstance(content, dict) and content.get("type") in {
-                    "image",
-                    "image_url",
-                    "input_image",
-                }:
-                    return True
-
-        return False
-
     safety_settings = new_kwargs.pop("safety_settings", {})
     base_config["safety_settings"] = []
 
@@ -381,14 +321,9 @@ def update_genai_kwargs(
         excluded_categories.add(HarmCategory.HARM_CATEGORY_JAILBREAK)
 
     if safety_settings is not None:
-        # google-genai has separate categories for image content.
-        has_image = _genai_kwargs_has_image_content(new_kwargs)
-        image_categories = [
-            c
-            for c in HarmCategory
-            if c not in excluded_categories
-            and c.name.startswith("HARM_CATEGORY_IMAGE_")
-        ]
+        # HARM_CATEGORY_IMAGE_* categories are only valid on Vertex AI, not
+        # the Google GenAI API.  Since update_genai_kwargs is exclusively
+        # called from GenAI handlers, we must always use text categories.
         text_categories = [
             c
             for c in HarmCategory
@@ -396,29 +331,13 @@ def update_genai_kwargs(
             and not c.name.startswith("HARM_CATEGORY_IMAGE_")
         ]
 
-        supported_categories = (
-            image_categories if (has_image and image_categories) else text_categories
-        )
-
-        def _map_text_to_image_category_name(image_category_name: str) -> str | None:
-            suffix = image_category_name.removeprefix("HARM_CATEGORY_IMAGE_")
-            # google-genai uses IMAGE_HATE while text uses HATE_SPEECH
-            if suffix == "HATE":
-                return "HARM_CATEGORY_HATE_SPEECH"
-            return f"HARM_CATEGORY_{suffix}"
+        supported_categories = text_categories
 
         for category in supported_categories:
             threshold = HarmBlockThreshold.OFF
             if isinstance(safety_settings, dict):
                 if category in safety_settings:
                     threshold = safety_settings[category]
-                # If we are using image categories, try to honor thresholds passed via text categories.
-                elif has_image and category.name.startswith("HARM_CATEGORY_IMAGE_"):
-                    mapped_name = _map_text_to_image_category_name(category.name)
-                    if mapped_name is not None and hasattr(HarmCategory, mapped_name):
-                        mapped_category = getattr(HarmCategory, mapped_name)
-                        if mapped_category in safety_settings:
-                            threshold = safety_settings[mapped_category]
 
             base_config["safety_settings"].append(
                 {

--- a/tests/genai/test_safety_settings.py
+++ b/tests/genai/test_safety_settings.py
@@ -1,8 +1,13 @@
 from instructor.providers.gemini.utils import update_genai_kwargs
 
 
-def test_update_genai_kwargs_safety_settings_with_image_content_uses_image_categories():
-    """Image inputs should use IMAGE_* harm categories when available."""
+def test_update_genai_kwargs_always_uses_text_categories_even_with_image_content():
+    """Image inputs must still use text harm categories on Google GenAI (not Vertex AI).
+
+    HARM_CATEGORY_IMAGE_* categories are only valid on Vertex AI.
+    update_genai_kwargs is exclusively called from GenAI handlers,
+    so it must never emit IMAGE_* categories.  See issue #2146.
+    """
     from google.genai import types
     from google.genai.types import HarmCategory
 
@@ -10,15 +15,12 @@ def test_update_genai_kwargs_safety_settings_with_image_content_uses_image_categ
     if hasattr(HarmCategory, "HARM_CATEGORY_JAILBREAK"):
         excluded_categories.add(HarmCategory.HARM_CATEGORY_JAILBREAK)
 
-    image_categories = [
+    text_categories = [
         c
         for c in HarmCategory
-        if c not in excluded_categories and c.name.startswith("HARM_CATEGORY_IMAGE_")
+        if c not in excluded_categories
+        and not c.name.startswith("HARM_CATEGORY_IMAGE_")
     ]
-
-    # Older SDKs may not expose separate image categories.
-    if not image_categories:
-        return
 
     kwargs = {
         "contents": [
@@ -28,33 +30,26 @@ def test_update_genai_kwargs_safety_settings_with_image_content_uses_image_categ
             )
         ]
     }
-    base_config = {}
+    base_config: dict = {}
 
     result = update_genai_kwargs(kwargs, base_config)
 
     assert "safety_settings" in result
     assert isinstance(result["safety_settings"], list)
-    assert len(result["safety_settings"]) == len(image_categories)
-    assert {s["category"] for s in result["safety_settings"]} == set(image_categories)
+    assert len(result["safety_settings"]) == len(text_categories)
+    emitted = {s["category"] for s in result["safety_settings"]}
+    assert emitted == set(text_categories)
+    # Ensure no IMAGE_* category leaked through
+    for s in result["safety_settings"]:
+        assert not s["category"].name.startswith("HARM_CATEGORY_IMAGE_"), (
+            f"IMAGE_* category {s['category']} should not appear in GenAI safety settings"
+        )
 
 
-def test_update_genai_kwargs_maps_text_thresholds_to_image_categories():
-    """Text thresholds should carry over to equivalent IMAGE_* categories."""
+def test_update_genai_kwargs_text_thresholds_applied_with_image_content():
+    """User-supplied text thresholds should be respected even when images are present."""
     from google.genai import types
     from google.genai.types import HarmBlockThreshold, HarmCategory
-
-    excluded_categories = {HarmCategory.HARM_CATEGORY_UNSPECIFIED}
-    if hasattr(HarmCategory, "HARM_CATEGORY_JAILBREAK"):
-        excluded_categories.add(HarmCategory.HARM_CATEGORY_JAILBREAK)
-
-    image_categories = [
-        c
-        for c in HarmCategory
-        if c not in excluded_categories and c.name.startswith("HARM_CATEGORY_IMAGE_")
-    ]
-
-    if not image_categories or not hasattr(HarmCategory, "HARM_CATEGORY_IMAGE_HATE"):
-        return
 
     custom_safety = {
         HarmCategory.HARM_CATEGORY_HATE_SPEECH: HarmBlockThreshold.BLOCK_LOW_AND_ABOVE
@@ -69,17 +64,20 @@ def test_update_genai_kwargs_maps_text_thresholds_to_image_categories():
         ],
         "safety_settings": custom_safety,
     }
-    base_config = {}
+    base_config: dict = {}
 
     result = update_genai_kwargs(kwargs, base_config)
 
     for setting in result["safety_settings"]:
-        if setting["category"] == HarmCategory.HARM_CATEGORY_IMAGE_HATE:
+        if setting["category"] == HarmCategory.HARM_CATEGORY_HATE_SPEECH:
             assert setting["threshold"] == HarmBlockThreshold.BLOCK_LOW_AND_ABOVE
+            break
+    else:
+        raise AssertionError("HARM_CATEGORY_HATE_SPEECH not found in safety_settings")
 
 
-def test_handle_genai_tools_autodetect_images_uses_image_categories():
-    """Autodetected image content should switch safety_settings to IMAGE_* categories."""
+def test_handle_genai_tools_autodetect_images_uses_text_categories():
+    """Autodetected image content must still use text categories on GenAI."""
     from pydantic import BaseModel
 
     from instructor.providers.gemini.utils import handle_genai_tools
@@ -105,7 +103,8 @@ def test_handle_genai_tools_autodetect_images_uses_image_categories():
 
     assert "config" in out
     assert out["config"].safety_settings is not None
-    assert any(
-        s.category.name.startswith("HARM_CATEGORY_IMAGE_")
-        for s in out["config"].safety_settings
-    )
+    # All emitted categories must be text categories, not IMAGE_*
+    for s in out["config"].safety_settings:
+        assert not s.category.name.startswith("HARM_CATEGORY_IMAGE_"), (
+            f"IMAGE_* category {s.category} should not appear in GenAI safety settings"
+        )


### PR DESCRIPTION
Fixes a regression where GenAI (non-Vertex) requests with image content crash with InvalidArgument because the safety settings code was sending Vertex-only HARM_CATEGORY_IMAGE_* categories to the GenAI API. The fix ensures text harm categories are always used for GenAI calls regardless of content type.