### PR TITLE
Preserve OpenAI usage subclasses when accumulating tokens

### DIFF
--- a/instructor/utils/core.py
+++ b/instructor/utils/core.py
@@ -347,7 +347,22 @@ def update_total_usage(
         ):
             tpd.audio_tokens = (tpd.audio_tokens or 0) + (rpd.audio_tokens or 0)
             tpd.cached_tokens = (tpd.cached_tokens or 0) + (rpd.cached_tokens or 0)
-        response.usage = total_usage  # type: ignore  # Replace each response usage with the total usage
+        # Keep the concrete usage type attached to the response (for example
+        # LiteLLM subclasses CompletionUsage with helper methods), while still
+        # surfacing the accumulated totals.
+        response_usage.completion_tokens = total_usage.completion_tokens
+        response_usage.prompt_tokens = total_usage.prompt_tokens
+        response_usage.total_tokens = total_usage.total_tokens
+        response_usage.completion_tokens_details = (
+            total_usage.completion_tokens_details.model_copy(deep=True)
+            if total_usage.completion_tokens_details is not None
+            else None
+        )
+        response_usage.prompt_tokens_details = (
+            total_usage.prompt_tokens_details.model_copy(deep=True)
+            if total_usage.prompt_tokens_details is not None
+            else None
+        )
         return response
 
     # Anthropic usage.

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,5 +1,6 @@
 import json
 import pytest
+from openai.types import CompletionUsage
 from instructor.utils import (
     classproperty,
     extract_json_from_codeblock,
@@ -8,6 +9,7 @@ from instructor.utils import (
     merge_consecutive_messages,
     extract_system_messages,
     combine_system_messages,
+    update_total_usage,
 )
 
 
@@ -224,6 +226,37 @@ def test_combine_system_messages_list_string():
         {"type": "text", "text": "Existing"},
         {"type": "text", "text": "New"},
     ]
+
+
+def test_update_total_usage_preserves_openai_usage_subclass():
+    class LiteLLMUsage(CompletionUsage):
+        def get(self, key, default=None):
+            return getattr(self, key, default)
+
+    class Response:
+        def __init__(self, usage):
+            self.usage = usage
+
+    response_usage = LiteLLMUsage(
+        prompt_tokens=3,
+        completion_tokens=4,
+        total_tokens=7,
+    )
+    total_usage = CompletionUsage(
+        prompt_tokens=10,
+        completion_tokens=20,
+        total_tokens=30,
+    )
+    response = Response(response_usage)
+
+    updated = update_total_usage(response, total_usage)
+
+    assert updated is response
+    assert response.usage is response_usage
+    assert isinstance(response.usage, LiteLLMUsage)
+    assert response.usage.get("total_tokens") == 37
+    assert response.usage.prompt_tokens == 13
+    assert response.usage.completion_tokens == 24
 
 
 def test_combine_system_messages_none_string():


### PR DESCRIPTION
## Summary

Preserve the concrete `response.usage` type when accumulating OpenAI token usage across retries.

This fixes LiteLLM integrations where `response.usage` may be a subclass of `CompletionUsage` with extra helper methods. Replacing it with a plain `CompletionUsage` breaks those integrations.

## Changes

- keep the original `response.usage` object attached to the response
- update its token counts in place with the accumulated totals
- add a regression test covering a `CompletionUsage` subclass with LiteLLM-style helper methods

## Testing

- `python -m pytest tests/test_utils.py -k "update_total_usage_preserves_openai_usage_subclass"`

Closes #2113
