### PR TITLE
fix: raise IncompleteOutputException directly instead of wrapping in InstructorRetryException

### DIFF
--- a/instructor/core/retry.py
+++ b/instructor/core/retry.py
@@ -7,6 +7,7 @@ from json import JSONDecodeError
 from typing import Any, Callable, TypeVar
 
 from .exceptions import (
+    IncompleteOutputException,
     InstructorRetryException,
     AsyncValidationError,
     FailedAttempt,
@@ -188,6 +189,14 @@ def retry_sync(
     # Track all failed attempts
     failed_attempts: list[FailedAttempt] = []
 
+    # IncompleteOutputException is stored here so it can be re-raised
+    # *outside* the tenacity retry loop.  Raising it inside the
+    # ``with attempt:`` context manager would cause tenacity to treat it
+    # as a retryable failure and wrap it in RetryError, which in turn
+    # gets converted to InstructorRetryException — making it impossible
+    # for callers to catch IncompleteOutputException directly.
+    _incomplete_error: IncompleteOutputException | None = None
+
     try:
         response = None
         for attempt in max_retries:
@@ -260,6 +269,18 @@ def retry_sync(
                         failed_attempts=failed_attempts,
                     )
                     raise e
+                except IncompleteOutputException as e:
+                    # Store for re-raise after exiting the tenacity context.
+                    # Do NOT re-raise here — tenacity would catch it and
+                    # wrap it in RetryError → InstructorRetryException.
+                    logger.debug(f"Incomplete output: {e}")
+                    hooks.emit_completion_error(
+                        e,
+                        attempt_number=attempt.retry_state.attempt_number,
+                        max_attempts=None,
+                        is_last_attempt=True,
+                    )
+                    _incomplete_error = e
                 except Exception as e:
                     # Emit completion:error for non-validation errors (API errors, network errors, etc.)
                     logger.debug(f"Completion error: {e}")
@@ -307,6 +328,14 @@ def retry_sync(
                             is_last_attempt=True,
                         )
                     raise e
+
+        # Re-raise IncompleteOutputException outside the retry loop so
+        # callers can catch it directly (fixes #2273).
+        if _incomplete_error is not None:
+            raise _incomplete_error
+
+    except IncompleteOutputException:
+        raise
     except RetryError as e:
         logger.debug(f"Retry error: {e}")
         raise InstructorRetryException(
@@ -365,6 +394,9 @@ async def retry_async(
 
     # Track all failed attempts
     failed_attempts: list[FailedAttempt] = []
+
+    # See comment in retry_sync for rationale.
+    _incomplete_error: IncompleteOutputException | None = None
 
     try:
         response = None
@@ -439,6 +471,16 @@ async def retry_async(
                         failed_attempts=failed_attempts,
                     )
                     raise e
+                except IncompleteOutputException as e:
+                    # Store for re-raise after exiting the tenacity context.
+                    logger.debug(f"Incomplete output: {e}")
+                    hooks.emit_completion_error(
+                        e,
+                        attempt_number=attempt.retry_state.attempt_number,
+                        max_attempts=None,
+                        is_last_attempt=True,
+                    )
+                    _incomplete_error = e
                 except Exception as e:
                     # Emit completion:error for non-validation errors (API errors, network errors, etc.)
                     logger.debug(f"Completion error: {e}")
@@ -486,6 +528,14 @@ async def retry_async(
                             is_last_attempt=True,
                         )
                     raise e
+
+        # Re-raise IncompleteOutputException outside the retry loop so
+        # callers can catch it directly (fixes #2273).
+        if _incomplete_error is not None:
+            raise _incomplete_error
+
+    except IncompleteOutputException:
+        raise
     except RetryError as e:
         logger.debug(f"Retry error: {e}")
         raise InstructorRetryException(

--- a/tests/test_incomplete_output_not_wrapped.py
+++ b/tests/test_incomplete_output_not_wrapped.py
@@ -1,0 +1,159 @@
+"""
+Test that IncompleteOutputException is raised directly and not wrapped
+in InstructorRetryException.
+
+This is a regression test for issue #2273.
+"""
+
+import pytest
+from unittest.mock import Mock
+
+import instructor
+from instructor.core.exceptions import (
+    IncompleteOutputException,
+    InstructorRetryException,
+)
+from instructor.mode import Mode
+from pydantic import BaseModel
+
+
+class Report(BaseModel):
+    content: str
+
+
+def _make_truncated_response() -> Mock:
+    """Create a mock response that simulates a max_tokens truncation."""
+    mock_response = Mock()
+    mock_response.choices = [Mock()]
+    mock_response.choices[0].message = Mock()
+    mock_response.choices[0].message.content = '{"content": "partial...'
+    mock_response.choices[0].finish_reason = "length"  # key: truncated
+    mock_response.choices[0].message.tool_calls = None
+    mock_response.choices[0].message.refusal = None
+    mock_response.usage = None
+    return mock_response
+
+
+def test_incomplete_output_exception_not_wrapped_in_retry():
+    """IncompleteOutputException should be catchable directly, not wrapped.
+
+    Before the fix, IncompleteOutputException was caught by the generic
+    Exception handler in retry_sync, forwarded to tenacity, and then
+    re-raised as InstructorRetryException.  Users could not write:
+
+        except IncompleteOutputException as e: ...
+
+    because it was always wrapped.
+    """
+    mock_response = _make_truncated_response()
+
+    mock_client = Mock()
+    mock_client.chat = Mock()
+    mock_client.chat.completions = Mock()
+    mock_client.chat.completions.create = Mock(return_value=mock_response)
+
+    client = instructor.patch(mock_client, mode=Mode.JSON)
+
+    with pytest.raises(IncompleteOutputException) as exc_info:
+        client.chat.completions.create(
+            model="gpt-4",
+            response_model=Report,
+            messages=[{"role": "user", "content": "Write a long report..."}],
+            max_retries=0,
+        )
+
+    assert exc_info.value.last_completion is mock_response
+
+
+def test_incomplete_output_exception_catchable_with_retries():
+    """IncompleteOutputException should be raised directly even with retries > 0.
+
+    Retrying on a max_tokens truncation is pointless because the same
+    token limit will apply.  The exception should escape immediately.
+    """
+    mock_response = _make_truncated_response()
+
+    call_count = 0
+    original_create = Mock(return_value=mock_response)
+
+    def counting_create(*args, **kwargs):
+        nonlocal call_count
+        call_count += 1
+        return original_create(*args, **kwargs)
+
+    mock_client = Mock()
+    mock_client.chat = Mock()
+    mock_client.chat.completions = Mock()
+    mock_client.chat.completions.create = counting_create
+
+    client = instructor.patch(mock_client, mode=Mode.JSON)
+
+    with pytest.raises(IncompleteOutputException):
+        client.chat.completions.create(
+            model="gpt-4",
+            response_model=Report,
+            messages=[{"role": "user", "content": "Write a long report..."}],
+            max_retries=3,
+        )
+
+    # Should NOT have retried — only one call to the API
+    assert call_count == 1
+
+
+def test_incomplete_output_not_caught_as_retry_exception():
+    """Verify IncompleteOutputException is NOT an InstructorRetryException."""
+    mock_response = _make_truncated_response()
+
+    mock_client = Mock()
+    mock_client.chat = Mock()
+    mock_client.chat.completions = Mock()
+    mock_client.chat.completions.create = Mock(return_value=mock_response)
+
+    client = instructor.patch(mock_client, mode=Mode.JSON)
+
+    caught_as_retry = False
+    caught_as_incomplete = False
+
+    try:
+        client.chat.completions.create(
+            model="gpt-4",
+            response_model=Report,
+            messages=[{"role": "user", "content": "Write a long report..."}],
+            max_retries=0,
+        )
+    except InstructorRetryException:
+        caught_as_retry = True
+    except IncompleteOutputException:
+        caught_as_incomplete = True
+
+    assert caught_as_incomplete, "Should be caught as IncompleteOutputException"
+    assert not caught_as_retry, "Should NOT be caught as InstructorRetryException"
+
+
+def test_incomplete_output_exception_tools_mode():
+    """IncompleteOutputException should also work in TOOLS mode."""
+    mock_response = Mock()
+    mock_response.choices = [Mock()]
+    mock_response.choices[0].message = Mock()
+    mock_response.choices[0].message.content = None
+    mock_response.choices[0].message.tool_calls = None
+    mock_response.choices[0].message.refusal = None
+    mock_response.choices[0].finish_reason = "length"
+    mock_response.usage = None
+
+    mock_client = Mock()
+    mock_client.chat = Mock()
+    mock_client.chat.completions = Mock()
+    mock_client.chat.completions.create = Mock(return_value=mock_response)
+
+    client = instructor.patch(mock_client, mode=Mode.TOOLS)
+
+    with pytest.raises(IncompleteOutputException) as exc_info:
+        client.chat.completions.create(
+            model="gpt-4",
+            response_model=Report,
+            messages=[{"role": "user", "content": "Write a long report..."}],
+            max_retries=0,
+        )
+
+    assert exc_info.value.last_completion is mock_response


### PR DESCRIPTION
## Summary

Fixes #2273 — `IncompleteOutputException` is now directly catchable by callers instead of being wrapped in `InstructorRetryException`.

**Root cause:** When `process_response()` raises `IncompleteOutputException`, tenacity's `with attempt:` context manager catches it and treats it as a retryable failure. After retries exhaust, it gets wrapped in `RetryError` → `InstructorRetryException`, making it impossible to write `except IncompleteOutputException`.

**Fix:** Catch `IncompleteOutputException` inside the retry loop and store it without re-raising (so tenacity doesn't intercept it). After the retry loop exits, re-raise it directly. This also avoids pointless retries — the same `max_tokens` limit will be hit again.

## Changes

- `instructor/core/retry.py` — both `retry_sync` and `retry_async`:
  - Added `_incomplete_error` variable to store the exception
  - Added `except IncompleteOutputException` handler before the generic `except Exception`
  - Re-raise stored exception after the tenacity for-loop
  - Added `except IncompleteOutputException: raise` in outer try/except to propagate past `RetryError` handler
- `tests/test_incomplete_output_not_wrapped.py` — 4 new tests:
  - Direct catchability in JSON mode with `max_retries=0`
  - No unnecessary retries with `max_retries=3`
  - Not caught as `InstructorRetryException`
  - Works in TOOLS mode too

## Test plan

- [x] All 4 new tests pass (`pytest tests/test_incomplete_output_not_wrapped.py`)
- [x] Existing exception tests pass (`pytest tests/test_exceptions.py`)
- [x] Existing retry tests pass (`pytest tests/test_retry_json_mode.py`)
- [x] Ruff lint and format checks pass
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)