### PR TITLE
fix(genai): skip templating for non-text Parts in multimodal messages

### DIFF
--- a/instructor/templating.py
+++ b/instructor/templating.py
@@ -23,7 +23,7 @@ def process_message(
             parts=[
                 (
                     types.Part.from_text(text=apply_template(part.text, context))
-                    if hasattr(part, "text")
+                    if hasattr(part, "text") and part.text is not None
                     else part
                 )
                 for part in message.parts
@@ -44,7 +44,7 @@ def process_message(
             parts=[
                 (
                     gm.Part.from_text(apply_template(part.text, context))
-                    if hasattr(part, "text")
+                    if hasattr(part, "text") and part.text is not None
                     else part
                 )
                 for part in message.parts

--- a/tests/genai/test_templating_multimodal.py
+++ b/tests/genai/test_templating_multimodal.py
@@ -1,0 +1,80 @@
+"""Regression test for #2253: templating crashes on genai image parts.
+
+When a genai Content message contains non-text Parts (images, URIs, bytes),
+the `text` attribute exists but is None. process_message must skip
+templating for these parts instead of passing None to Jinja2.
+"""
+
+from google.genai import types
+
+from instructor.mode import Mode
+from instructor.templating import handle_templating, process_message
+
+
+def test_process_message_skips_non_text_genai_parts():
+    """Image/URI parts with text=None must pass through untemplated."""
+    msg = types.Content(
+        role="user",
+        parts=[
+            types.Part.from_text(text="Describe {{ subject }}"),
+            types.Part.from_uri(
+                file_uri="gs://bucket/image.jpg", mime_type="image/jpeg"
+            ),
+        ],
+    )
+
+    result = process_message(msg, {"subject": "this image"}, Mode.GENAI_TOOLS)
+
+    assert result.parts[0].text == "Describe this image"
+    # The URI part should pass through unchanged
+    assert result.parts[1].file_data is not None
+    assert result.parts[1].file_data.file_uri == "gs://bucket/image.jpg"
+
+
+def test_process_message_handles_bytes_part():
+    """Parts created from raw bytes also have text=None."""
+    msg = types.Content(
+        role="user",
+        parts=[
+            types.Part.from_text(text="Analyze this"),
+            types.Part.from_bytes(data=b"\x89PNG", mime_type="image/png"),
+        ],
+    )
+
+    result = process_message(msg, {"key": "val"}, Mode.GENAI_STRUCTURED_OUTPUTS)
+
+    assert result.parts[0].text == "Analyze this"
+    assert result.parts[1].inline_data is not None
+
+
+def test_handle_templating_with_multimodal_genai_contents():
+    """End-to-end: handle_templating must not crash on multimodal genai messages."""
+    kwargs = {
+        "messages": [
+            types.Content(
+                role="user",
+                parts=[
+                    types.Part.from_text(text="What is {{ item }}?"),
+                    types.Part.from_uri(
+                        file_uri="gs://b/img.jpg", mime_type="image/jpeg"
+                    ),
+                ],
+            )
+        ]
+    }
+
+    result = handle_templating(kwargs, Mode.GENAI_TOOLS, context={"item": "this"})
+    processed = result["messages"][0]
+    assert processed.parts[0].text == "What is this?"
+
+
+def test_handle_templating_no_context_passthrough():
+    """Without context, messages should pass through unchanged."""
+    msg = types.Content(
+        role="user",
+        parts=[types.Part.from_text(text="{{ not_a_template }}")],
+    )
+    kwargs = {"messages": [msg]}
+
+    result = handle_templating(kwargs, Mode.GENAI_TOOLS, context=None)
+    assert result["messages"][0].parts[0].text == "{{ not_a_template }}"


### PR DESCRIPTION
## Summary

Fixes #2253

When using GENAI_TOOLS or GENAI_STRUCTURED_OUTPUTS mode with multimodal messages (image/URI/bytes parts) and a non-None `validation_context`, `process_message` crashes:

```
TypeError: Can't compile non template nodes
```

The crash happens because genai `Part` objects for images/URIs/bytes have a `text` attribute that exists but is `None`. The existing `hasattr(part, "text")` check passes, so `None` gets fed to `SandboxedEnvironment().from_string()`, which Jinja2 rejects.

## Fix

Add `and part.text is not None` to the condition on both the GENAI path (line 26) and the VertexAI path (line 47), so non-text parts pass through unchanged.

**Before:** any Part with a `text` attribute (including `text=None`) is templated → crash
**After:** only Parts with actual text content are templated; image/URI/bytes parts pass through

## Tests

Added 4 regression tests in `tests/genai/test_templating_multimodal.py`:
- URI parts pass through untemplated
- Raw bytes parts pass through untemplated
- End-to-end `handle_templating` with mixed text+image content
- No-context passthrough (no crash, no transformation)

All existing tests pass (`pytest tests/genai/ tests/test_message_processing.py tests/test_formatting.py` — 46 passed).