### PR TITLE
Update pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -79,7 +79,7 @@ test-docs = [
     "pandas<3.0.0,>=2.2.0",
     "tabulate<1.0.0,>=0.9.0",
     "pydantic-extra-types<3.0.0,>=2.6.0",
-    "litellm<2.0.0,>=1.35.31",
+    "litellm<=1.82.6,>=1.35.31",
     "mistralai<2.0.0,>=1.5.1",
 ]
 anthropic = ["anthropic==0.76.0", "xmltodict>=0.13,<1.1"]
@@ -93,7 +93,7 @@ bedrock = ["boto3<2.0.0,>=1.34.0"]
 mistral = ["mistralai<2.0.0,>=1.5.1"]
 perplexity = ["openai>=2.0.0,<3.0.0"]
 google-genai = ["google-genai>=1.5.0","jsonref<2.0.0,>=1.1.0"]
-litellm = ["litellm<2.0.0,>=1.35.31"]
+litellm = ["litellm<=1.82.6,>=1.35.31"]
 xai = ["xai-sdk>=0.2.0 ; python_version >= '3.10'"]
 phonenumbers = ["phonenumbers>=8.13.33,<10.0.0"]
 graphviz = ["graphviz<1.0.0,>=0.20.3"]


### PR DESCRIPTION
Remove compromised version of litellm and pin to a safe version.

567-labs/instructor has been listed in [here](https://futuresearch.ai/blog/litellm-hack-were-you-one-of-the-47000/) as one of PyPI packages with with compromised litellm version