### PR TITLE
Preserve LiteLLM cache token counts

### DIFF
--- a/instructor/utils/core.py
+++ b/instructor/utils/core.py
@@ -38,6 +38,10 @@ logger = logging.getLogger("instructor")
 R_co = TypeVar("R_co", covariant=True)
 T_Model = TypeVar("T_Model", bound=BaseModel)
 T = TypeVar("T")
+_OPTIONAL_OPENAI_USAGE_FIELDS = (
+    "cache_creation_input_tokens",
+    "cache_read_input_tokens",
+)
 
 
 def extract_json_from_codeblock(content: str) -> str:
@@ -347,7 +351,32 @@ def update_total_usage(
         ):
             tpd.audio_tokens = (tpd.audio_tokens or 0) + (rpd.audio_tokens or 0)
             tpd.cached_tokens = (tpd.cached_tokens or 0) + (rpd.cached_tokens or 0)
-        response.usage = total_usage  # type: ignore  # Replace each response usage with the total usage
+        for field_name in _OPTIONAL_OPENAI_USAGE_FIELDS:
+            if hasattr(response_usage, field_name):
+                setattr(
+                    total_usage,
+                    field_name,
+                    (getattr(total_usage, field_name, 0) or 0)
+                    + (getattr(response_usage, field_name, 0) or 0),
+                )
+        # Keep the original usage object attached so provider-specific fields
+        # from LiteLLM/Bedrock remain available after retries.
+        response_usage.completion_tokens = total_usage.completion_tokens
+        response_usage.prompt_tokens = total_usage.prompt_tokens
+        response_usage.total_tokens = total_usage.total_tokens
+        response_usage.completion_tokens_details = (
+            total_usage.completion_tokens_details.model_copy(deep=True)
+            if total_usage.completion_tokens_details is not None
+            else None
+        )
+        response_usage.prompt_tokens_details = (
+            total_usage.prompt_tokens_details.model_copy(deep=True)
+            if total_usage.prompt_tokens_details is not None
+            else None
+        )
+        for field_name in _OPTIONAL_OPENAI_USAGE_FIELDS:
+            if hasattr(total_usage, field_name):
+                setattr(response_usage, field_name, getattr(total_usage, field_name))
         return response
 
     # Anthropic usage.

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,7 +1,9 @@
 import json
 import pytest
+from openai.types import CompletionUsage
 from instructor.utils import (
     classproperty,
+    update_total_usage,
     extract_json_from_codeblock,
     extract_json_from_stream,
     extract_json_from_stream_async,
@@ -187,6 +189,49 @@ def test_classproperty():
             return cls.clvar
 
     assert MyClass.my_property == 1
+
+
+def test_update_total_usage_preserves_openai_cache_token_counts():
+    class LiteLLMUsage(CompletionUsage):
+        def get(self, key, default=None):
+            return getattr(self, key, default)
+
+    class Response:
+        def __init__(self, usage):
+            self.usage = usage
+
+    total_usage = CompletionUsage(
+        prompt_tokens=0,
+        completion_tokens=0,
+        total_tokens=0,
+    )
+
+    first_usage = LiteLLMUsage(
+        prompt_tokens=3,
+        completion_tokens=4,
+        total_tokens=7,
+    )
+    first_usage.cache_read_input_tokens = 11
+    first_usage.cache_creation_input_tokens = 5
+
+    second_usage = LiteLLMUsage(
+        prompt_tokens=2,
+        completion_tokens=1,
+        total_tokens=3,
+    )
+    second_usage.cache_read_input_tokens = 13
+    second_usage.cache_creation_input_tokens = 7
+
+    update_total_usage(Response(first_usage), total_usage)
+    updated = update_total_usage(Response(second_usage), total_usage)
+
+    assert updated is not None
+    assert isinstance(updated.usage, LiteLLMUsage)
+    assert updated.usage.prompt_tokens == 5
+    assert updated.usage.completion_tokens == 5
+    assert updated.usage.total_tokens == 10
+    assert updated.usage.get("cache_read_input_tokens") == 24
+    assert updated.usage.get("cache_creation_input_tokens") == 12
 
 
 def test_combine_system_messages_string_string():


### PR DESCRIPTION
## Summary

Preserve LiteLLM/Bedrock cache token details when Instructor aggregates `completion.usage`.

Today `update_total_usage()` replaces OpenAI-compatible usage objects with a plain aggregated `CompletionUsage`, which drops provider-specific fields like `cache_read_input_tokens` and `cache_creation_input_tokens`. This makes cache read/write token counts disappear from `completion.usage`.

## Changes

- keep provider-specific OpenAI-compatible usage objects attached to the response
- accumulate `cache_read_input_tokens` and `cache_creation_input_tokens` alongside the standard token totals
- add a regression test covering aggregated cache read/write token counts across retries

## Testing

- `python -m pytest tests/test_utils.py -k "update_total_usage_preserves_openai_cache_token_counts"`
- `python -m pytest tests/test_cache_integration.py`

Closes #2153
