### PR TITLE
staging: v1.15.1 release candidate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 
 ---
 
+## [Unreleased] - 1.15.1
+
+### Fixed
+- **Anthropic usage**: Initialize usage correctly for `ANTHROPIC_REASONING_TOOLS` and `ANTHROPIC_PARALLEL_TOOLS` modes — previously fell through to OpenAI usage tracking with wrong field names
+- **OpenRouter**: Use `reask_md_json` for `OPENROUTER_STRUCTURED_OUTPUTS` retries instead of `reask_default` (tool-call format), fixing malformed retry prompts
+- **Templating**: Return `kwargs` unchanged instead of `None` in `handle_templating` when message list is empty or format is unrecognized; `process_message` also now returns the original message unchanged for unrecognized formats instead of `None`
+- **`from_openai`**: Allow `Mode.JSON_SCHEMA` for the OpenAI provider — it was incorrectly blocked by the mode validation check
+- **Bedrock**: Pass through `cachePoint` dicts in message content unchanged — previously raised `ValueError: Unsupported dict content for Bedrock`, breaking prompt caching (regression since v1.13.0)
+- **Parallel tools**: `ParallelBase` generator now consumed into `ListResponse` in both sync and async paths, fixing `AttributeError` when setting `_raw_response` on a generator
+
+---
+
 ## [1.15.0] - 2026-04-02
 
 ### Security

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,12 +9,21 @@ Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 
 ## [Unreleased] - 1.15.1
 
+### Security
+- **Bedrock**: Block remote HTTP(S) image URL fetching in `_openai_image_part_to_bedrock` — only `data:` URLs are now accepted, preventing SSRF via user-controlled image URLs
+- **Bedrock/PDF**: Block remote URL and local file fetching in `PDF.to_bedrock` — only base64 data or `s3://` sources are now supported, preventing SSRF and local file disclosure
+
+### Added
+- **Hooks**: `completion:error` and `completion:last_attempt` handlers now receive `attempt_number`, `max_attempts`, and `is_last_attempt` as keyword arguments. Old-style handlers remain fully backward-compatible.
+- **Anthropic**: `from_provider("anthropic/...")` now sets a `User-Agent: instructor/<version>` header on the Anthropic client
+
 ### Fixed
 - **Anthropic usage**: Initialize usage correctly for `ANTHROPIC_REASONING_TOOLS` and `ANTHROPIC_PARALLEL_TOOLS` modes — previously fell through to OpenAI usage tracking with wrong field names
 - **OpenRouter**: Use `reask_md_json` for `OPENROUTER_STRUCTURED_OUTPUTS` retries instead of `reask_default` (tool-call format), fixing malformed retry prompts
 - **Templating**: Return `kwargs` unchanged instead of `None` in `handle_templating` when message list is empty or format is unrecognized; `process_message` also now returns the original message unchanged for unrecognized formats instead of `None`
 - **`from_openai`**: Allow `Mode.JSON_SCHEMA` for the OpenAI provider — it was incorrectly blocked by the mode validation check
 - **Bedrock**: Pass through `cachePoint` dicts in message content unchanged — previously raised `ValueError: Unsupported dict content for Bedrock`, breaking prompt caching (regression since v1.13.0)
+- **Bedrock**: Allow `Mode.MD_JSON` in `from_bedrock`
 - **Parallel tools**: `ParallelBase` generator now consumed into `ListResponse` in both sync and async paths, fixing `AttributeError` when setting `_raw_response` on a generator
 
 ---

--- a/docs/concepts/hooks.md
+++ b/docs/concepts/hooks.md
@@ -13,9 +13,11 @@ Hooks let you intercept and handle events during the completion and parsing proc
 |-------|-------------|-------------------|
 | `completion:kwargs` | Arguments passed to completion | `def handler(*args, **kwargs)` |
 | `completion:response` | Raw API response received | `def handler(response)` |
-| `completion:error` | Error before retries | `def handler(error)` |
+| `completion:error` | Error during a retry attempt | `def handler(error, *, attempt_number, max_attempts, is_last_attempt)` |
 | `parse:error` | Pydantic validation failed | `def handler(error)` |
