### PR TITLE
fix(validation): require is_valid in Validator

### DIFF
--- a/instructor/processing/validators.py
+++ b/instructor/processing/validators.py
@@ -14,11 +14,9 @@ class Validator(OpenAISchema):
     """
 
     is_valid: bool = Field(
-        default=True,
         description="Whether the attribute is valid based on the requirements",
     )
-    reason: Optional[str] = Field(
-        default=None,
+    reason: str = Field(
         description="The error message if the attribute is not valid, otherwise None",
     )
     fixed_value: Optional[str] = Field(


### PR DESCRIPTION
Fixes #2225

## Summary

This PR makes `Validator.is_valid` required instead of relying on a default value.

## What Changed

- Removed the default `True` value from `Validator.is_valid`
- Made `reason` required as well

## Why

The issue describes a fail-open case where partial validator output like:

```json
{"reason": "value violates the rule"}
```

can be interpreted as valid because `is_valid` falls back to a default.

Rather than changing the fallback behavior, this PR enforces the expected schema so responses that omit `is_valid` fail validation instead of being treated as valid.

Issue: https://github.com/567-labs/instructor/issues/2225