### PR TITLE
fix: make Validator.is_valid default to False (fail-closed)

### DIFF
--- a/instructor/processing/validators.py
+++ b/instructor/processing/validators.py
@@ -14,7 +14,7 @@ class Validator(OpenAISchema):
     """
 
     is_valid: bool = Field(
-        default=True,
+        default=False,
         description="Whether the attribute is valid based on the requirements",
     )
     reason: Optional[str] = Field(


### PR DESCRIPTION
Fixes #2225

## Problem

`Validator.is_valid` defaults to `True`, so if the LLM omits `is_valid` from its response (e.g. returning only `{"reason": "value violates the rule"}`), the validation silently passes — a fail-open behavior.

## Fix

Change `is_valid` default from `True` to `False`. Now if the model omits the field, validation fails-closed, which is the safe default for a security/validation check.

This is a one-line change in `instructor/processing/validators.py`.