### PR TITLE
fix: detect truncated responses in GENAI_STRUCTURED_OUTPUTS mode

### DIFF
--- a/instructor/processing/function_calls.py
+++ b/instructor/processing/function_calls.py
@@ -269,6 +269,16 @@ class OpenAISchema(BaseModel):
         validation_context: Optional[dict[str, Any]] = None,
         strict: Optional[bool] = None,
     ) -> BaseModel:
+        from google.genai import types
+
+        if (
+            hasattr(completion, "candidates")
+            and completion.candidates
+            and completion.candidates[0].finish_reason
+            == types.FinishReason.MAX_TOKENS
+        ):
+            raise IncompleteOutputException(last_completion=completion)
+
         return cls.model_validate_json(
             completion.text, context=validation_context, strict=strict
         )


### PR DESCRIPTION
## Summary
- Add `finish_reason == MAX_TOKENS` check to `parse_genai_structured_outputs()` before attempting JSON parsing
- Raises `IncompleteOutputException` immediately on truncated output, matching the pattern used by OpenAI and Anthropic providers
- Prevents exponential token consumption during retry loops (~920K prompt tokens per failure)

## Problem
When using Gemini with `GENAI_STRUCTURED_OUTPUTS` mode, truncated responses were not detected before `model_validate_json()`. This caused `ValidationError` on incomplete JSON, triggering retries that concatenated the truncated text back into the prompt — each retry compounding the previous truncated output.

## Test plan
- [ ] Verify existing tests pass
- [ ] Test with Gemini model using a prompt that produces output exceeding `max_output_tokens` to confirm `IncompleteOutputException` is raised instead of entering retry loop

Fixes #2210