### PR TITLE
fix: exclude Vertex AI-only IMAGE_ harm categories from Gemini API

### DIFF
--- a/instructor/providers/gemini/utils.py
+++ b/instructor/providers/gemini/utils.py
@@ -304,66 +304,6 @@ def update_genai_kwargs(
             if val is not None:  # Only set if value is not None
                 base_config[gemini_key] = val
 
-    def _genai_kwargs_has_image_content(genai_kwargs: dict[str, Any]) -> bool:
-        """
-        Best-effort check for image content in a GenAI request.
-
-        We use this to decide whether to send text vs image harm categories in
-        `safety_settings`. The google-genai SDK has separate image categories
-        (e.g., `HARM_CATEGORY_IMAGE_HATE`) which are required for image content.
-        """
-        # Prefer typed GenAI contents if present (works with autodetect_images)
-        contents = genai_kwargs.get("contents")
-        if isinstance(contents, list):
-            for content in contents:
-                parts = getattr(content, "parts", None)
-                if not parts:
-                    continue
-                for part in parts:
-                    inline_data = getattr(part, "inline_data", None)
-                    if inline_data is not None:
-                        mime_type = getattr(inline_data, "mime_type", None)
-                        if isinstance(mime_type, str) and mime_type.startswith(
-                            "image/"
-                        ):
-                            return True
-
-                    file_data = getattr(part, "file_data", None)
-                    if file_data is not None:
-                        mime_type = getattr(file_data, "mime_type", None)
-                        if isinstance(mime_type, str) and mime_type.startswith(
-                            "image/"
-                        ):
-                            return True
-
-        # Fall back to OpenAI-style messages if present
-        messages = genai_kwargs.get("messages")
-        if isinstance(messages, list):
-            for message in messages:
-                if not isinstance(message, dict):
-                    continue
-                content = message.get("content")
-                if isinstance(content, Image):
-                    return True
-                if isinstance(content, list):
-                    for item in content:
-                        if isinstance(item, Image):
-                            return True
-                        if isinstance(item, dict) and item.get("type") in {
-                            "image",
-                            "image_url",
-                            "input_image",
-                        }:
-                            return True
-                if isinstance(content, dict) and content.get("type") in {
-                    "image",
-                    "image_url",
-                    "input_image",
-                }:
-                    return True
-
-        return False
-
     safety_settings = new_kwargs.pop("safety_settings", {})
     base_config["safety_settings"] = []
 
@@ -381,44 +321,24 @@ def update_genai_kwargs(
         excluded_categories.add(HarmCategory.HARM_CATEGORY_JAILBREAK)
 
     if safety_settings is not None:
-        # google-genai has separate categories for image content.
-        has_image = _genai_kwargs_has_image_content(new_kwargs)
-        image_categories = [
-            c
-            for c in HarmCategory
-            if c not in excluded_categories
-            and c.name.startswith("HARM_CATEGORY_IMAGE_")
-        ]
-        text_categories = [
+        # IMAGE_ harm categories (e.g. HARM_CATEGORY_IMAGE_HATE) are only
+        # supported by Vertex AI, not by the standard Gemini API.  Since
+        # update_genai_kwargs is only called from the GenAI (non-Vertex) code
+        # path, we must always exclude them here.  Including them causes the
+        # Gemini API to reject the request with a 400 error.
+        # See: https://github.com/instructor-ai/instructor/issues/2146
+        supported_categories = [
             c
             for c in HarmCategory
             if c not in excluded_categories
             and not c.name.startswith("HARM_CATEGORY_IMAGE_")
         ]
 
-        supported_categories = (
-            image_categories if (has_image and image_categories) else text_categories
-        )
-
-        def _map_text_to_image_category_name(image_category_name: str) -> str | None:
-            suffix = image_category_name.removeprefix("HARM_CATEGORY_IMAGE_")
-            # google-genai uses IMAGE_HATE while text uses HATE_SPEECH
-            if suffix == "HATE":
-                return "HARM_CATEGORY_HATE_SPEECH"
-            return f"HARM_CATEGORY_{suffix}"
-
         for category in supported_categories:
             threshold = HarmBlockThreshold.OFF
             if isinstance(safety_settings, dict):
                 if category in safety_settings:
                     threshold = safety_settings[category]
-                # If we are using image categories, try to honor thresholds passed via text categories.
-                elif has_image and category.name.startswith("HARM_CATEGORY_IMAGE_"):
-                    mapped_name = _map_text_to_image_category_name(category.name)
-                    if mapped_name is not None and hasattr(HarmCategory, mapped_name):
-                        mapped_category = getattr(HarmCategory, mapped_name)
-                        if mapped_category in safety_settings:
-                            threshold = safety_settings[mapped_category]
 
             base_config["safety_settings"].append(
                 {

--- a/tests/genai/test_safety_settings.py
+++ b/tests/genai/test_safety_settings.py
@@ -1,24 +1,13 @@
 from instructor.providers.gemini.utils import update_genai_kwargs
 
 
-def test_update_genai_kwargs_safety_settings_with_image_content_uses_image_categories():
-    """Image inputs should use IMAGE_* harm categories when available."""
+def test_update_genai_kwargs_excludes_image_categories_for_gemini_api():
+    """IMAGE_* harm categories are Vertex AI-only and must not be sent to the Gemini API.
+
+    See: https://github.com/instructor-ai/instructor/issues/2146
+    """
     from google.genai import types
     from google.genai.types import HarmCategory
-
-    excluded_categories = {HarmCategory.HARM_CATEGORY_UNSPECIFIED}
-    if hasattr(HarmCategory, "HARM_CATEGORY_JAILBREAK"):
-        excluded_categories.add(HarmCategory.HARM_CATEGORY_JAILBREAK)
-
-    image_categories = [
-        c
-        for c in HarmCategory
-        if c not in excluded_categories and c.name.startswith("HARM_CATEGORY_IMAGE_")
-    ]
-
-    # Older SDKs may not expose separate image categories.
-    if not image_categories:
-        return
 
     kwargs = {
         "contents": [
@@ -28,37 +17,34 @@ def test_update_genai_kwargs_safety_settings_with_image_content_uses_image_categ
             )
         ]
     }
-    base_config = {}
+    base_config: dict = {}
 
     result = update_genai_kwargs(kwargs, base_config)
 
     assert "safety_settings" in result
     assert isinstance(result["safety_settings"], list)
-    assert len(result["safety_settings"]) == len(image_categories)
-    assert {s["category"] for s in result["safety_settings"]} == set(image_categories)
+    # No IMAGE_* categories should be present -- they cause 400 on the Gemini API
+    for setting in result["safety_settings"]:
+        assert not setting["category"].name.startswith("HARM_CATEGORY_IMAGE_"), (
+            f"IMAGE_ category {setting['category'].name} should not be sent to Gemini API"
+        )
 
 
-def test_update_genai_kwargs_maps_text_thresholds_to_image_categories():
-    """Text thresholds should carry over to equivalent IMAGE_* categories."""
+def test_update_genai_kwargs_includes_text_categories_for_image_content():
+    """Even when the request contains images, only text categories should be used."""
     from google.genai import types
-    from google.genai.types import HarmBlockThreshold, HarmCategory
+    from google.genai.types import HarmCategory
 
     excluded_categories = {HarmCategory.HARM_CATEGORY_UNSPECIFIED}
     if hasattr(HarmCategory, "HARM_CATEGORY_JAILBREAK"):
         excluded_categories.add(HarmCategory.HARM_CATEGORY_JAILBREAK)
 
-    image_categories = [
+    text_categories = [
         c
         for c in HarmCategory
-        if c not in excluded_categories and c.name.startswith("HARM_CATEGORY_IMAGE_")
+        if c not in excluded_categories
+        and not c.name.startswith("HARM_CATEGORY_IMAGE_")
     ]
-
-    if not image_categories or not hasattr(HarmCategory, "HARM_CATEGORY_IMAGE_HATE"):
-        return
-
-    custom_safety = {
-        HarmCategory.HARM_CATEGORY_HATE_SPEECH: HarmBlockThreshold.BLOCK_LOW_AND_ABOVE
-    }
 
     kwargs = {
         "contents": [
@@ -66,20 +52,42 @@ def test_update_genai_kwargs_maps_text_thresholds_to_image_categories():
                 role="user",
                 parts=[types.Part.from_bytes(data=b"123", mime_type="image/png")],
             )
-        ],
-        "safety_settings": custom_safety,
+        ]
     }
-    base_config = {}
+    base_config: dict = {}
+
+    result = update_genai_kwargs(kwargs, base_config)
+
+    returned_categories = {s["category"] for s in result["safety_settings"]}
+    assert returned_categories == set(text_categories)
+
+
+def test_update_genai_kwargs_respects_custom_thresholds():
+    """User-provided thresholds should be applied to text categories."""
+    from google.genai.types import HarmBlockThreshold, HarmCategory
+
+    custom_safety = {
+        HarmCategory.HARM_CATEGORY_HATE_SPEECH: HarmBlockThreshold.BLOCK_LOW_AND_ABOVE
+    }
+
+    kwargs: dict = {"safety_settings": custom_safety}
+    base_config: dict = {}
 
     result = update_genai_kwargs(kwargs, base_config)
 
     for setting in result["safety_settings"]:
-        if setting["category"] == HarmCategory.HARM_CATEGORY_IMAGE_HATE:
+        if setting["category"] == HarmCategory.HARM_CATEGORY_HATE_SPEECH:
             assert setting["threshold"] == HarmBlockThreshold.BLOCK_LOW_AND_ABOVE
+            break
+    else:
+        raise AssertionError("HARM_CATEGORY_HATE_SPEECH not found in safety settings")
 
 
-def test_handle_genai_tools_autodetect_images_uses_image_categories():
-    """Autodetected image content should switch safety_settings to IMAGE_* categories."""
+def test_handle_genai_tools_excludes_image_categories():
+    """handle_genai_tools must not include IMAGE_* categories even with image content.
+
+    Regression test for https://github.com/instructor-ai/instructor/issues/2146
+    """
     from pydantic import BaseModel
 
     from instructor.providers.gemini.utils import handle_genai_tools
@@ -105,7 +113,7 @@ def test_handle_genai_tools_autodetect_images_uses_image_categories():
 
     assert "config" in out
     assert out["config"].safety_settings is not None
-    assert any(
+    assert not any(
         s.category.name.startswith("HARM_CATEGORY_IMAGE_")
         for s in out["config"].safety_settings
-    )
+    ), "IMAGE_ categories should not be sent to the Gemini API"

--- a/tests/llm/test_genai/test_utils.py
+++ b/tests/llm/test_genai/test_utils.py
@@ -108,8 +108,11 @@ def test_update_genai_kwargs_with_custom_safety_settings():
             assert setting["threshold"] == HarmBlockThreshold.OFF
 
 
-def test_update_genai_kwargs_safety_settings_with_image_content_uses_image_categories():
-    """Test that image content switches to IMAGE_* harm categories when available."""
+def test_update_genai_kwargs_excludes_image_categories_even_with_image_content():
+    """IMAGE_* categories are Vertex AI-only; the Gemini API must never include them.
+
+    Regression test for https://github.com/instructor-ai/instructor/issues/2146
+    """
     from google.genai import types
     from google.genai.types import HarmCategory
 
@@ -117,15 +120,12 @@ def test_update_genai_kwargs_safety_settings_with_image_content_uses_image_categ
     if hasattr(HarmCategory, "HARM_CATEGORY_JAILBREAK"):
         excluded_categories.add(HarmCategory.HARM_CATEGORY_JAILBREAK)
 
-    image_categories = [
+    text_categories = [
         c
         for c in HarmCategory
-        if c not in excluded_categories and c.name.startswith("HARM_CATEGORY_IMAGE_")
+        if c not in excluded_categories
+        and not c.name.startswith("HARM_CATEGORY_IMAGE_")
     ]
-
-    # Older SDKs may not expose separate image categories.
-    if not image_categories:
-        return
 
     kwargs = {
         "contents": [
@@ -141,48 +141,13 @@ def test_update_genai_kwargs_safety_settings_with_image_content_uses_image_categ
 
     assert "safety_settings" in result
     assert isinstance(result["safety_settings"], list)
-    assert len(result["safety_settings"]) == len(image_categories)
-    assert {s["category"] for s in result["safety_settings"]} == set(image_categories)
-
-
-def test_update_genai_kwargs_maps_text_thresholds_to_image_categories():
-    """Test that text-based safety settings are applied to equivalent IMAGE_* categories."""
-    from google.genai import types
-    from google.genai.types import HarmCategory, HarmBlockThreshold
-
-    excluded_categories = {HarmCategory.HARM_CATEGORY_UNSPECIFIED}
-    if hasattr(HarmCategory, "HARM_CATEGORY_JAILBREAK"):
-        excluded_categories.add(HarmCategory.HARM_CATEGORY_JAILBREAK)
-
-    image_categories = [
-        c
-        for c in HarmCategory
-        if c not in excluded_categories and c.name.startswith("HARM_CATEGORY_IMAGE_")
-    ]
-
-    if not image_categories or not hasattr(HarmCategory, "HARM_CATEGORY_IMAGE_HATE"):
-        return
-
-    custom_safety = {
-        HarmCategory.HARM_CATEGORY_HATE_SPEECH: HarmBlockThreshold.BLOCK_LOW_AND_ABOVE
-    }
-
-    kwargs = {
-        "contents": [
-            types.Content(
-                role="user",
-                parts=[types.Part.from_bytes(data=b"123", mime_type="image/png")],
-            )
-        ],
-        "safety_settings": custom_safety,
-    }
-    base_config = {}
-
-    result = update_genai_kwargs(kwargs, base_config)
-
-    for setting in result["safety_settings"]:
-        if setting["category"] == HarmCategory.HARM_CATEGORY_IMAGE_HATE:
-            assert setting["threshold"] == HarmBlockThreshold.BLOCK_LOW_AND_ABOVE
+    # Should only contain text categories, never IMAGE_* categories
+    returned_categories = {s["category"] for s in result["safety_settings"]}
+    assert returned_categories == set(text_categories)
+    assert not any(
+        s["category"].name.startswith("HARM_CATEGORY_IMAGE_")
+        for s in result["safety_settings"]
+    )
 
 
 def test_update_genai_kwargs_none_values():


### PR DESCRIPTION
## Summary
- Filter out `IMAGE_` harm categories (e.g., `HARM_CATEGORY_IMAGE_HATE`) when using the standard Gemini API
- These categories are Vertex AI-only and cause 400 errors on the Gemini API
- Remove the now-unused `_genai_kwargs_has_image_content` helper function
- Update tests to verify IMAGE_ categories are excluded from Gemini API calls

## Problem
Since PR #2007 (v1.14.4), all Gemini API calls that trigger safety settings fail with a 400 error because `update_genai_kwargs` includes Vertex AI-only `IMAGE_` harm categories. The `update_genai_kwargs` function is only called from the GenAI (non-Vertex) code path, so these categories should never be included. See #2146.

## Root Cause
PR #2007 added logic to switch between text and image harm categories based on whether the request contained image content. However, `IMAGE_` harm categories (`HARM_CATEGORY_IMAGE_HATE`, `HARM_CATEGORY_IMAGE_HARASSMENT`, etc.) are only supported by the Vertex AI API. The standard Gemini API rejects them with a 400 `INVALID_ARGUMENT` error.

## Fix
- Always use text-only categories in `update_genai_kwargs` since it is exclusively called from the Gemini API (non-Vertex) code path
- Vertex AI handlers (`handle_vertexai_tools`, `handle_vertexai_json`, etc.) have their own separate processing and are unaffected

## Test plan
- [x] Updated `tests/genai/test_safety_settings.py` to verify IMAGE_ categories are excluded
- [x] Updated `tests/llm/test_genai/test_utils.py` to verify IMAGE_ categories are excluded even with image content
- [ ] Gemini API calls no longer fail with 400 due to unsupported harm categories
- [ ] Vertex AI calls are unaffected (separate code path)

Fixes #2146