-| `completion:last_attempt` | Last retry attempt | `def handler(error)` |
+| `completion:last_attempt` | Final retry attempt exhausted | `def handler(error, *, attempt_number, max_attempts, is_last_attempt)` |
+
+`completion:error` and `completion:last_attempt` handlers receive optional retry metadata as keyword arguments. Old-style handlers that only accept `error` continue to work — the metadata is silently dropped for backward compatibility.
 
 ## Registering and Removing Hooks
 
@@ -61,6 +63,27 @@ from instructor.hooks import HookName
 client.on(HookName.COMPLETION_KWARGS, log_kwargs)  # Using enum
 client.on("completion:kwargs", log_kwargs)          # Using string
 ```
+
+## Retry Metadata
+
+`completion:error` and `completion:last_attempt` handlers can receive attempt metadata:
+
+```python
+import instructor
+
+client = instructor.from_provider("openai/gpt-4.1-mini")
+
+
+def on_error(error: Exception, *, attempt_number: int, max_attempts: int | None, is_last_attempt: bool):
+    print(f"Attempt {attempt_number}/{max_attempts or '?'} failed: {error}")
+    if is_last_attempt:
+        print("No more retries.")
+
+
+client.on("completion:error", on_error)
+```
+
+Old-style handlers that only accept `error` continue to work unchanged — the metadata is silently dropped.
 
 ## Practical Example: Logging
 

--- a/instructor/auto_client.py
+++ b/instructor/auto_client.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 from typing import Any, Union, Literal, overload
 from .core.client import AsyncInstructor, Instructor
 import instructor
+from instructor import __version__
 from instructor.models import KnownModelName
 from instructor.cache import BaseCache
 import warnings
@@ -414,9 +415,15 @@ def from_provider(
             from instructor import from_anthropic  # type: ignore[attr-defined]  # type: ignore[attr-defined]
 
             client = (
-                anthropic.AsyncAnthropic(api_key=api_key)
+                anthropic.AsyncAnthropic(
+                    api_key=api_key,
+                    default_headers={"User-Agent": f"instructor/{__version__}"},
+                )
                 if async_client
-                else anthropic.Anthropic(api_key=api_key)
+                else anthropic.Anthropic(
+                    api_key=api_key,
+                    default_headers={"User-Agent": f"instructor/{__version__}"},
+                )
             )
             max_tokens = kwargs.pop("max_tokens", 4096)
             result = from_anthropic(

--- a/instructor/core/client.py
+++ b/instructor/core/client.py
@@ -823,6 +823,7 @@ def from_openai(
         assert mode in {
             instructor.Mode.TOOLS,
             instructor.Mode.JSON,
+            instructor.Mode.JSON_SCHEMA,
             instructor.Mode.FUNCTIONS,
             instructor.Mode.PARALLEL_TOOLS,
             instructor.Mode.MD_JSON,

--- a/instructor/core/hooks.py
+++ b/instructor/core/hooks.py
@@ -3,6 +3,7 @@ from enum import Enum
 from collections import defaultdict
 from typing import Any, Literal, TypeVar, Protocol, Union
 
+import inspect
 import traceback
 import warnings
 
@@ -136,6 +137,13 @@ class Hooks:
         """
         for handler in self._handlers[hook_name]:
             try:
+                if kwargs:
+                    try:
+                        sig = inspect.signature(handler)
+                        sig.bind(*args, **kwargs)
+                    except TypeError:
+                        handler(*args)  # type: ignore
+                        continue
                 handler(*args, **kwargs)  # type: ignore
             except Exception:
                 error_traceback = traceback.format_exc()
@@ -163,23 +171,25 @@ class Hooks:
         """
         self.emit(HookName.COMPLETION_RESPONSE, response)
 
-    def emit_completion_error(self, error: Exception) -> None:
+    def emit_completion_error(self, error: Exception, **kwargs: Any) -> None:
         """
         Emit a completion error event.
 
         Args:
             error: The exception to pass to handlers
+            **kwargs: Optional metadata (attempt_number, max_attempts, is_last_attempt)
         """
-        self.emit(HookName.COMPLETION_ERROR, error)
+        self.emit(HookName.COMPLETION_ERROR, error, **kwargs)
 
-    def emit_completion_last_attempt(self, error: Exception) -> None:
+    def emit_completion_last_attempt(self, error: Exception, **kwargs: Any) -> None:
         """
         Emit a completion last attempt event.
 
         Args:
             error: The exception to pass to handlers
+            **kwargs: Optional metadata (attempt_number, max_attempts, is_last_attempt)
         """
-        self.emit(HookName.COMPLETION_LAST_ATTEMPT, error)
+        self.emit(HookName.COMPLETION_LAST_ATTEMPT, error, **kwargs)
 
     def emit_parse_error(self, error: Exception) -> None:
         """

--- a/instructor/core/retry.py
+++ b/instructor/core/retry.py
@@ -107,7 +107,12 @@ def initialize_usage(mode: Mode) -> CompletionUsage | Any:
         ),
         prompt_tokens_details=PromptTokensDetails(audio_tokens=0, cached_tokens=0),
     )
-    if mode in {Mode.ANTHROPIC_TOOLS, Mode.ANTHROPIC_JSON}:
+    if mode in {
+        Mode.ANTHROPIC_TOOLS,
+        Mode.ANTHROPIC_JSON,
+        Mode.ANTHROPIC_REASONING_TOOLS,
+        Mode.ANTHROPIC_PARALLEL_TOOLS,
+    }:
         from anthropic.types import Usage as AnthropicUsage
 
         total_usage = AnthropicUsage(

--- a/instructor/core/retry.py
+++ b/instructor/core/retry.py
@@ -227,23 +227,30 @@ def retry_sync(
                     )
 
                     # Check if this is the last attempt
+                    attempt_number = attempt.retry_state.attempt_number
+                    max_attempt_number = (
+                        getattr(max_retries.stop, "max_attempt_number", None)
+                        if isinstance(max_retries, Retrying)
+                        and hasattr(max_retries, "stop")
+                        else None
+                    )
                     if isinstance(max_retries, Retrying) and hasattr(
                         max_retries, "stop"
                     ):
-                        # For tenacity Retrying objects, check if next attempt would exceed limit
                         will_retry = (
                             attempt.retry_state.outcome is None
                             or not attempt.retry_state.outcome.failed
                         )
-                        is_last_attempt = (
-                            not will_retry
-                            or attempt.retry_state.attempt_number
-                            >= getattr(
-                                max_retries.stop, "max_attempt_number", float("inf")
-                            )
+                        is_last_attempt = not will_retry or attempt_number >= (
+                            max_attempt_number or float("inf")
                         )
                         if is_last_attempt:
-                            hooks.emit_completion_last_attempt(e)
+                            hooks.emit_completion_last_attempt(
+                                e,
+                                attempt_number=attempt_number,
+                                max_attempts=max_attempt_number,
+                                is_last_attempt=True,
+                            )
 
                     kwargs = handle_reask_kwargs(
                         kwargs=kwargs,
@@ -256,18 +263,15 @@ def retry_sync(
                 except Exception as e:
                     # Emit completion:error for non-validation errors (API errors, network errors, etc.)
                     logger.debug(f"Completion error: {e}")
-                    hooks.emit_completion_error(e)
-
-                    # Track this failed attempt
-                    failed_attempts.append(
-                        FailedAttempt(
-                            attempt_number=attempt.retry_state.attempt_number,
-                            exception=e,
-                            completion=response,
-                        )
+                    attempt_number = attempt.retry_state.attempt_number
+                    max_attempt_number = (
+                        getattr(max_retries.stop, "max_attempt_number", None)
+                        if isinstance(max_retries, Retrying)
+                        and hasattr(max_retries, "stop")
+                        else None
                     )
 
-                    # Check if this is the last attempt for completion errors
+                    is_last_attempt = False
                     if isinstance(max_retries, Retrying) and hasattr(
                         max_retries, "stop"
                     ):
@@ -275,15 +279,33 @@ def retry_sync(
                             attempt.retry_state.outcome is None
                             or not attempt.retry_state.outcome.failed
                         )
-                        is_last_attempt = (
-                            not will_retry
-                            or attempt.retry_state.attempt_number
-                            >= getattr(
-                                max_retries.stop, "max_attempt_number", float("inf")
-                            )
+                        is_last_attempt = not will_retry or attempt_number >= (
+                            max_attempt_number or float("inf")
                         )
-                        if is_last_attempt:
-                            hooks.emit_completion_last_attempt(e)
+
+                    hooks.emit_completion_error(
+                        e,
+                        attempt_number=attempt_number,
+                        max_attempts=max_attempt_number,
+                        is_last_attempt=is_last_attempt,
+                    )
+
+                    # Track this failed attempt
+                    failed_attempts.append(
+                        FailedAttempt(
+                            attempt_number=attempt_number,
+                            exception=e,
+                            completion=response,
+                        )
+                    )
+
+                    if is_last_attempt:
+                        hooks.emit_completion_last_attempt(
+                            e,
+                            attempt_number=attempt_number,
+                            max_attempts=max_attempt_number,
+                            is_last_attempt=True,
+                        )
                     raise e
     except RetryError as e:
         logger.debug(f"Retry error: {e}")
@@ -384,23 +406,30 @@ async def retry_async(
                     )
 
                     # Check if this is the last attempt
+                    attempt_number = attempt.retry_state.attempt_number
+                    max_attempt_number = (
+                        getattr(max_retries.stop, "max_attempt_number", None)
+                        if isinstance(max_retries, AsyncRetrying)
+                        and hasattr(max_retries, "stop")
+                        else None
+                    )
                     if isinstance(max_retries, AsyncRetrying) and hasattr(
                         max_retries, "stop"
                     ):
-                        # For tenacity AsyncRetrying objects, check if next attempt would exceed limit
                         will_retry = (
                             attempt.retry_state.outcome is None
                             or not attempt.retry_state.outcome.failed
                         )
-                        is_last_attempt = (
-                            not will_retry
-                            or attempt.retry_state.attempt_number
-                            >= getattr(
-                                max_retries.stop, "max_attempt_number", float("inf")
-                            )
+                        is_last_attempt = not will_retry or attempt_number >= (
+                            max_attempt_number or float("inf")
                         )
                         if is_last_attempt:
-                            hooks.emit_completion_last_attempt(e)
+                            hooks.emit_completion_last_attempt(
+                                e,
+                                attempt_number=attempt_number,
+                                max_attempts=max_attempt_number,
+                                is_last_attempt=True,
+                            )
 
                     kwargs = handle_reask_kwargs(
                         kwargs=kwargs,
@@ -413,18 +442,15 @@ async def retry_async(
                 except Exception as e:
                     # Emit completion:error for non-validation errors (API errors, network errors, etc.)
                     logger.debug(f"Completion error: {e}")
-                    hooks.emit_completion_error(e)
-
-                    # Track this failed attempt
-                    failed_attempts.append(
-                        FailedAttempt(
-                            attempt_number=attempt.retry_state.attempt_number,
-                            exception=e,
-                            completion=response,
-                        )
+                    attempt_number = attempt.retry_state.attempt_number
+                    max_attempt_number = (
+                        getattr(max_retries.stop, "max_attempt_number", None)
+                        if isinstance(max_retries, AsyncRetrying)
+                        and hasattr(max_retries, "stop")
+                        else None
                     )
 
-                    # Check if this is the last attempt for completion errors
+                    is_last_attempt = False
                     if isinstance(max_retries, AsyncRetrying) and hasattr(
                         max_retries, "stop"
                     ):
@@ -432,15 +458,33 @@ async def retry_async(
                             attempt.retry_state.outcome is None
                             or not attempt.retry_state.outcome.failed
                         )
-                        is_last_attempt = (
-                            not will_retry
-                            or attempt.retry_state.attempt_number
-                            >= getattr(
-                                max_retries.stop, "max_attempt_number", float("inf")
-                            )
+                        is_last_attempt = not will_retry or attempt_number >= (
+                            max_attempt_number or float("inf")
                         )
-                        if is_last_attempt:
-                            hooks.emit_completion_last_attempt(e)
+
+                    hooks.emit_completion_error(
+                        e,
+                        attempt_number=attempt_number,
+                        max_attempts=max_attempt_number,
+                        is_last_attempt=is_last_attempt,
+                    )
+
+                    # Track this failed attempt
+                    failed_attempts.append(
+                        FailedAttempt(
+                            attempt_number=attempt_number,
+                            exception=e,
+                            completion=response,
+                        )
+                    )
+
+                    if is_last_attempt:
+                        hooks.emit_completion_last_attempt(
+                            e,
+                            attempt_number=attempt_number,
+                            max_attempts=max_attempt_number,
+                            is_last_attempt=True,
+                        )
                     raise e
     except RetryError as e:
         logger.debug(f"Retry error: {e}")

--- a/instructor/processing/multimodal.py
+++ b/instructor/processing/multimodal.py
@@ -837,21 +837,11 @@ class PDF(BaseModel):
                 }
             }
 
-        # Handle bytes-based sources (URLs, paths, base64)
+        # Handle bytes-based sources (base64 only)
         if not self.data:
-            # Need to fetch/load the data
-            if isinstance(self.source, str) and self.source.startswith(
-                ("http://", "https://")
-            ):
-                response = requests.get(self.source)
-                response.raise_for_status()
-                pdf_bytes = response.content
-            elif isinstance(self.source, Path) or (
-                isinstance(self.source, str) and Path(self.source).exists()
-            ):
-                pdf_bytes = Path(self.source).read_bytes()
-            else:
-                raise ValueError("PDF data is missing and source cannot be loaded")
+            raise ValueError(
+                "PDF data is missing. Provide base64-encoded data or use an s3:// source."
+            )
         else:
             # Decode base64 data to bytes
             pdf_bytes = base64.b64decode(self.data)

--- a/instructor/processing/response.py
+++ b/instructor/processing/response.py
@@ -685,7 +685,7 @@ def handle_reask_kwargs(
         # Perplexity modes
         Mode.PERPLEXITY_JSON: reask_perplexity_json,
         # OpenRouter modes
-        Mode.OPENROUTER_STRUCTURED_OUTPUTS: reask_default,
+        Mode.OPENROUTER_STRUCTURED_OUTPUTS: reask_md_json,
         # XAI modes
         Mode.XAI_JSON: reask_xai_json,
         Mode.XAI_TOOLS: reask_xai_tools,

--- a/instructor/processing/response.py
+++ b/instructor/processing/response.py
@@ -265,8 +265,10 @@ async def process_response_async(
 
     if isinstance(response_model, ParallelBase):
         logger.debug(f"Returning model from ParallelBase")
-        model._raw_response = response
-        return model
+        return ListResponse.from_list(  # type: ignore[return-value]
+            list(model),
+            raw_response=response,
+        )
 
     if isinstance(model, AdapterBase):
         logger.debug(f"Returning model from AdapterBase")
@@ -383,8 +385,10 @@ def process_response(
 
     if isinstance(response_model, ParallelBase):
         logger.debug(f"Returning model from ParallelBase")
-        model._raw_response = response
-        return model
+        return ListResponse.from_list(  # type: ignore[return-value]
+            list(model),
+            raw_response=response,
+        )
 
     if isinstance(model, AdapterBase):
         logger.debug(f"Returning model from AdapterBase")

--- a/instructor/providers/bedrock/client.py
+++ b/instructor/providers/bedrock/client.py
@@ -51,6 +51,7 @@ def from_bedrock(
     valid_modes = {
         instructor.Mode.BEDROCK_TOOLS,
         instructor.Mode.BEDROCK_JSON,
+        instructor.Mode.MD_JSON,
     }
 
     if mode not in valid_modes:

--- a/instructor/providers/bedrock/utils.py
+++ b/instructor/providers/bedrock/utils.py
@@ -268,6 +268,10 @@ def _to_bedrock_content_items(content: Any) -> list[dict[str, Any]]:
                 if "document" in p and isinstance(p["document"], dict):
                     items.append(p)
                     continue
+                # Pass-through Bedrock cache point as-is
+                if "cachePoint" in p:
+                    items.append(p)
+                    continue
 
                 raise ValueError(f"Unsupported dict content for Bedrock: {p}")
 

--- a/instructor/providers/bedrock/utils.py
+++ b/instructor/providers/bedrock/utils.py
@@ -9,7 +9,6 @@ from __future__ import annotations
 import base64
 import json
 import mimetypes
-import requests
 from textwrap import dedent
 from typing import Any
 
@@ -156,16 +155,13 @@ def _normalize_bedrock_image_format(mime_or_ext: str) -> str:
 def _openai_image_part_to_bedrock(part: dict[str, Any]) -> dict[str, Any]:
     """
     Convert OpenAI-style image part:
-      {"type":"image_url","image_url":{"url": "<data:... or http(s):...>"}}
+      {"type":"image_url","image_url":{"url": "<data:...>"}}
     into Bedrock Converse image content:
       {"image":{"format": "<fmt>","source":{"bytes": <raw-bytes>}}}
     """
     image_url = (part.get("image_url") or {}).get("url")
     if not image_url:
         raise ValueError("image_url.url is required for OpenAI-style image parts")
-
-    guessed_mime = mimetypes.guess_type(image_url)[0] or "image/jpeg"
-    fmt = _normalize_bedrock_image_format(guessed_mime)
 
     # data URL to bytes
     if image_url.startswith("data:"):
@@ -175,38 +171,24 @@ def _openai_image_part_to_bedrock(part: dict[str, Any]) -> dict[str, Any]:
             raise ValueError("Invalid data URL in image_url.url") from e
         if ";base64" not in header:
             raise ValueError("Only base64 data URLs are supported for Bedrock")
+        meta = header[5:]  # strip 'data:'
+        mime = meta.split(";", 1)[0]
+        if not mime or "/" not in mime:
+            guessed = None
+            for token in meta.split(";")[1:]:
+                if token.startswith("name="):
+                    name = token[len("name=") :].strip().strip('"')
+                    guessed = mimetypes.guess_type(name)[0]
+                    if guessed:
+                        break
+            mime = guessed or "image/jpeg"
+        fmt = _normalize_bedrock_image_format(mime)
         return {"image": {"format": fmt, "source": {"bytes": base64.b64decode(b64)}}}
 
-    # http(s) URL to bytes
-    elif image_url.startswith(("http://", "https://")):
-        try:
-            resp = requests.get(image_url, timeout=15)
-            resp.raise_for_status()
-            ctype = resp.headers.get("Content-Type")
-            if ctype and "/" in ctype:
-                fmt = _normalize_bedrock_image_format(ctype)
-            return {"image": {"format": fmt, "source": {"bytes": resp.content}}}
-        except requests.exceptions.Timeout as e:  # type: ignore[attr-defined]
-            raise ValueError(f"Timed out while fetching image from {image_url}") from e
-        except requests.exceptions.ConnectionError as e:  # type: ignore[attr-defined]
-            raise ValueError(
-                f"Connection error while fetching image from {image_url}: {e}"
-            ) from e
-        except requests.exceptions.HTTPError as e:  # type: ignore[attr-defined]
-            raise ValueError(
-                f"HTTP error while fetching image from {image_url}: {e}"
-            ) from e
-        except requests.exceptions.RequestException as e:  # type: ignore[attr-defined]
-            raise ValueError(
-                f"Request error while fetching image from {image_url}: {e}"
-            ) from e
-        except Exception as e:
-            raise ValueError(
-                f"Unexpected error while fetching image from {image_url}: {e}"
-            ) from e
     else:
         raise ValueError(
-            "Unsupported image_url scheme. Use http(s) or data:image/...;base64,..."
+            "Unsupported image_url scheme for Bedrock. "
+            "Use data:image/...;base64,... or pass Bedrock-native image bytes."
         )
 
 

--- a/instructor/templating.py
+++ b/instructor/templating.py
@@ -119,12 +119,12 @@ def handle_templating(
     if isinstance(new_kwargs, list):
         messages = new_kwargs
         if not messages:
-            return
+            return new_kwargs
     elif isinstance(new_kwargs, dict):
         messages = new_kwargs.get("messages") or new_kwargs.get("contents")
 
     if not messages:
-        return
+        return new_kwargs
 
     if "messages" in new_kwargs:
         new_kwargs["messages"] = [

--- a/instructor/templating.py
+++ b/instructor/templating.py
@@ -80,6 +80,8 @@ def process_message(
         message["message"] = apply_template(message["message"], context)
         return message
 
+    return message
+
 
 def handle_templating(
     kwargs: dict[str, Any], mode: Mode, context: dict[str, Any] | None = None

--- a/tests/llm/test_bedrock/test_prepare_kwargs.py
+++ b/tests/llm/test_bedrock/test_prepare_kwargs.py
@@ -1,8 +1,9 @@
 from __future__ import annotations
+import pytest
 from instructor.providers.bedrock.utils import _prepare_bedrock_converse_kwargs_internal
 
 
-def test_prepare_bedrock_kwargs_openai_text_plus_image(image_url: str):
+def test_prepare_bedrock_kwargs_openai_text_plus_image(tiny_png_data_url: str):
     call_kwargs = {
         "model": "anthropic.claude-3-5-sonnet",
         "temperature": 0.3,
@@ -15,7 +16,7 @@ def test_prepare_bedrock_kwargs_openai_text_plus_image(image_url: str):
                 "role": "user",
                 "content": [
                     {"type": "text", "text": "hi"},
-                    {"type": "image_url", "image_url": {"url": image_url}},
+                    {"type": "image_url", "image_url": {"url": tiny_png_data_url}},
                 ],
             },
         ],
@@ -36,3 +37,23 @@ def test_prepare_bedrock_kwargs_openai_text_plus_image(image_url: str):
     assert parts[1]["image"]["format"] in {"jpeg", "png", "gif", "webp"}
     assert isinstance(parts[1]["image"]["source"]["bytes"], (bytes, bytearray))
     assert len(parts[1]["image"]["source"]["bytes"]) > 0
+
+
+def test_prepare_bedrock_kwargs_openai_image_url_rejects_http():
+    """Remote HTTP(S) URLs are not fetched (SSRF prevention) — must use data: URLs."""
+    call_kwargs = {
+        "model": "anthropic.claude-3-5-sonnet",
+        "messages": [
+            {
+                "role": "user",
+                "content": [
+                    {
+                        "type": "image_url",
+                        "image_url": {"url": "https://example.com/image.jpg"},
+                    }
+                ],
+            }
+        ],
+    }
+    with pytest.raises(ValueError, match="Unsupported image_url scheme for Bedrock"):
+        _prepare_bedrock_converse_kwargs_internal(call_kwargs)

--- a/tests/test_multimodal.py
+++ b/tests/test_multimodal.py
@@ -608,25 +608,17 @@ def test_pdf_to_bedrock_with_path_source(tmp_path):
 
 
 def test_pdf_to_bedrock_with_url_source():
-    """Test PDF.to_bedrock with HTTP URL source."""
-    pdf_bytes = b"%PDF-1.4\nfetched content"
-
-    with patch("instructor.processing.multimodal.requests.get") as mock_get:
-        resp = MagicMock()
-        resp.content = pdf_bytes
-        resp.raise_for_status = MagicMock()
-        mock_get.return_value = resp
-
-        pdf = PDF(
-            source="https://example.com/doc.pdf",
-            media_type="application/pdf",
-            data=None,
-        )
-        bedrock_format = pdf.to_bedrock()
-
-    assert bedrock_format["document"]["format"] == "pdf"
-    assert bedrock_format["document"]["name"] == "docpdf"
-    assert bedrock_format["document"]["source"]["bytes"] == pdf_bytes
+    """Test PDF.to_bedrock rejects HTTP URL source without data (SSRF prevention)."""
+    pdf = PDF(
+        source="https://example.com/doc.pdf",
+        media_type="application/pdf",
+        data=None,
+    )
+    with pytest.raises(
+        ValueError,
+        match="PDF data is missing. Provide base64-encoded data or use an s3:// source.",
+    ):
+        pdf.to_bedrock()
 
 
 def test_pdf_to_bedrock_name_sanitization():
@@ -668,21 +660,18 @@ def test_pdf_to_bedrock_name_from_path_source(tmp_path):
 
 
 def test_pdf_to_bedrock_name_from_url():
-    """Test that PDF.to_bedrock extracts name from URL."""
+    """Test that PDF.to_bedrock uses URL path for name when data is provided."""
+    import base64
+
     pdf_bytes = b"%PDF-1.4\ntest"
+    encoded = base64.b64encode(pdf_bytes).decode("utf-8")
 
-    with patch("instructor.processing.multimodal.requests.get") as mock_get:
-        resp = MagicMock()
-        resp.content = pdf_bytes
-        resp.raise_for_status = MagicMock()
-        mock_get.return_value = resp
-
-        pdf = PDF(
-            source="https://example.com/reports/annual-report-2024.pdf",
-            media_type="application/pdf",
-            data=None,
-        )
-        bedrock_format = pdf.to_bedrock()
+    pdf = PDF(
+        source="https://example.com/reports/annual-report-2024.pdf",
+        media_type="application/pdf",
+        data=encoded,
+    )
+    bedrock_format = pdf.to_bedrock()
 
     assert bedrock_format["document"]["name"] == "annual-report-2024pdf"
 
@@ -730,6 +719,7 @@ def test_pdf_to_bedrock_missing_data_no_source():
     )
 
     with pytest.raises(
-        ValueError, match="PDF data is missing and source cannot be loaded"
+        ValueError,
+        match="PDF data is missing. Provide base64-encoded data or use an s3:// source.",
     ):
         pdf.to_bedrock()


### PR DESCRIPTION
## Summary

- fix(retry): initialize Anthropic usage for REASONING_TOOLS and PARALLEL_TOOLS modes
- fix(openrouter): use reask_md_json for OPENROUTER_STRUCTURED_OUTPUTS retries
- fix(templating): return kwargs instead of None in handle_templating and process_message for empty/unrecognized formats
- fix(openai): allow Mode.JSON_SCHEMA in from_openai
- fix(bedrock): pass through cachePoint dicts in message content (regression since v1.13.0)
- fix(parallel): consume ParallelBase generator into ListResponse to fix AttributeError on _raw_response

## Test plan

- [ ] Run full test suite: `uv run pytest tests/ -k 'not llm and not openai'`
- [ ] Verify Anthropic usage tracking with REASONING_TOOLS mode
- [ ] Verify OpenRouter retries use JSON format
- [ ] Verify Bedrock cachePoint pass-through
- [ ] Verify parallel tools return ListResponse

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core retry/response processing paths across multiple providers (Anthropic/OpenAI/OpenRouter/Bedrock) and could change runtime behavior for retries and returned response types. Scope is contained to bug fixes but spans frequently used execution paths.
> 
> **Overview**
> Prepares the `1.15.1` release with targeted fixes across provider integrations and core response plumbing.
> 
> Fixes include: correct Anthropic usage initialization for `ANTHROPIC_REASONING_TOOLS`/`ANTHROPIC_PARALLEL_TOOLS`, enabling `Mode.JSON_SCHEMA` in `from_openai` mode validation, switching `OPENROUTER_STRUCTURED_OUTPUTS` retries to `reask_md_json`, passing Bedrock `cachePoint` content blocks through without error, making templating helpers return inputs unchanged (instead of `None`) for empty/unrecognized message formats, and returning `ParallelBase` results as a consumed `ListResponse` (sync + async) to avoid generator `_raw_response` errors.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 099a95e8b2095861b9249eb9ea870a6d1c856eb1. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->