### PR TITLE
fix: check finish_reason before parsing Gemini structured outputs

### DIFF
--- a/instructor/processing/function_calls.py
+++ b/instructor/processing/function_calls.py
@@ -269,6 +269,16 @@ class OpenAISchema(BaseModel):
         validation_context: Optional[dict[str, Any]] = None,
         strict: Optional[bool] = None,
     ) -> BaseModel:
+        from google.genai import types
+
+        if (
+            hasattr(completion, "candidates")
+            and completion.candidates
+            and completion.candidates[0].finish_reason
+            == types.FinishReason.MAX_TOKENS
+        ):
+            raise IncompleteOutputException(last_completion=completion)
+
         return cls.model_validate_json(
             completion.text, context=validation_context, strict=strict
         )


### PR DESCRIPTION
## Summary
- Add `finish_reason == MAX_TOKENS` check in `parse_genai_structured_outputs` before attempting JSON parsing
- Raise `IncompleteOutputException` immediately on truncated responses instead of parsing incomplete output
- Prevents exponential prompt growth during retries (~1.5M tokens burned per failure cycle)
- Matches the pattern already used by OpenAI (`finish_reason == "length"`) and Anthropic (`stop_reason == "max_tokens"`) providers

## Problem
When Gemini returns a truncated response (`finish_reason=MAX_TOKENS`), `parse_genai_structured_outputs` attempted to parse the incomplete JSON. This produced a `ValidationError` (retryable), entering the retry loop where `reask_genai_structured_outputs` appended the full truncated output back into the prompt each iteration, causing exponential token consumption. See #2210.

## Test plan
- [ ] Truncated Gemini responses trigger immediate `IncompleteOutputException` without appending output
- [ ] Normal (non-truncated) responses still parse correctly via `model_validate_json`
- [ ] Retry count is respected for non-truncation validation errors
- [ ] Existing tests pass

Fixes #2210