### PR TITLE
fix: change Validator.is_valid default to False (fail-closed)

### DIFF
--- a/instructor/processing/validators.py
+++ b/instructor/processing/validators.py
@@ -14,7 +14,7 @@ class Validator(OpenAISchema):
     """
 
     is_valid: bool = Field(
-        default=True,
+        default=False,
         description="Whether the attribute is valid based on the requirements",
     )
     reason: Optional[str] = Field(


### PR DESCRIPTION
## Summary
Change `Validator.is_valid` default from `True` to `False` so that when the LLM response omits `is_valid`, validation fails safely instead of silently passing.

## Problem
```python
# Before: default=True → fail-open
# LLM returns {"reason": "violates rule"} without is_valid
# → is_valid defaults to True → validation passes silently
```

## Fix
```diff
- is_valid: bool = Field(default=True, ...)
+ is_valid: bool = Field(default=False, ...)
```

## Test plan
- [ ] LLM response with `is_valid=True` → passes (no change)
- [ ] LLM response with `is_valid=False` → fails (no change)
- [ ] LLM response omitting `is_valid` → now fails (was silently passing)

Closes #2225