### PR TITLE
fix: preserve descriptions in responses tools mode

### DIFF
--- a/instructor/providers/openai/utils.py
+++ b/instructor/providers/openai/utils.py
@@ -383,17 +383,11 @@ def handle_responses_tools(
             f"the required parameters with correct types"
         )
 
-    new_kwargs["tools"] = [
-        {
-            "type": "function",
-            "name": schema["function"]["name"],
-            "parameters": schema["function"]["parameters"],
-        }
-    ]
+    new_kwargs["tools"] = [tool_definition]
 
     new_kwargs["tool_choice"] = {
         "type": "function",
-        "name": generate_openai_schema(response_model)["name"],
+        "name": tool_definition["name"],
     }
 
     return response_model, new_kwargs

--- a/tests/test_openai_responses_tools.py
+++ b/tests/test_openai_responses_tools.py
@@ -1,0 +1,29 @@
+from pydantic import BaseModel
+
+from openai import pydantic_function_tool
+
+from instructor.providers.openai.utils import (
+    handle_responses_tools,
+    handle_responses_tools_with_inbuilt_tools,
+)
+
+
+class ResponseToolModel(BaseModel):
+    """Extract a structured response for the user."""
+
+    name: str
+
+
+def test_responses_tools_preserves_function_description() -> None:
+    expected_description = pydantic_function_tool(ResponseToolModel)["function"][
+        "description"
+    ]
+
+    _, responses_tools_kwargs = handle_responses_tools(ResponseToolModel, {})
+    _, inbuilt_tools_kwargs = handle_responses_tools_with_inbuilt_tools(
+        ResponseToolModel, {}
+    )
+
+    assert responses_tools_kwargs["tools"][0]["description"] == expected_description
+    assert inbuilt_tools_kwargs["tools"][0]["description"] == expected_description
+    assert responses_tools_kwargs["tools"][0] == inbuilt_tools_kwargs["tools"][0]


### PR DESCRIPTION
## Summary
Preserve the function description in `RESPONSES_TOOLS` payloads by reusing the full `tool_definition`, matching `RESPONSES_TOOLS_WITH_INBUILT_TOOLS`.

## Tests
- `uv run pytest -q tests/test_openai_responses_tools.py tests/test_schema_utils.py`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk change limited to request payload construction for OpenAI `RESPONSES_TOOLS`, plus a regression test; main risk is minor behavior differences in tool metadata sent to the API.
> 
> **Overview**
> Fixes `RESPONSES_TOOLS` payload construction to reuse the full `tool_definition` (including `description`) and align `tool_choice.name` with that definition, matching the inbuilt-tools variant.
> 
> Adds a regression test ensuring function descriptions are preserved and that both responses-tools modes emit identical tool definitions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 86fedf8745794aeeaab08c3e1a5a9b02a248340f. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->