### PR TITLE
Use VertexAI-specific default mode in from_provider

### DIFF
--- a/instructor/auto_client.py
+++ b/instructor/auto_client.py
@@ -893,12 +893,14 @@ def from_provider(
                 result = from_genai(
                     client,
                     use_async=True,
-                    mode=mode if mode else instructor.Mode.GENAI_TOOLS,
+                    mode=mode if mode else instructor.Mode.VERTEXAI_TOOLS,
                     **kwargs,
                 )  # type: ignore
             else:
                 result = from_genai(
-                    client, mode=mode if mode else instructor.Mode.GENAI_TOOLS, **kwargs
+                    client,
+                    mode=mode if mode else instructor.Mode.VERTEXAI_TOOLS,
+                    **kwargs,
                 )  # type: ignore
             logger.info(
                 "Client initialized",

--- a/tests/test_auto_client.py
+++ b/tests/test_auto_client.py
@@ -657,3 +657,84 @@ def test_generative_ai_provider_runtime_import_error_propagates():
 
             # Should be the socksio error, NOT a ConfigurationError
             assert "socksio" in str(excinfo.value)
+
+
+def test_vertexai_provider_defaults_to_vertexai_tools_mode():
+    """VertexAI provider should use VertexAI-specific handling by default."""
+    from unittest.mock import patch, MagicMock
+    import warnings
+    import instructor
+    import sys
+
+    mock_genai_module = MagicMock()
+    mock_client = MagicMock()
+    mock_genai_module.Client.return_value = mock_client
+    mock_google = MagicMock()
+    mock_google.genai = mock_genai_module
+
+    with patch.dict(
+        sys.modules,
+        {"google": mock_google, "google.genai": mock_genai_module},
+    ):
+        with patch.object(
+            __import__("instructor"), "from_genai", create=True
+        ) as mock_from_genai:
+            mock_instructor = MagicMock()
+            mock_from_genai.return_value = mock_instructor
+
+            with warnings.catch_warnings():
+                warnings.simplefilter("ignore", DeprecationWarning)
+                client = from_provider(
+                    "vertexai/gemini-3-flash",
+                    project="test-project",
+                )
+
+            mock_genai_module.Client.assert_called_once_with(
+                vertexai=True,
+                project="test-project",
+                location="us-central1",
+            )
+            mock_from_genai.assert_called_once()
+            _, kwargs = mock_from_genai.call_args
+            assert kwargs["mode"] == instructor.Mode.VERTEXAI_TOOLS
+            assert kwargs["model"] == "gemini-3-flash"
+            assert client is mock_instructor
+
+
+def test_vertexai_provider_async_defaults_to_vertexai_tools_mode():
+    """Async VertexAI provider should also use VertexAI-specific handling."""
+    from unittest.mock import patch, MagicMock
+    import warnings
+    import instructor
+    import sys
+
+    mock_genai_module = MagicMock()
+    mock_client = MagicMock()
+    mock_genai_module.Client.return_value = mock_client
+    mock_google = MagicMock()
+    mock_google.genai = mock_genai_module
+
+    with patch.dict(
+        sys.modules,
+        {"google": mock_google, "google.genai": mock_genai_module},
+    ):
+        with patch.object(
+            __import__("instructor"), "from_genai", create=True
+        ) as mock_from_genai:
+            mock_instructor = MagicMock()
+            mock_from_genai.return_value = mock_instructor
+
+            with warnings.catch_warnings():
+                warnings.simplefilter("ignore", DeprecationWarning)
+                client = from_provider(
+                    "vertexai/gemini-3-flash",
+                    async_client=True,
+                    project="test-project",
+                )
+
+            mock_from_genai.assert_called_once()
+            _, kwargs = mock_from_genai.call_args
+            assert kwargs["use_async"] is True
+            assert kwargs["mode"] == instructor.Mode.VERTEXAI_TOOLS
+            assert kwargs["model"] == "gemini-3-flash"
+            assert client is mock_instructor


### PR DESCRIPTION
## Summary

Use `VERTEXAI_TOOLS` as the default mode for the deprecated `vertexai/*` provider path in `from_provider`.

The Vertex AI path already routes through the Vertex-specific request/response handling stack, but it was still defaulting to `GENAI_TOOLS`. This could send Vertex requests through the wrong processing path and lead to provider-specific failures.

## Changes

- default `from_provider("vertexai/...")` to `Mode.VERTEXAI_TOOLS`
- keep explicit `mode=` overrides unchanged
- add sync and async regression tests for the deprecated VertexAI provider path

## Testing

- `python -m pytest tests/test_auto_client.py -k "vertexai_provider_defaults_to_vertexai_tools_mode or vertexai_provider_async_defaults_to_vertexai_tools_mode or vertexai_provider_runtime_import_error_propagates"`

Closes #1929
