### PR TITLE
Support legacy mistralai client imports

### DIFF
--- a/instructor/auto_client.py
+++ b/instructor/auto_client.py
@@ -519,7 +519,10 @@ def from_provider(
 
     elif provider == "mistral":
         try:
-            from mistralai import Mistral
+            try:
+                from mistralai import Mistral
+            except ImportError:
+                from mistralai.client import Mistral
             from instructor import from_mistral  # type: ignore[attr-defined]
             import os
 

--- a/instructor/providers/mistral/client.py
+++ b/instructor/providers/mistral/client.py
@@ -1,10 +1,13 @@
 # Future imports to ensure compatibility with Python 3.9
 from __future__ import annotations
 
-
-from mistralai import Mistral
 import instructor
 from typing import overload, Any, Literal
+
+try:
+    from mistralai import Mistral
+except ImportError:
+    from mistralai.client import Mistral
 
 
 @overload

--- a/tests/test_auto_client.py
+++ b/tests/test_auto_client.py
@@ -657,3 +657,43 @@ def test_generative_ai_provider_runtime_import_error_propagates():
 
             # Should be the socksio error, NOT a ConfigurationError
             assert "socksio" in str(excinfo.value)
+
+
+def test_mistral_provider_falls_back_to_legacy_client_module_import():
+    """Support mistralai layouts where Mistral lives in mistralai.client."""
+    import os
+    import sys
+    import types
+    from unittest.mock import MagicMock, patch
+    import instructor
+
+    class FakeMistral:
+        def __init__(self, api_key=None):
+            self.api_key = api_key
+
+    mock_mistralai = types.ModuleType("mistralai")
+    mock_mistralai.__path__ = []
+    mock_mistralai_client = types.ModuleType("mistralai.client")
+    mock_mistralai_client.Mistral = FakeMistral
+
+    with patch.dict(
+        sys.modules,
+        {
+            "mistralai": mock_mistralai,
+            "mistralai.client": mock_mistralai_client,
+        },
+    ):
+        with patch.object(
+            instructor, "from_mistral", create=True
+        ) as mock_from_mistral:
+            mock_instructor = MagicMock()
+            mock_from_mistral.return_value = mock_instructor
+
+            with patch.dict(os.environ, {"MISTRAL_API_KEY": "test-key"}, clear=True):
+                client = from_provider("mistral/ministral-8b-latest")
+
+            mock_from_mistral.assert_called_once()
+            passed_client = mock_from_mistral.call_args.args[0]
+            assert isinstance(passed_client, FakeMistral)
+            assert passed_client.api_key == "test-key"
+            assert client is mock_instructor


### PR DESCRIPTION
## Summary

Support `mistralai` layouts where `Mistral` is exposed from `mistralai.client` instead of the package root.

This keeps Mistral provider initialization working across both import styles and avoids breaking the provider path when the top-level import is unavailable.

## Changes

- add a fallback import for `Mistral` in the Mistral provider client
- add the same fallback in `from_provider(..., provider="mistral")`
- add a regression test covering the legacy `mistralai.client.Mistral` import path

## Testing

- `python -m pytest tests/test_auto_client.py -k "mistral_provider_falls_back_to_legacy_client_module_import or invalid_provider_format or unsupported_provider"`
- `python -m pytest tests/test_auto_client.py -k "google_provider_runtime_import_error_propagates or generative_ai_provider_runtime_import_error_propagates"`

Closes #2137
