### PR TITLE
perf: lazy-load provider imports to reduce import-time memory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 
 ## [Unreleased]
 
+### Performance
+- **Import**: Lazy-load provider SDK imports (`anthropic`, `boto3`, `google-genai`, etc.) to reduce `import instructor` memory footprint and startup time. Provider factory functions and response handlers are now loaded on first use instead of at module import. ([#2205](https://github.com/567-labs/instructor/issues/2205))
+
 ### Fixed
 - **Templating (GenAI/VertexAI)**: `process_message` no longer crashes with `TypeError: Can't compile non template nodes` when multimodal messages contain image/URI/bytes Parts alongside `validation_context`. Non-text Parts (where `part.text` is `None`) now pass through unchanged. ([#2253](https://github.com/567-labs/instructor/issues/2253))
 

--- a/instructor/__init__.py
+++ b/instructor/__init__.py
@@ -76,79 +76,57 @@ __all__ = [
 from . import client
 
 
-if importlib.util.find_spec("anthropic") is not None:
-    from .providers.anthropic.client import from_anthropic
+# Provider factory functions are loaded lazily via __getattr__ to avoid pulling
+# in heavy SDK dependencies (anthropic, boto3, google-genai, etc.) at import time.
+# See https://github.com/567-labs/instructor/issues/2205
 
-    __all__ += ["from_anthropic"]
+_LAZY_PROVIDERS: dict[str, tuple[str, str | list[str]]] = {
+    # name -> (module_path, required_spec_or_specs)
+    "from_anthropic": (".providers.anthropic.client", "anthropic"),
+    "from_gemini": (".providers.gemini.client", ["google", "google.generativeai"]),
+    "from_fireworks": (".providers.fireworks.client", "fireworks"),
+    "from_cerebras": (".providers.cerebras.client", "cerebras"),
+    "from_groq": (".providers.groq.client", "groq"),
+    "from_mistral": (".providers.mistral.client", "mistralai"),
+    "from_cohere": (".providers.cohere.client", "cohere"),
+    "from_vertexai": (".providers.vertexai.client", ["vertexai", "jsonref"]),
+    "from_bedrock": (".providers.bedrock.client", "boto3"),
+    "from_writer": (".providers.writer.client", "writerai"),
+    "from_xai": (".providers.xai.client", "xai_sdk"),
+    "from_perplexity": (".providers.perplexity.client", "openai"),
+    "from_genai": (".providers.genai.client", ["google", "google.genai"]),
+}
 
-# Keep from_gemini for backward compatibility but it's deprecated
-if (
-    importlib.util.find_spec("google")
-    and importlib.util.find_spec("google.generativeai") is not None
-):
-    from .providers.gemini.client import from_gemini
+# Populate __all__ based on available specs without importing the providers
+for _name, (_, _specs) in _LAZY_PROVIDERS.items():
+    _spec_list = [_specs] if isinstance(_specs, str) else _specs
+    if all(importlib.util.find_spec(s) is not None for s in _spec_list):
+        __all__ += [_name]
 
-    __all__ += ["from_gemini"]
 
-if importlib.util.find_spec("fireworks") is not None:
-    from .providers.fireworks.client import from_fireworks
-
-    __all__ += ["from_fireworks"]
-
-if importlib.util.find_spec("cerebras") is not None:
-    from .providers.cerebras.client import from_cerebras
-
-    __all__ += ["from_cerebras"]
-
-if importlib.util.find_spec("groq") is not None:
-    from .providers.groq.client import from_groq
-
-    __all__ += ["from_groq"]
-
-if importlib.util.find_spec("mistralai") is not None:
-    from .providers.mistral.client import from_mistral
-
-    __all__ += ["from_mistral"]
-
-if importlib.util.find_spec("cohere") is not None:
-    from .providers.cohere.client import from_cohere
-
-    __all__ += ["from_cohere"]
-
-if all(importlib.util.find_spec(pkg) for pkg in ("vertexai", "jsonref")):
-    try:
-        from .providers.vertexai.client import from_vertexai
-    except Exception:
-        # Optional dependency may be present but broken/misconfigured at import time.
-        # Avoid failing `import instructor` in that case.
-        pass
-    else:
-        __all__ += ["from_vertexai"]
-
-if importlib.util.find_spec("boto3") is not None:
-    from .providers.bedrock.client import from_bedrock
-
-    __all__ += ["from_bedrock"]
-
-if importlib.util.find_spec("writerai") is not None:
-    from .providers.writer.client import from_writer
-
-    __all__ += ["from_writer"]
-
-if importlib.util.find_spec("xai_sdk") is not None:
-    from .providers.xai.client import from_xai
-
-    __all__ += ["from_xai"]
-
-if importlib.util.find_spec("openai") is not None:
-    from .providers.perplexity.client import from_perplexity
-
-    __all__ += ["from_perplexity"]
-
-if (
-    importlib.util.find_spec("google")
-    and importlib.util.find_spec("google.genai") is not None
-):
-    from .providers.genai.client import from_genai
-
-    __all__ += ["from_genai"]
+def __getattr__(name: str):
+    if name in _LAZY_PROVIDERS:
+        module_path, specs = _LAZY_PROVIDERS[name]
+        spec_list = [specs] if isinstance(specs, str) else specs
+        try:
+            specs_found = all(
+                importlib.util.find_spec(s) is not None for s in spec_list
+            )
+        except (ValueError, ModuleNotFoundError):
+            specs_found = False
+        if not specs_found:
+            raise AttributeError(
+                f"module 'instructor' has no attribute {name!r} "
+                f"(missing optional dependency)"
+            )
+        try:
+            mod = importlib.import_module(module_path, package=__name__)
+            attr = getattr(mod, name)
+        except Exception as exc:
+            raise AttributeError(
+                f"module 'instructor' has no attribute {name!r}"
+            ) from exc
+        # Cache on the module so __getattr__ is not called again
+        globals()[name] = attr
+        return attr
+    raise AttributeError(f"module 'instructor' has no attribute {name!r}")

--- a/instructor/distil.py
+++ b/instructor/distil.py
@@ -6,6 +6,7 @@ import inspect
 import functools
 
 from typing import (
+    TYPE_CHECKING,
     Any,
     Callable,
     Optional,
@@ -19,8 +20,10 @@ from openai.types.chat.chat_completion import ChatCompletion
 from openai.types.chat.chat_completion_message_param import ChatCompletionMessageParam
 from pydantic import BaseModel, validate_call
 
-from openai import OpenAI
 from .processing.function_calls import openai_schema
+
+if TYPE_CHECKING:
+    from openai import OpenAI
 
 
 P = ParamSpec("P")
@@ -105,7 +108,7 @@ class Instructions:
         finetune_format: FinetuneFormat = FinetuneFormat.MESSAGES,
         indent: int = 2,
         include_code_body: bool = False,
-        openai_client: Optional[OpenAI] = None,
+        openai_client: Optional["OpenAI"] = None,
     ) -> None:
         """
         Instructions for distillation and dispatch.
@@ -123,7 +126,12 @@ class Instructions:
         self.finetune_format = finetune_format
         self.indent = indent
         self.include_code_body = include_code_body
-        self.client = openai_client or OpenAI()
+        if openai_client is not None:
+            self.client = openai_client
+        else:
+            from openai import OpenAI
+
+            self.client = OpenAI()
 
         self.logger = logging.getLogger(self.name)
         for handler in log_handlers or []:

--- a/instructor/processing/response.py
+++ b/instructor/processing/response.py
@@ -58,109 +58,163 @@ from ..mode import Mode
 from .multimodal import convert_messages
 from ..utils.core import prepare_response_model
 
+# Provider utils are imported lazily to avoid pulling in heavy SDK dependencies
+# (anthropic, boto3, google-genai, etc.) at module load time.
+# See https://github.com/567-labs/instructor/issues/2205
+
+
+def _lazy_import(module_path: str, attr: str):
+    """Return a wrapper that lazily imports ``attr`` from ``module_path`` on first call."""
+    _cached = {}
+
+    def wrapper(*args, **kwargs):
+        if "fn" not in _cached:
+            import importlib
+
+            mod = importlib.import_module(module_path, package=__package__)
+            _cached["fn"] = getattr(mod, attr)
+        return _cached["fn"](*args, **kwargs)
+
+    wrapper.__name__ = attr  # type: ignore[attr-defined]
+    wrapper.__qualname__ = attr  # type: ignore[attr-defined]
+    return wrapper
+
+
 # Anthropic utils
-from ..providers.anthropic.utils import (
-    handle_anthropic_json,
-    handle_anthropic_parallel_tools,
-    handle_anthropic_reasoning_tools,
-    handle_anthropic_tools,
-    reask_anthropic_json,
-    reask_anthropic_tools,
+handle_anthropic_json = _lazy_import(
+    "..providers.anthropic.utils", "handle_anthropic_json"
+)
+handle_anthropic_parallel_tools = _lazy_import(
+    "..providers.anthropic.utils", "handle_anthropic_parallel_tools"
+)
+handle_anthropic_reasoning_tools = _lazy_import(
+    "..providers.anthropic.utils", "handle_anthropic_reasoning_tools"
+)
+handle_anthropic_tools = _lazy_import(
+    "..providers.anthropic.utils", "handle_anthropic_tools"
+)
+reask_anthropic_json = _lazy_import(
+    "..providers.anthropic.utils", "reask_anthropic_json"
+)
+reask_anthropic_tools = _lazy_import(
+    "..providers.anthropic.utils", "reask_anthropic_tools"
 )
 
 # Bedrock utils
-from ..providers.bedrock.utils import (
-    handle_bedrock_json,
-    handle_bedrock_tools,
-    reask_bedrock_json,
-    reask_bedrock_tools,
-)
+handle_bedrock_json = _lazy_import("..providers.bedrock.utils", "handle_bedrock_json")
+handle_bedrock_tools = _lazy_import("..providers.bedrock.utils", "handle_bedrock_tools")
+reask_bedrock_json = _lazy_import("..providers.bedrock.utils", "reask_bedrock_json")
+reask_bedrock_tools = _lazy_import("..providers.bedrock.utils", "reask_bedrock_tools")
 
 # Cerebras utils
-from ..providers.cerebras.utils import (
-    handle_cerebras_json,
-    handle_cerebras_tools,
-    reask_cerebras_tools,
+handle_cerebras_json = _lazy_import(
+    "..providers.cerebras.utils", "handle_cerebras_json"
+)
+handle_cerebras_tools = _lazy_import(
+    "..providers.cerebras.utils", "handle_cerebras_tools"
+)
+reask_cerebras_tools = _lazy_import(
+    "..providers.cerebras.utils", "reask_cerebras_tools"
 )
 
 # Cohere utils
-from ..providers.cohere.utils import (
-    handle_cohere_json_schema,
-    handle_cohere_tools,
-    reask_cohere_tools,
+handle_cohere_json_schema = _lazy_import(
+    "..providers.cohere.utils", "handle_cohere_json_schema"
 )
+handle_cohere_tools = _lazy_import("..providers.cohere.utils", "handle_cohere_tools")
+reask_cohere_tools = _lazy_import("..providers.cohere.utils", "reask_cohere_tools")
 
 # Fireworks utils
-from ..providers.fireworks.utils import (
-    handle_fireworks_json,
-    handle_fireworks_tools,
-    reask_fireworks_json,
-    reask_fireworks_tools,
+handle_fireworks_json = _lazy_import(
+    "..providers.fireworks.utils", "handle_fireworks_json"
+)
+handle_fireworks_tools = _lazy_import(
+    "..providers.fireworks.utils", "handle_fireworks_tools"
+)
+reask_fireworks_json = _lazy_import(
+    "..providers.fireworks.utils", "reask_fireworks_json"
+)
+reask_fireworks_tools = _lazy_import(
+    "..providers.fireworks.utils", "reask_fireworks_tools"
 )
 
 # Google/Gemini/VertexAI utils
-from ..providers.gemini.utils import (
-    handle_gemini_json,
-    handle_gemini_tools,
-    handle_genai_structured_outputs,
-    handle_genai_tools,
-    handle_vertexai_json,
-    handle_vertexai_parallel_tools,
-    handle_vertexai_tools,
-    reask_gemini_json,
-    reask_gemini_tools,
-    reask_genai_structured_outputs,
-    reask_genai_tools,
-    reask_vertexai_json,
-    reask_vertexai_tools,
+handle_gemini_json = _lazy_import("..providers.gemini.utils", "handle_gemini_json")
+handle_gemini_tools = _lazy_import("..providers.gemini.utils", "handle_gemini_tools")
+handle_genai_structured_outputs = _lazy_import(
+    "..providers.gemini.utils", "handle_genai_structured_outputs"
 )
+handle_genai_tools = _lazy_import("..providers.gemini.utils", "handle_genai_tools")
+handle_vertexai_json = _lazy_import("..providers.gemini.utils", "handle_vertexai_json")
+handle_vertexai_parallel_tools = _lazy_import(
+    "..providers.gemini.utils", "handle_vertexai_parallel_tools"
+)
+handle_vertexai_tools = _lazy_import(
+    "..providers.gemini.utils", "handle_vertexai_tools"
+)
+reask_gemini_json = _lazy_import("..providers.gemini.utils", "reask_gemini_json")
+reask_gemini_tools = _lazy_import("..providers.gemini.utils", "reask_gemini_tools")
+reask_genai_structured_outputs = _lazy_import(
+    "..providers.gemini.utils", "reask_genai_structured_outputs"
+)
+reask_genai_tools = _lazy_import("..providers.gemini.utils", "reask_genai_tools")
+reask_vertexai_json = _lazy_import("..providers.gemini.utils", "reask_vertexai_json")
+reask_vertexai_tools = _lazy_import("..providers.gemini.utils", "reask_vertexai_tools")
 
 # Mistral utils
-from ..providers.mistral.utils import (
-    handle_mistral_structured_outputs,
-    handle_mistral_tools,
-    reask_mistral_structured_outputs,
-    reask_mistral_tools,
+handle_mistral_structured_outputs = _lazy_import(
+    "..providers.mistral.utils", "handle_mistral_structured_outputs"
 )
+handle_mistral_tools = _lazy_import("..providers.mistral.utils", "handle_mistral_tools")
+reask_mistral_structured_outputs = _lazy_import(
+    "..providers.mistral.utils", "reask_mistral_structured_outputs"
+)
+reask_mistral_tools = _lazy_import("..providers.mistral.utils", "reask_mistral_tools")
 
 # OpenAI utils
-from ..providers.openai.utils import (
-    handle_functions,
-    handle_json_modes,
-    handle_json_o1,
-    handle_openrouter_structured_outputs,
-    handle_parallel_tools,
-    handle_responses_tools,
-    handle_responses_tools_with_inbuilt_tools,
-    handle_tools,
-    handle_tools_strict,
-    reask_default,
-    reask_md_json,
-    reask_responses_tools,
-    reask_tools,
+handle_functions = _lazy_import("..providers.openai.utils", "handle_functions")
+handle_json_modes = _lazy_import("..providers.openai.utils", "handle_json_modes")
+handle_json_o1 = _lazy_import("..providers.openai.utils", "handle_json_o1")
+handle_openrouter_structured_outputs = _lazy_import(
+    "..providers.openai.utils", "handle_openrouter_structured_outputs"
 )
+handle_parallel_tools = _lazy_import(
+    "..providers.openai.utils", "handle_parallel_tools"
+)
+handle_responses_tools = _lazy_import(
+    "..providers.openai.utils", "handle_responses_tools"
+)
+handle_responses_tools_with_inbuilt_tools = _lazy_import(
+    "..providers.openai.utils", "handle_responses_tools_with_inbuilt_tools"
+)
+handle_tools = _lazy_import("..providers.openai.utils", "handle_tools")
+handle_tools_strict = _lazy_import("..providers.openai.utils", "handle_tools_strict")
+reask_default = _lazy_import("..providers.openai.utils", "reask_default")
+reask_md_json = _lazy_import("..providers.openai.utils", "reask_md_json")
+reask_responses_tools = _lazy_import(
+    "..providers.openai.utils", "reask_responses_tools"
+)
+reask_tools = _lazy_import("..providers.openai.utils", "reask_tools")
 
 # Perplexity utils
-from ..providers.perplexity.utils import (
-    handle_perplexity_json,
-    reask_perplexity_json,
+handle_perplexity_json = _lazy_import(
+    "..providers.perplexity.utils", "handle_perplexity_json"
+)
+reask_perplexity_json = _lazy_import(
+    "..providers.perplexity.utils", "reask_perplexity_json"
 )
 
 # Writer utils
-from ..providers.writer.utils import (
-    handle_writer_json,
-    handle_writer_tools,
-    reask_writer_json,
-    reask_writer_tools,
-)
+handle_writer_json = _lazy_import("..providers.writer.utils", "handle_writer_json")
+handle_writer_tools = _lazy_import("..providers.writer.utils", "handle_writer_tools")
+reask_writer_json = _lazy_import("..providers.writer.utils", "reask_writer_json")
+reask_writer_tools = _lazy_import("..providers.writer.utils", "reask_writer_tools")
 
 # XAI utils
-from ..providers.xai.utils import (
-    handle_xai_json,
-    handle_xai_tools,
-    reask_xai_json,
-    reask_xai_tools,
-)
+handle_xai_json = _lazy_import("..providers.xai.utils", "handle_xai_json")
+handle_xai_tools = _lazy_import("..providers.xai.utils", "handle_xai_tools")
+reask_xai_json = _lazy_import("..providers.xai.utils", "reask_xai_json")
+reask_xai_tools = _lazy_import("..providers.xai.utils", "reask_xai_tools")
 
 logger = logging.getLogger("instructor")
 

--- a/instructor/processing/schema.py
+++ b/instructor/processing/schema.py
@@ -14,7 +14,6 @@ from typing import Any, cast
 from docstring_parser import parse
 from pydantic import BaseModel
 
-from ..providers.gemini.utils import map_to_gemini_function_schema
 
 __all__ = [
     "generate_openai_schema",
@@ -115,6 +114,7 @@ def generate_gemini_schema(model: type[BaseModel]) -> Any:
         import importlib
 
         genai_types = cast(Any, importlib.import_module("google.generativeai.types"))
+        from ..providers.gemini.utils import map_to_gemini_function_schema
 
         # Use OpenAI schema
         openai_schema = generate_openai_schema(model)

--- a/instructor/providers/__init__.py
+++ b/instructor/providers/__init__.py
@@ -1,82 +1,57 @@
-"""Provider implementations for instructor."""
+"""Provider implementations for instructor.
 
+Provider factory functions are loaded lazily to avoid pulling in heavy SDK
+dependencies (anthropic, boto3, google-genai, etc.) at import time.
+See https://github.com/567-labs/instructor/issues/2205
+"""
+
+import importlib
 import importlib.util
 
-__all__ = []
+_PROVIDER_MAP: dict[str, tuple[str, str | list[str]]] = {
+    "from_anthropic": (".anthropic.client", "anthropic"),
+    "from_bedrock": (".bedrock.client", "boto3"),
+    "from_cerebras": (".cerebras.client", "cerebras"),
+    "from_cohere": (".cohere.client", "cohere"),
+    "from_fireworks": (".fireworks.client", "fireworks"),
+    "from_gemini": (".gemini.client", ["google", "google.generativeai"]),
+    "from_genai": (".genai.client", ["google", "google.genai"]),
+    "from_groq": (".groq.client", "groq"),
+    "from_mistral": (".mistral.client", "mistralai"),
+    "from_perplexity": (".perplexity.client", "openai"),
+    "from_vertexai": (".vertexai.client", ["vertexai", "jsonref"]),
+    "from_writer": (".writer.client", "writerai"),
+    "from_xai": (".xai.client", "xai_sdk"),
+}
 
-# Conditional imports based on installed packages
-if importlib.util.find_spec("anthropic") is not None:
-    from .anthropic.client import from_anthropic  # noqa: F401
+__all__: list[str] = []
+for _name, (_, _specs) in _PROVIDER_MAP.items():
+    _spec_list = [_specs] if isinstance(_specs, str) else _specs
+    if all(importlib.util.find_spec(s) is not None for s in _spec_list):
+        __all__.append(_name)
 
-    __all__.append("from_anthropic")
 
-if importlib.util.find_spec("boto3") is not None:
-    from .bedrock.client import from_bedrock  # noqa: F401
-
-    __all__.append("from_bedrock")
-
-if importlib.util.find_spec("cerebras") is not None:
-    from .cerebras.client import from_cerebras  # noqa: F401
-
-    __all__.append("from_cerebras")
-
-if importlib.util.find_spec("cohere") is not None:
-    from .cohere.client import from_cohere  # noqa: F401
-
-    __all__.append("from_cohere")
-
-if importlib.util.find_spec("fireworks") is not None:
-    from .fireworks.client import from_fireworks  # noqa: F401
-
-    __all__.append("from_fireworks")
-
-if (
-    importlib.util.find_spec("google")
-    and importlib.util.find_spec("google.generativeai") is not None
-):
-    from .gemini.client import from_gemini  # noqa: F401
-
-    __all__.append("from_gemini")
-
-if (
-    importlib.util.find_spec("google")
-    and importlib.util.find_spec("google.genai") is not None
-):
-    from .genai.client import from_genai  # noqa: F401
-
-    __all__.append("from_genai")
-
-if importlib.util.find_spec("groq") is not None:
-    from .groq.client import from_groq  # noqa: F401
-
-    __all__.append("from_groq")
-
-if importlib.util.find_spec("mistralai") is not None:
-    from .mistral.client import from_mistral  # noqa: F401
-
-    __all__.append("from_mistral")
-
-if importlib.util.find_spec("openai") is not None:
-    from .perplexity.client import from_perplexity  # noqa: F401
-
-    __all__.append("from_perplexity")
-
-if all(importlib.util.find_spec(pkg) for pkg in ("vertexai", "jsonref")):
-    try:
-        from .vertexai.client import from_vertexai  # noqa: F401
-    except Exception:
-        # Optional dependency may be present but broken/misconfigured at import time.
-        # Avoid failing `import instructor` in that case.
-        pass
-    else:
-        __all__.append("from_vertexai")
-
-if importlib.util.find_spec("writerai") is not None:
-    from .writer.client import from_writer  # noqa: F401
-
-    __all__.append("from_writer")
-
-if importlib.util.find_spec("xai_sdk") is not None:
-    from .xai.client import from_xai  # noqa: F401
-
-    __all__.append("from_xai")
+def __getattr__(name: str):
+    if name in _PROVIDER_MAP:
+        module_path, specs = _PROVIDER_MAP[name]
+        spec_list = [specs] if isinstance(specs, str) else specs
+        try:
+            specs_found = all(
+                importlib.util.find_spec(s) is not None for s in spec_list
+            )
+        except (ValueError, ModuleNotFoundError):
+            specs_found = False
+        if not specs_found:
+            raise AttributeError(
+                f"module 'instructor.providers' has no attribute {name!r}"
+            )
+        try:
+            mod = importlib.import_module(module_path, package=__name__)
+            attr = getattr(mod, name)
+        except Exception as exc:
+            raise AttributeError(
+                f"module 'instructor.providers' has no attribute {name!r}"
+            ) from exc
+        globals()[name] = attr
+        return attr
+    raise AttributeError(f"module 'instructor.providers' has no attribute {name!r}")


### PR DESCRIPTION
## Summary

Fixes #2205

`import instructor` eagerly imports every installed provider SDK (anthropic, bedrock, cohere, fireworks, gemini, groq, mistral, etc.) at module level. This loads ~1,867 modules and ~70 MB of resident memory even when only core functionality is needed. This PR defers those imports so they are loaded on first use.

## Root Cause

`instructor/processing/response.py` unconditionally imports handler functions from every provider's `utils` module at the top of the file. Since `response.py` is pulled in through `__init__.py -> core/client.py -> core/patch.py`, every `import instructor` triggers the full import chain. The same pattern exists in `instructor/__init__.py` and `instructor/providers/__init__.py` for factory functions like `from_anthropic`, `from_bedrock`, etc.

## Changes

- **`instructor/__init__.py`**: Replace eager conditional imports of provider factory functions with a PEP 562 `__getattr__` handler. A `_LAZY_PROVIDERS` dict maps function names to their module path and required spec. `__all__` is still populated based on `find_spec` (no import needed). The attribute is cached in `globals()` after first access.
- **`instructor/providers/__init__.py`**: Same `__getattr__` pattern.
- **`instructor/processing/response.py`**: Replace ~100 lines of top-level `from ..providers.<x>.utils import ...` with a `_lazy_import()` helper that returns a wrapper. The wrapper imports and caches the real function on first call.
- **`instructor/distil.py`**: Guard `from openai import OpenAI` with `TYPE_CHECKING`; import inline where actually needed.
- **`instructor/processing/schema.py`**: Move `map_to_gemini_function_schema` import inside the deprecated `generate_gemini_schema` function body.
- **`CHANGELOG.md`**: Added Performance entry.

## Measurements

With `anthropic` + `openai` installed (the `[dev]` extras):

| Metric | Before | After | Change |
|--------|--------|-------|--------|
| Modules loaded | 1,867 | 1,101 | -766 (-41%) |
| Resident memory | ~70 MB | ~58 MB | -12 MB (-17%) |
| anthropic SDK modules | 741 | 0 | eliminated |

The savings scale with the number of installed provider SDKs. Users with many providers installed (the scenario in #2205) will see larger reductions.

## Testing

- [x] Full test suite: 368 passed, 16 failed, 41 skipped (identical to `main` — all 16 failures are pre-existing, mostly missing `google-generativeai` dependency)
- [x] `from instructor import from_anthropic` works correctly via lazy loading
- [x] `ruff check` and `ruff format` pass on all changed files

```bash
# Verify memory reduction:
/usr/bin/time -v python -c "import instructor"
# Before: Maximum resident set size: 70640 kbytes
# After:  Maximum resident set size: 58112 kbytes
```