### PR TITLE
fix: exclude IMAGE_ harm categories from standard Gemini API

### DIFF
--- a/instructor/providers/gemini/utils.py
+++ b/instructor/providers/gemini/utils.py
@@ -304,66 +304,6 @@ def update_genai_kwargs(
             if val is not None:  # Only set if value is not None
                 base_config[gemini_key] = val
 
-    def _genai_kwargs_has_image_content(genai_kwargs: dict[str, Any]) -> bool:
-        """
-        Best-effort check for image content in a GenAI request.
-
-        We use this to decide whether to send text vs image harm categories in
-        `safety_settings`. The google-genai SDK has separate image categories
-        (e.g., `HARM_CATEGORY_IMAGE_HATE`) which are required for image content.
-        """
-        # Prefer typed GenAI contents if present (works with autodetect_images)
-        contents = genai_kwargs.get("contents")
-        if isinstance(contents, list):
-            for content in contents:
-                parts = getattr(content, "parts", None)
-                if not parts:
-                    continue
-                for part in parts:
-                    inline_data = getattr(part, "inline_data", None)
-                    if inline_data is not None:
-                        mime_type = getattr(inline_data, "mime_type", None)
-                        if isinstance(mime_type, str) and mime_type.startswith(
-                            "image/"
-                        ):
-                            return True
-
-                    file_data = getattr(part, "file_data", None)
-                    if file_data is not None:
-                        mime_type = getattr(file_data, "mime_type", None)
-                        if isinstance(mime_type, str) and mime_type.startswith(
-                            "image/"
-                        ):
-                            return True
-
-        # Fall back to OpenAI-style messages if present
-        messages = genai_kwargs.get("messages")
-        if isinstance(messages, list):
-            for message in messages:
-                if not isinstance(message, dict):
-                    continue
-                content = message.get("content")
-                if isinstance(content, Image):
-                    return True
-                if isinstance(content, list):
-                    for item in content:
-                        if isinstance(item, Image):
-                            return True
-                        if isinstance(item, dict) and item.get("type") in {
-                            "image",
-                            "image_url",
-                            "input_image",
-                        }:
-                            return True
-                if isinstance(content, dict) and content.get("type") in {
-                    "image",
-                    "image_url",
-                    "input_image",
-                }:
-                    return True
-
-        return False
-
     safety_settings = new_kwargs.pop("safety_settings", {})
     base_config["safety_settings"] = []
 
@@ -381,14 +321,12 @@ def update_genai_kwargs(
         excluded_categories.add(HarmCategory.HARM_CATEGORY_JAILBREAK)
 
     if safety_settings is not None:
-        # google-genai has separate categories for image content.
-        has_image = _genai_kwargs_has_image_content(new_kwargs)
-        image_categories = [
-            c
-            for c in HarmCategory
-            if c not in excluded_categories
-            and c.name.startswith("HARM_CATEGORY_IMAGE_")
-        ]
+        # Only use text harm categories here. IMAGE_ harm categories
+        # (e.g. HARM_CATEGORY_IMAGE_HATE) are only supported by the Vertex AI
+        # API and must NOT be sent to the standard Gemini API, which is what
+        # this code path serves.  Sending them causes:
+        #   400 INVALID_ARGUMENT "Invalid value at safety_settings[0].category"
+        # See: https://github.com/567-labs/instructor/issues/2146
         text_categories = [
             c
             for c in HarmCategory
@@ -396,29 +334,11 @@ def update_genai_kwargs(
             and not c.name.startswith("HARM_CATEGORY_IMAGE_")
         ]
 
-        supported_categories = (
-            image_categories if (has_image and image_categories) else text_categories
-        )
-
-        def _map_text_to_image_category_name(image_category_name: str) -> str | None:
-            suffix = image_category_name.removeprefix("HARM_CATEGORY_IMAGE_")
-            # google-genai uses IMAGE_HATE while text uses HATE_SPEECH
-            if suffix == "HATE":
-                return "HARM_CATEGORY_HATE_SPEECH"
-            return f"HARM_CATEGORY_{suffix}"
-
-        for category in supported_categories:
+        for category in text_categories:
             threshold = HarmBlockThreshold.OFF
             if isinstance(safety_settings, dict):
                 if category in safety_settings:
                     threshold = safety_settings[category]
-                # If we are using image categories, try to honor thresholds passed via text categories.
-                elif has_image and category.name.startswith("HARM_CATEGORY_IMAGE_"):
-                    mapped_name = _map_text_to_image_category_name(category.name)
-                    if mapped_name is not None and hasattr(HarmCategory, mapped_name):
-                        mapped_category = getattr(HarmCategory, mapped_name)
-                        if mapped_category in safety_settings:
-                            threshold = safety_settings[mapped_category]
 
             base_config["safety_settings"].append(
                 {

--- a/tests/genai/test_safety_settings.py
+++ b/tests/genai/test_safety_settings.py
@@ -1,24 +1,15 @@
 from instructor.providers.gemini.utils import update_genai_kwargs
 
 
-def test_update_genai_kwargs_safety_settings_with_image_content_uses_image_categories():
-    """Image inputs should use IMAGE_* harm categories when available."""
+def test_update_genai_kwargs_safety_settings_excludes_image_categories():
+    """IMAGE_* harm categories must never be sent to the standard Gemini API.
+
+    They are only supported by Vertex AI and cause 400 INVALID_ARGUMENT errors
+    on the standard Gemini API.
+    See: https://github.com/567-labs/instructor/issues/2146
+    """
     from google.genai import types
     from google.genai.types import HarmCategory
-
-    excluded_categories = {HarmCategory.HARM_CATEGORY_UNSPECIFIED}
-    if hasattr(HarmCategory, "HARM_CATEGORY_JAILBREAK"):
-        excluded_categories.add(HarmCategory.HARM_CATEGORY_JAILBREAK)
-
-    image_categories = [
-        c
-        for c in HarmCategory
-        if c not in excluded_categories and c.name.startswith("HARM_CATEGORY_IMAGE_")
-    ]
-
-    # Older SDKs may not expose separate image categories.
-    if not image_categories:
-        return
 
     kwargs = {
         "contents": [
@@ -34,27 +25,18 @@ def test_update_genai_kwargs_safety_settings_with_image_content_uses_image_categ
 
     assert "safety_settings" in result
     assert isinstance(result["safety_settings"], list)
-    assert len(result["safety_settings"]) == len(image_categories)
-    assert {s["category"] for s in result["safety_settings"]} == set(image_categories)
+    # No IMAGE_* categories should be present
+    for setting in result["safety_settings"]:
+        assert not setting["category"].name.startswith("HARM_CATEGORY_IMAGE_"), (
+            f"IMAGE_ category {setting['category'].name} must not be sent to the "
+            "standard Gemini API"
+        )
 
 
-def test_update_genai_kwargs_maps_text_thresholds_to_image_categories():
-    """Text thresholds should carry over to equivalent IMAGE_* categories."""
+def test_update_genai_kwargs_text_only_categories_for_image_content():
+    """Even with image content, only text harm categories should be used."""
     from google.genai import types
     from google.genai.types import HarmBlockThreshold, HarmCategory
-
-    excluded_categories = {HarmCategory.HARM_CATEGORY_UNSPECIFIED}
-    if hasattr(HarmCategory, "HARM_CATEGORY_JAILBREAK"):
-        excluded_categories.add(HarmCategory.HARM_CATEGORY_JAILBREAK)
-
-    image_categories = [
-        c
-        for c in HarmCategory
-        if c not in excluded_categories and c.name.startswith("HARM_CATEGORY_IMAGE_")
-    ]
-
-    if not image_categories or not hasattr(HarmCategory, "HARM_CATEGORY_IMAGE_HATE"):
-        return
 
     custom_safety = {
         HarmCategory.HARM_CATEGORY_HATE_SPEECH: HarmBlockThreshold.BLOCK_LOW_AND_ABOVE
@@ -73,13 +55,18 @@ def test_update_genai_kwargs_maps_text_thresholds_to_image_categories():
 
     result = update_genai_kwargs(kwargs, base_config)
 
+    # Custom threshold should be preserved for text category
+    found_hate_speech = False
     for setting in result["safety_settings"]:
-        if setting["category"] == HarmCategory.HARM_CATEGORY_IMAGE_HATE:
+        assert not setting["category"].name.startswith("HARM_CATEGORY_IMAGE_")
+        if setting["category"] == HarmCategory.HARM_CATEGORY_HATE_SPEECH:
             assert setting["threshold"] == HarmBlockThreshold.BLOCK_LOW_AND_ABOVE
+            found_hate_speech = True
+    assert found_hate_speech, "HARM_CATEGORY_HATE_SPEECH should be in safety_settings"
 
 
-def test_handle_genai_tools_autodetect_images_uses_image_categories():
-    """Autodetected image content should switch safety_settings to IMAGE_* categories."""
+def test_handle_genai_tools_autodetect_images_excludes_image_categories():
+    """Autodetected image content should NOT use IMAGE_* harm categories."""
     from pydantic import BaseModel
 
     from instructor.providers.gemini.utils import handle_genai_tools
@@ -105,7 +92,8 @@ def test_handle_genai_tools_autodetect_images_uses_image_categories():
 
     assert "config" in out
     assert out["config"].safety_settings is not None
-    assert any(
+    # No IMAGE_* categories should be present
+    assert not any(
         s.category.name.startswith("HARM_CATEGORY_IMAGE_")
         for s in out["config"].safety_settings
-    )
+    ), "IMAGE_ categories must not be sent to the standard Gemini API"

--- a/tests/llm/test_genai/test_utils.py
+++ b/tests/llm/test_genai/test_utils.py
@@ -108,24 +108,14 @@ def test_update_genai_kwargs_with_custom_safety_settings():
             assert setting["threshold"] == HarmBlockThreshold.OFF
 
 
-def test_update_genai_kwargs_safety_settings_with_image_content_uses_image_categories():
-    """Test that image content switches to IMAGE_* harm categories when available."""
+def test_update_genai_kwargs_safety_settings_excludes_image_categories():
+    """IMAGE_* harm categories must never be sent to the standard Gemini API.
+
+    They are only supported by Vertex AI and cause 400 INVALID_ARGUMENT errors.
+    See: https://github.com/567-labs/instructor/issues/2146
+    """
     from google.genai import types
     from google.genai.types import HarmCategory
-
-    excluded_categories = {HarmCategory.HARM_CATEGORY_UNSPECIFIED}
-    if hasattr(HarmCategory, "HARM_CATEGORY_JAILBREAK"):
-        excluded_categories.add(HarmCategory.HARM_CATEGORY_JAILBREAK)
-
-    image_categories = [
-        c
-        for c in HarmCategory
-        if c not in excluded_categories and c.name.startswith("HARM_CATEGORY_IMAGE_")
-    ]
-
-    # Older SDKs may not expose separate image categories.
-    if not image_categories:
-        return
 
     kwargs = {
         "contents": [
@@ -141,27 +131,18 @@ def test_update_genai_kwargs_safety_settings_with_image_content_uses_image_categ
 
     assert "safety_settings" in result
     assert isinstance(result["safety_settings"], list)
-    assert len(result["safety_settings"]) == len(image_categories)
-    assert {s["category"] for s in result["safety_settings"]} == set(image_categories)
+    # No IMAGE_* categories should be present, even with image content
+    for setting in result["safety_settings"]:
+        assert not setting["category"].name.startswith("HARM_CATEGORY_IMAGE_"), (
+            f"IMAGE_ category {setting['category'].name} must not be sent to the "
+            "standard Gemini API"
+        )
 
 
-def test_update_genai_kwargs_maps_text_thresholds_to_image_categories():
-    """Test that text-based safety settings are applied to equivalent IMAGE_* categories."""
+def test_update_genai_kwargs_text_categories_with_image_content():
+    """Even with image content, only text harm categories should be used."""
     from google.genai import types
-    from google.genai.types import HarmCategory, HarmBlockThreshold
-
-    excluded_categories = {HarmCategory.HARM_CATEGORY_UNSPECIFIED}
-    if hasattr(HarmCategory, "HARM_CATEGORY_JAILBREAK"):
-        excluded_categories.add(HarmCategory.HARM_CATEGORY_JAILBREAK)
-
-    image_categories = [
-        c
-        for c in HarmCategory
-        if c not in excluded_categories and c.name.startswith("HARM_CATEGORY_IMAGE_")
-    ]
-
-    if not image_categories or not hasattr(HarmCategory, "HARM_CATEGORY_IMAGE_HATE"):
-        return
+    from google.genai.types import HarmBlockThreshold, HarmCategory
 
     custom_safety = {
         HarmCategory.HARM_CATEGORY_HATE_SPEECH: HarmBlockThreshold.BLOCK_LOW_AND_ABOVE
@@ -180,9 +161,14 @@ def test_update_genai_kwargs_maps_text_thresholds_to_image_categories():
 
     result = update_genai_kwargs(kwargs, base_config)
 
+    # Custom threshold should be preserved for text category
+    found_hate_speech = False
     for setting in result["safety_settings"]:
-        if setting["category"] == HarmCategory.HARM_CATEGORY_IMAGE_HATE:
+        assert not setting["category"].name.startswith("HARM_CATEGORY_IMAGE_")
+        if setting["category"] == HarmCategory.HARM_CATEGORY_HATE_SPEECH:
             assert setting["threshold"] == HarmBlockThreshold.BLOCK_LOW_AND_ABOVE
+            found_hate_speech = True
+    assert found_hate_speech, "HARM_CATEGORY_HATE_SPEECH should be in safety_settings"
 
 
 def test_update_genai_kwargs_none_values():


### PR DESCRIPTION
## Summary

Fixes #2146

- `IMAGE_` family harm categories (e.g. `HARM_CATEGORY_IMAGE_HATE`) added in v1.14.4 (PR #2007) are only supported by the **Vertex AI** API, not the standard **Gemini API**
- Sending them to the standard Gemini API causes `400 INVALID_ARGUMENT` errors: `Invalid value at safety_settings[0].category, "HARM_CATEGORY_IMAGE_HATE"`
- Since `update_genai_kwargs()` is only called from GenAI (non-Vertex) code paths (`handle_genai_tools` and `handle_genai_structured_outputs`), always filter out `IMAGE_` categories
- Removed the now-unused `_genai_kwargs_has_image_content()` helper and image-category mapping logic
- Updated tests to verify `IMAGE_` categories are never included in standard Gemini API safety settings

## Test plan

- [x] `tests/genai/test_safety_settings.py` - 3 tests pass (updated to verify IMAGE_ exclusion)
- [x] `tests/test_genai_config_merging.py` - 21 tests pass (no regressions)
- [ ] Manual test with standard Gemini API to confirm no 400 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)