### PR TITLE
test: cover partial streaming for PEP 604 unions

### DIFF
--- a/tests/dsl/test_partial.py
+++ b/tests/dsl/test_partial.py
@@ -45,6 +45,10 @@ class UnionWithNested(BaseModel):
     c: NestedB
 
 
+class PEP604UnionField(BaseModel):
+    value: str | int
+
+
 def test_partial():
     partial = Partial[SamplePartial]
     assert partial.model_json_schema() == {
@@ -208,6 +212,14 @@ def test_union_with_nested():
     partial.get_partial_model().model_validate_json(
         '{"a": [{"b": "b"}, {"d": "d"}], "b": [{"b": "b"}], "c": {"d": "d"}, "e": [1, "a"]}'
     )
+
+
+def test_partial_streaming_with_pep604_union_field():
+    partial = Partial[PEP604UnionField]
+
+    models = list(partial.model_from_chunks(['{"value": ', "1}"]))
+
+    assert models[-1].model_dump() == {"value": 1}
 
 
 def test_partial_with_default_factory():


### PR DESCRIPTION
## Summary
Add a regression test for issue `#2088` to lock in support for partial streaming models with PEP 604 union fields like `str | int`.

Current `main` already handles this case in code; this PR adds focused test coverage so it stays fixed.

## Tests
- `uv run pytest tests/dsl/test_partial.py -k "pep604_union_field or union_with_nested"`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: test-only change that adds coverage for a previously fixed streaming/validation edge case around `str | int` (PEP 604) union fields.
> 
> **Overview**
> Adds a focused regression test ensuring `Partial.model_from_chunks()` correctly streams and validates models containing a PEP 604 union field (`value: str | int`), asserting the final parsed value is typed as `int` when streamed in chunks.
> 
> Introduces a small test model (`PEP604UnionField`) used solely to exercise this partial-streaming union behavior alongside existing union/nested tests.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1a7f6c9b62ab241ef87891fae16084f568a04803. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->