### PR TITLE
fix(validators): make allow_override work in llm_validator

### DIFF
--- a/instructor/validation/llm_validators.py
+++ b/instructor/validation/llm_validators.py
@@ -64,13 +64,14 @@ def llm_validator(
             temperature=temperature,
         )
 
-        # If the response is  not valid, return the reason, this could be used in
-        # the future to generate a better response, via reasking mechanism.
-        assert resp.is_valid, resp.reason
+        # If the value is not valid but we allow overrides and the LLM
+        # suggested a corrected value, return the fixed value instead of
+        # raising an assertion error.
+        if not resp.is_valid:
+            if allow_override and resp.fixed_value is not None:
+                return resp.fixed_value
+            assert resp.is_valid, resp.reason
 
-        if allow_override and not resp.is_valid and resp.fixed_value is not None:
-            # If the value is not valid, but we allow override, return the fixed value
-            return resp.fixed_value
         return v
 
     return llm

--- a/tests/test_llm_validator_allow_override.py
+++ b/tests/test_llm_validator_allow_override.py
@@ -1,0 +1,100 @@
+"""Tests for llm_validator allow_override functionality.
+
+Verifies that the allow_override parameter in llm_validator correctly
+returns a fixed value when the LLM deems the input invalid, instead of
+raising an AssertionError.
+"""
+
+from unittest.mock import Mock
+
+import pytest
+
+from instructor.processing.validators import Validator
+from instructor.validation.llm_validators import llm_validator
+
+
+def _make_mock_client(*, is_valid: bool, reason: str | None = None, fixed_value: str | None = None):
+    """Create a mock instructor client that returns a predetermined Validator response."""
+    mock_client = Mock()
+    mock_client.chat.completions.create.return_value = Validator(
+        is_valid=is_valid,
+        reason=reason,
+        fixed_value=fixed_value,
+    )
+    return mock_client
+
+
+class TestAllowOverride:
+    """Tests for the allow_override parameter in llm_validator."""
+
+    def test_valid_value_returns_original(self):
+        """When the LLM deems the value valid, the original value is returned."""
+        client = _make_mock_client(is_valid=True)
+        validator = llm_validator(
+            statement="Must be lowercase",
+            client=client,
+            allow_override=False,
+        )
+
+        result = validator("jason liu")
+        assert result == "jason liu"
+
+    def test_invalid_without_override_raises(self):
+        """When the value is invalid and allow_override is False, an AssertionError is raised."""
+        client = _make_mock_client(
+            is_valid=False,
+            reason="Name is not lowercase",
+            fixed_value="jason liu",
+        )
+        validator = llm_validator(
+            statement="Must be lowercase",
+            client=client,
+            allow_override=False,
+        )
+
+        with pytest.raises(AssertionError, match="Name is not lowercase"):
+            validator("Jason Liu")
+
+    def test_invalid_with_override_returns_fixed_value(self):
+        """When allow_override is True and the LLM provides a fixed value, that value is returned."""
+        client = _make_mock_client(
+            is_valid=False,
+            reason="Name is not lowercase",
+            fixed_value="jason liu",
+        )
+        validator = llm_validator(
+            statement="Must be lowercase",
+            client=client,
+            allow_override=True,
+        )
+
+        result = validator("Jason Liu")
+        assert result == "jason liu"
+
+    def test_invalid_with_override_but_no_fixed_value_raises(self):
+        """When allow_override is True but the LLM provides no fixed value, an AssertionError is raised."""
+        client = _make_mock_client(
+            is_valid=False,
+            reason="Name is not lowercase",
+            fixed_value=None,
+        )
+        validator = llm_validator(
+            statement="Must be lowercase",
+            client=client,
+            allow_override=True,
+        )
+
+        with pytest.raises(AssertionError, match="Name is not lowercase"):
+            validator("Jason Liu")
+
+    def test_valid_value_with_override_returns_original(self):
+        """When the value is valid, allow_override has no effect and the original is returned."""
+        client = _make_mock_client(is_valid=True)
+        validator = llm_validator(
+            statement="Must be lowercase",
+            client=client,
+            allow_override=True,
+        )
+
+        result = validator("jason liu")
+        assert result == "jason liu"


### PR DESCRIPTION
## Summary

- Fix dead code in `llm_validator` where the `allow_override` parameter could never take effect
- The `assert resp.is_valid` on line 69 always fired before the `allow_override` check on line 71, making the override path unreachable
- Restructure the logic so that when `allow_override=True` and the LLM provides a `fixed_value`, the corrected value is returned instead of raising `AssertionError`

## Problem

```python
# Before (broken): assert always fires first, override is dead code
assert resp.is_valid, resp.reason                          # <-- raises here
if allow_override and not resp.is_valid and resp.fixed_value is not None:
    return resp.fixed_value  # <-- never reached
```

```python
# After (fixed): check override before asserting
if not resp.is_valid:
    if allow_override and resp.fixed_value is not None:
        return resp.fixed_value
    assert resp.is_valid, resp.reason
```

## Test plan

- [x] `test_valid_value_returns_original` -- valid input returns original value
- [x] `test_invalid_without_override_raises` -- invalid input without override raises AssertionError
- [x] `test_invalid_with_override_returns_fixed_value` -- invalid input with override returns LLM-suggested fix
- [x] `test_invalid_with_override_but_no_fixed_value_raises` -- invalid input with override but no fix still raises
- [x] `test_valid_value_with_override_returns_original` -- valid input with override enabled returns original

```bash
python -m pytest tests/test_llm_validator_allow_override.py -v
```

Relates to #2056