### PR TITLE
fix(templating): skip non-text Parts in GENAI/VertexAI mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 
 ---
 
+## [Unreleased]
+
+### Fixed
+- **Templating (GenAI/VertexAI)**: `process_message` no longer crashes with `TypeError: Can't compile non template nodes` when multimodal messages contain image/URI/bytes Parts alongside `validation_context`. Non-text Parts (where `part.text` is `None`) now pass through unchanged. ([#2253](https://github.com/567-labs/instructor/issues/2253))
+
+---
+
 ## [1.15.1] - 2026-04-03
 
 ### Security

--- a/instructor/templating.py
+++ b/instructor/templating.py
@@ -23,7 +23,7 @@ def process_message(
             parts=[
                 (
                     types.Part.from_text(text=apply_template(part.text, context))
-                    if hasattr(part, "text")
+                    if isinstance(getattr(part, "text", None), str)
                     else part
                 )
                 for part in message.parts
@@ -44,7 +44,7 @@ def process_message(
             parts=[
                 (
                     gm.Part.from_text(apply_template(part.text, context))
-                    if hasattr(part, "text")
+                    if isinstance(getattr(part, "text", None), str)
                     else part
                 )
                 for part in message.parts

--- a/tests/test_formatting.py
+++ b/tests/test_formatting.py
@@ -141,3 +141,28 @@ def test_handle_templating_with_gemini_format():
     assert result == {
         "contents": [{"role": "user", "parts": ["Hello Eve!", "How are you Eve?"]}]
     }
+
+
+def test_handle_templating_with_genai_multimodal_parts():
+    """Non-text Parts (images/URIs) have text=None and must pass through untouched.
+
+    Regression test for #2253: apply_template was being called with None,
+    crashing Jinja2 with "Can't compile non template nodes".
+    """
+    from google.genai import types
+
+    text_part = types.Part.from_text(text="Describe {{ subject }}")
+    image_part = types.Part.from_uri(
+        file_uri="gs://example/cat.png", mime_type="image/png"
+    )
+    content = types.Content(role="user", parts=[text_part, image_part])
+
+    kwargs = {"contents": [content]}
+    context = {"subject": "this image"}
+
+    result = handle_templating(kwargs, Mode.GENAI_TOOLS, context)
+
+    processed = result["contents"][0]
+    assert processed.parts[0].text == "Describe this image"
+    assert processed.parts[1].text is None
+    assert processed.parts[1].file_data.file_uri == "gs://example/cat.png"


### PR DESCRIPTION
## Summary
- `google.genai.types.Part` and `vertexai.generative_models.Part` objects for images/URIs/bytes have a `text` attribute that exists but is `None`
- The previous `hasattr(part, "text")` guard passed, so `None` was handed to `SandboxedEnvironment().from_string(None)` and Jinja2 crashed with `TypeError: Can't compile non template nodes` whenever `validation_context` was set on a multimodal message
- Switched both the GENAI and VertexAI branches of `process_message` to `isinstance(getattr(part, "text", None), str)` so non-text Parts pass through unchanged

Closes #2253. Supersedes #2255 and #2257.

## Test plan
- [x] `uv run pytest tests/test_formatting.py -x`
- [x] New regression test `test_handle_templating_with_genai_multimodal_parts` constructs a real `types.Content` with a text Part and a URI Part, renders the template, and asserts the text Part is rendered while the URI Part is untouched

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: narrow guard change in GenAI/VertexAI templating plus a regression test; behavior only differs for multimodal Parts with `text=None`. Main risk is unintentionally skipping templating for unexpected non-string `text` values.
> 
> **Overview**
> Fixes multimodal templating for Google GenAI/VertexAI by only applying `apply_template` when `part.text` is actually a string, letting image/URI/bytes Parts pass through unchanged instead of crashing Jinja2.
> 
> Adds a regression test covering mixed text+URI GenAI `Content`, and documents the fix in the *Unreleased* changelog.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4a2caea8dcf307506f552f29a0e48b257af7482e. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->