### PR TITLE
fix(templating): skip non-text Parts in GENAI/VertexAI mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 
 ---
 
+## [Unreleased]
+
+### Fixed
+- **Templating**: Skip non-text `google.genai.types.Part` objects (image, binary) in GENAI and VertexAI templating branches — `part.text` is `None` for these, which crashed `SandboxedEnvironment().from_string(None)` ([#2257](https://github.com/instructor-ai/instructor/pull/2257))
+
+---
+
 ## [1.15.1] - 2026-04-03
 
 ### Security

--- a/instructor/templating.py
+++ b/instructor/templating.py
@@ -23,7 +23,7 @@ def process_message(
             parts=[
                 (
                     types.Part.from_text(text=apply_template(part.text, context))
-                    if hasattr(part, "text")
+                    if hasattr(part, "text") and isinstance(part.text, str)
                     else part
                 )
                 for part in message.parts
@@ -44,7 +44,7 @@ def process_message(
             parts=[
                 (
                     gm.Part.from_text(apply_template(part.text, context))
-                    if hasattr(part, "text")
+                    if hasattr(part, "text") and isinstance(part.text, str)
                     else part
                 )
                 for part in message.parts

--- a/tests/test_formatting.py
+++ b/tests/test_formatting.py
@@ -141,3 +141,25 @@ def test_handle_templating_with_gemini_format():
     assert result == {
         "contents": [{"role": "user", "parts": ["Hello Eve!", "How are you Eve?"]}]
     }
+
+
+def test_handle_templating_genai_skips_non_text_parts():
+    types = pytest.importorskip("google.genai").types
+
+    from instructor.templating import process_message
+
+    message = types.Content(
+        role="user",
+        parts=[
+            types.Part.from_text(text="Describe this for {{ user }}"),
+            types.Part.from_uri(
+                file_uri="https://example.com/image.jpg",
+                mime_type="image/jpeg",
+            ),
+        ],
+    )
+
+    result = process_message(message, {"user": "Alice"}, Mode.GENAI_TOOLS)
+
+    assert result.parts[0].text == "Describe this for Alice"
+    assert result.parts[1] is message.parts[1]


### PR DESCRIPTION
Closes #2253.

`google.genai.types.Part` objects for images and binary data have `text=None`. When `validation_context` is set, `process_message` passes that `None` into `SandboxedEnvironment().from_string(None)`, which crashes during Jinja2 compilation.

The fix adds `isinstance(part.text, str)` to the GENAI and VertexAI branches — matching the guard pattern already used in the Anthropic branch (line 64). Non-text Parts pass through unchanged.
