### PR TITLE
Preserve default literal fields during partial streaming

### DIFF
--- a/instructor/dsl/partial.py
+++ b/instructor/dsl/partial.py
@@ -30,7 +30,7 @@ from typing import (  # noqa: UP035
 
 from jiter import from_json
 from pydantic import BaseModel, create_model
-from pydantic.fields import FieldInfo
+from pydantic.fields import FieldInfo, PydanticUndefined
 
 from instructor.mode import Mode
 from instructor.utils import extract_json_from_stream, extract_json_from_stream_async
@@ -171,11 +171,13 @@ def _build_partial_object(
         else:
             result[field_name] = field_value
 
-    # Set missing fields to None or empty nested models
+    # Set missing fields to defaults, None, or empty nested models
     for field_name, field_info in model.model_fields.items():
         if field_name not in result:
             field_type = field_info.annotation
-            if isinstance(field_type, type) and issubclass(field_type, BaseModel):
+            if field_info.default is not PydanticUndefined:
+                result[field_name] = deepcopy(field_info.default)
+            elif isinstance(field_type, type) and issubclass(field_type, BaseModel):
                 result[field_name] = _build_partial_object(
                     {}, field_type, tracker, "", **kwargs
                 )

--- a/tests/dsl/test_partial.py
+++ b/tests/dsl/test_partial.py
@@ -423,6 +423,23 @@ class TestLiteralTypeStreaming:
         assert result.name == "John"
         assert result.status is None
 
+    def test_literal_default_is_available_during_streaming(self):
+        """Literal fields with explicit defaults should be present in partial results."""
+
+        class Person(BaseModel):
+            type: Literal["Person"] = "Person"
+            name: str
+            age: int
+
+        PartialModel = Partial[Person]
+
+        results = list(PartialModel.model_from_chunks(['{"name": "Joh']))
+
+        assert len(results) == 1
+        assert results[0].type == "Person"
+        assert results[0].name == "Joh"
+        assert results[0].age is None
+
     def test_literal_rejects_complete_invalid_value(self):
         """Complete but invalid Literal values should fail validation."""
 


### PR DESCRIPTION
## Summary

Preserve explicit default literal fields in partial streaming responses.

When building partial objects during streaming, missing fields were always filled with `None`, which caused known defaults like `type: Literal["Person"] = "Person"` to disappear until the model emitted them explicitly at the end of the stream.

## Changes

- keep explicit field defaults when constructing incomplete partial objects
- preserve streaming behavior for required fields and nested models
- add a regression test covering a default `Literal[...]` field during partial streaming

## Testing

- `python -m pytest tests/dsl/test_partial.py -k "literal_default_is_available_during_streaming or partial_with_default_factory or partial_validates_incremental_streaming_data"`

Closes #2054
