### PR TITLE
feat(client): add two_step and two_step_async pipeline helpers

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -29,6 +29,14 @@ Functions to create Instructor clients from various providers.
 
 ::: instructor.from_litellm
 
+## Two-Step Pipeline
+
+Helper functions for separating reasoning and structured output into two LLM calls.
+
+::: instructor.two_step
+
+::: instructor.two_step_async
+
 ## DSL Components
 
 Domain-specific language components for advanced patterns and data handling.

--- a/instructor/__init__.py
+++ b/instructor/__init__.py
@@ -25,6 +25,8 @@ from .core.client import (
     AsyncInstructor,
     from_openai,
     from_litellm,
+    two_step,
+    two_step_async,
 )
 from .core import hooks
 from .utils.providers import Provider
@@ -43,6 +45,8 @@ __all__ = [
     "from_openai",
     "from_litellm",
     "from_provider",
+    "two_step",
+    "two_step_async",
     "AsyncInstructor",
     "Provider",
     "OpenAISchema",

--- a/instructor/core/client.py
+++ b/instructor/core/client.py
@@ -28,6 +28,8 @@ from .hooks import Hooks, HookName
 
 
 T = TypeVar("T", bound=Union[BaseModel, "Iterable[Any]", "Partial[Any]"])
+T_think = TypeVar("T_think", bound=BaseModel)
+T_final = TypeVar("T_final", bound=BaseModel)
 
 
 class Response:
@@ -910,3 +912,107 @@ def from_litellm(
             mode=mode,
             **kwargs,
         )
+
+
+def two_step(
+    client: Instructor,
+    think_model: type[T_think],
+    final_model: type[T_final],
+    messages: list[ChatCompletionMessageParam],
+    think_max_tokens: int,
+    final_max_tokens: int,
+    think_kwargs: dict | None = None,
+    final_kwargs: dict | None = None,
+) -> tuple[T_final, T_think]:
+    """Two-step inference for models without native thinking support"""
+
+    if any(msg["role"] == "system" for msg in messages):
+        raise ValueError(
+            "System messages in 'messages' are not allowed. "
+            "The pipeline uses its own system prompts for each step."
+        )
+
+    reasoning_result = client.create(
+        messages=[
+            {
+                "role": "system",
+                "content": "You are a reasoning assistant. "
+                "Do NOT answer the question directly. "
+                "Only think step-by-step and write your thought process.",
+            },
+            *messages,
+        ],
+        response_model=think_model,
+        max_tokens=think_max_tokens,
+        **(think_kwargs or {}),
+    )
+
+    final_result = client.create(
+        messages=[
+            {
+                "role": "system",
+                "content": "You are a precise assistant. "
+                "Based on the provided reasoning, give ONLY the final answer.",
+            },
+            *messages,
+            {"role": "assistant", "content": reasoning_result.model_dump_json()},
+            {"role": "user", "content": "Now produce the final structured answer."},
+        ],
+        response_model=final_model,
+        max_tokens=final_max_tokens,
+        **(final_kwargs or {}),
+    )
+
+    return final_result, reasoning_result
+
+
+async def two_step_async(
+    client: AsyncInstructor,
+    think_model: type[T_think],
+    final_model: type[T_final],
+    messages: list[ChatCompletionMessageParam],
+    think_max_tokens: int,
+    final_max_tokens: int,
+    think_kwargs: dict | None = None,
+    final_kwargs: dict | None = None,
+) -> tuple[T_final, T_think]:
+    """Two-step inference for models without native thinking support"""
+
+    if any(msg["role"] == "system" for msg in messages):
+        raise ValueError(
+            "System messages in 'messages' are not allowed. "
+            "The pipeline uses its own system prompts for each step."
+        )
+
+    reasoning_result = await client.create(
+        messages=[
+            {
+                "role": "system",
+                "content": "You are a reasoning assistant. "
+                "Do NOT answer the question directly. "
+                "Only think step-by-step and write your thought process.",
+            },
+            *messages,
+        ],
+        response_model=think_model,
+        max_tokens=think_max_tokens,
+        **(think_kwargs or {}),
+    )
+
+    final_result = await client.create(
+        messages=[
+            {
+                "role": "system",
+                "content": "You are a precise assistant. "
+                "Based on the provided reasoning, give ONLY the final answer.",
+            },
+            *messages,
+            {"role": "assistant", "content": reasoning_result.model_dump_json()},
+            {"role": "user", "content": "Now produce the final structured answer."},
+        ],
+        response_model=final_model,
+        max_tokens=final_max_tokens,
+        **(final_kwargs or {}),
+    )
+
+    return final_result, reasoning_result

--- a/tests/test_two_step.py
+++ b/tests/test_two_step.py
@@ -1,0 +1,99 @@
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from pydantic import BaseModel
+
+from instructor.core.client import two_step, two_step_async
+
+
+class ReasoningModel(BaseModel):
+    reasoning: str
+
+
+class Answer(BaseModel):
+    final_answer: str
+
+
+def test_two_step_returns_correct_types():
+    mock_client = MagicMock()
+    mock_client.create.side_effect = [
+        ReasoningModel(reasoning="Rayleigh scattering causes it."),
+        Answer(final_answer="The sky is blue due to Rayleigh scattering."),
+    ]
+
+    answer, reasoning = two_step(
+        client=mock_client,
+        messages=[{"role": "user", "content": "Why is the sky blue?"}],
+        think_model=ReasoningModel,
+        final_model=Answer,
+        think_max_tokens=256,
+        final_max_tokens=128,
+    )
+
+    assert isinstance(answer, Answer)
+    assert isinstance(reasoning, ReasoningModel)
+    assert mock_client.create.call_count == 2
+
+
+def test_two_step_rejects_system_messages():
+    mock_client = MagicMock()
+
+    with pytest.raises(ValueError, match="System messages"):
+        two_step(
+            client=mock_client,
+            messages=[
+                {"role": "system", "content": "You are a physics expert."},
+                {"role": "user", "content": "Why is the sky blue?"},
+            ],
+            think_model=ReasoningModel,
+            final_model=Answer,
+            think_max_tokens=256,
+            final_max_tokens=128,
+        )
+
+    assert mock_client.create.call_count == 0
+
+
+@pytest.mark.asyncio
+async def test_two_step_async_returns_correct_types():
+    mock_client = MagicMock()
+    mock_client.create = AsyncMock(
+        side_effect=[
+            ReasoningModel(reasoning="Rayleigh scattering causes it."),
+            Answer(final_answer="The sky is blue due to Rayleigh scattering."),
+        ]
+    )
+
+    answer, reasoning = await two_step_async(
+        client=mock_client,
+        messages=[{"role": "user", "content": "Why is the sky blue?"}],
+        think_model=ReasoningModel,
+        final_model=Answer,
+        think_max_tokens=256,
+        final_max_tokens=128,
+    )
+
+    assert isinstance(answer, Answer)
+    assert isinstance(reasoning, ReasoningModel)
+    assert mock_client.create.call_count == 2
+
+
+@pytest.mark.asyncio
+async def test_two_step_async_rejects_system_messages():
+    mock_client = MagicMock()
+    mock_client.create = AsyncMock()
+
+    with pytest.raises(ValueError, match="System messages"):
+        await two_step_async(
+            client=mock_client,
+            messages=[
+                {"role": "system", "content": "You are a physics expert."},
+                {"role": "user", "content": "Why is the sky blue?"},
+            ],
+            think_model=ReasoningModel,
+            final_model=Answer,
+            think_max_tokens=256,
+            final_max_tokens=128,
+        )
+
+    assert mock_client.create.call_count == 0


### PR DESCRIPTION
## Summary
Adds two_step and two_step_async as standalone functions for a 
model-agnostic two-step reasoning pipeline for models without 
native thinking support.

## Changes
- Add two_step and two_step_async functions in client.py
- Add tests in tests/test_two_step.py

Closes #2201