### PR TITLE
Support PEP 604 unions in Partial models

### DIFF
--- a/instructor/dsl/partial.py
+++ b/instructor/dsl/partial.py
@@ -259,6 +259,18 @@ def _process_generic_arg(
             return arg
 
 
+def _rebuild_generic_annotation(
+    generic_base: Any,
+    generic_args: tuple[Any, ...],
+) -> Any:
+    # `types.UnionType` (the runtime origin of `str | int`) cannot be
+    # subscripted directly, so reconstruct unions through `typing.Union`.
+    if generic_base in UNION_ORIGINS:
+        return Union[generic_args]  # type: ignore[arg-type]
+
+    return generic_base[generic_args]
+
+
 def _make_field_optional(
     field: FieldInfo,
 ) -> tuple[Any, FieldInfo]:
@@ -278,7 +290,9 @@ def _make_field_optional(
 
         # Reconstruct the generic type with modified arguments
         tmp_field.annotation = (
-            Optional[generic_base[modified_args]] if generic_base else None
+            Optional[_rebuild_generic_annotation(generic_base, modified_args)]
+            if generic_base
+            else None
         )
         tmp_field.default = None
         tmp_field.default_factory = None
@@ -1027,7 +1041,9 @@ class Partial(Generic[T_Model]):
 
                 # Reconstruct the generic type with modified arguments
                 tmp_field.annotation = (
-                    generic_base[modified_args] if generic_base else None
+                    _rebuild_generic_annotation(generic_base, modified_args)
+                    if generic_base
+                    else None
                 )
             # If the field is a BaseModel, then recursively convert it's
             # attributes to optionals.

--- a/tests/dsl/test_partial.py
+++ b/tests/dsl/test_partial.py
@@ -531,6 +531,19 @@ class TestPartialStreamingWithComplexTypes:
         result = TruePartial.model_validate({"value": 42})
         assert result.value == 42
 
+    def test_partial_model_supports_pep604_union_annotations(self):
+        class MyResponse(BaseModel):
+            value: str | int
+
+        PartialModel = Partial[MyResponse]
+        TruePartial = PartialModel.get_partial_model()
+
+        result = TruePartial.model_validate({"value": "hello"})
+        assert result.value == "hello"
+
+        result = TruePartial.model_validate({"value": 42})
+        assert result.value == 42
+
     def test_union_of_literals_matches_all_branches(self):
         """Union[Literal, Literal] should match values from all branches."""
 


### PR DESCRIPTION
## Summary

Support PEP 604 union annotations like `str | int` when building `Partial[...]` models.

`Partial[MyResponse]` currently fails for fields annotated with Python 3.10+ union syntax because the partial model builder tries to subscript `types.UnionType` directly.

## Changes

- add a shared helper to rebuild generic annotations
- special-case PEP 604 unions through `typing.Union` instead of subscripting `types.UnionType`
- add a regression test covering `Partial[...]` on a model with `str | int`

## Testing

- `python -m pytest tests/dsl/test_partial.py -k "pep604_union_annotations or union_literal_accepts_valid_values"`

Closes #2088
