### PR TITLE
fix(genai): raise IncompleteOutputException when finish_reason is MAX_TOKENS

### DIFF
--- a/instructor/processing/function_calls.py
+++ b/instructor/processing/function_calls.py
@@ -269,6 +269,14 @@ class OpenAISchema(BaseModel):
         validation_context: Optional[dict[str, Any]] = None,
         strict: Optional[bool] = None,
     ) -> BaseModel:
+        from google.genai import types
+
+        if (
+            hasattr(completion, "candidates")
+            and completion.candidates
+            and completion.candidates[0].finish_reason == types.FinishReason.MAX_TOKENS
+        ):
+            raise IncompleteOutputException(last_completion=completion)
         return cls.model_validate_json(
             completion.text, context=validation_context, strict=strict
         )

--- a/tests/genai/test_incomplete_output.py
+++ b/tests/genai/test_incomplete_output.py
@@ -1,0 +1,40 @@
+"""Tests for IncompleteOutputException raised on MAX_TOKENS in genai responses."""
+
+import pytest
+from unittest.mock import MagicMock
+import instructor
+from instructor.core.exceptions import IncompleteOutputException
+
+
+class _SimpleModel(instructor.OpenAISchema):  # type: ignore[misc]
+    name: str
+
+
+def _make_completion(finish_reason) -> MagicMock:
+    """Build a minimal mock GenerateContentResponse with the given finish_reason."""
+    candidate = MagicMock()
+    candidate.finish_reason = finish_reason
+    completion = MagicMock()
+    completion.candidates = [candidate]
+    return completion
+
+
+def test_parse_genai_structured_outputs_raises_on_max_tokens() -> None:
+    """parse_genai_structured_outputs should raise IncompleteOutputException when MAX_TOKENS."""
+    from google.genai import types
+
+    completion = _make_completion(types.FinishReason.MAX_TOKENS)
+
+    with pytest.raises(IncompleteOutputException):
+        _SimpleModel.parse_genai_structured_outputs(completion)  # type: ignore[attr-defined]
+
+
+def test_parse_genai_structured_outputs_does_not_raise_on_stop() -> None:
+    """parse_genai_structured_outputs should not raise when finish_reason is STOP."""
+    from google.genai import types
+
+    completion = _make_completion(types.FinishReason.STOP)
+    completion.text = '{"name": "Alice"}'
+
+    result = _SimpleModel.parse_genai_structured_outputs(completion)  # type: ignore[attr-defined]
+    assert result.name == "Alice"


### PR DESCRIPTION
## Describe your changes

`parse_genai_structured_outputs` was silently trying to parse truncated JSON whenever Gemini stopped due to token limits, resulting in a confusing `ValidationError` instead of an actionable `IncompleteOutputException`.

This adds the same guard that already exists for OpenAI (`finish_reason == "length"`) and Anthropic (`stop_reason == "max_tokens"`):

```python
if (
    hasattr(completion, "candidates")
    and completion.candidates
    and completion.candidates[0].finish_reason == types.FinishReason.MAX_TOKENS
):
    raise IncompleteOutputException(last_completion=completion)
```

Callers can now catch `IncompleteOutputException` and retry with a higher `max_output_tokens` budget, consistent with the behavior on other providers.

## Issue ticket number and link

Closes #2210

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] If it is a core feature, I have added thorough tests.
- [ ] If it is a core feature, I have added documentation.